### PR TITLE
fix(helper): harden lifecycle recovery

### DIFF
--- a/Tracexy/Core/Services/HelperClient+ForceRemove.swift
+++ b/Tracexy/Core/Services/HelperClient+ForceRemove.swift
@@ -13,10 +13,32 @@ extension HelperClient {
 
         // MARK: Internal
 
+        /// The raw merged stdout/stderr from the privileged script, regardless of
+        /// how it terminated.
+        var commandOutput: String {
+            switch self {
+            case let .commandFailed(_, output),
+                 let .commandTerminated(_, output):
+                output
+            }
+        }
+
+        /// Whether the failure is the user cancelling the administrator prompt
+        /// (osascript reports error `-128` / "User canceled") rather than a real
+        /// removal failure. A cancelled prompt must abort without reinstalling.
+        var isAuthorizationCancelled: Bool {
+            guard case let .commandFailed(_, output) = self else {
+                return false
+            }
+            return output.localizedCaseInsensitiveContains("User canceled")
+                || output.localizedCaseInsensitiveContains("User cancelled")
+                || output.contains("-128")
+        }
+
         var errorDescription: String? {
             switch self {
             case let .commandFailed(exitCode, output):
-                if output.localizedCaseInsensitiveContains("User canceled") {
+                if isAuthorizationCancelled {
                     return "The administrator authorization prompt was cancelled."
                 }
                 return output.isEmpty
@@ -105,5 +127,121 @@ extension HelperClient {
 
     nonisolated private static func shellQuote(_ value: String) -> String {
         "'\(value.replacingOccurrences(of: "'", with: "'\\''"))'"
+    }
+}
+
+// MARK: - ForceResetSummary
+
+/// The verified outcome of `forceResetAndReinstall`. Never self-asserts success:
+/// the `finalStatus` is snapshotted from a real re-probe, so the summary reflects
+/// what actually happened rather than what was attempted.
+struct ForceResetSummary: Equatable {
+    // MARK: Internal
+
+    enum Phase: Equatable {
+        /// A lifecycle action was already running, so no reset was attempted.
+        case operationInProgress
+        /// The administrator prompt was cancelled; nothing was removed or reinstalled.
+        case removalCancelled
+        /// The privileged removal failed (nonzero exit / exit-guard tripped);
+        /// state was left untouched and no reinstall was attempted.
+        case removalFailed
+        /// Removal succeeded (script exit 0) and a reinstall was attempted;
+        /// `finalStatus` carries the real post-reinstall state.
+        case reinstalled
+    }
+
+    let phase: Phase
+    /// Merged stdout/stderr from the privileged script (or the error text).
+    let removalOutput: String
+    /// The helper status after the operation, re-probed. `nil` only if never set.
+    let finalStatus: HelperClient.Status?
+
+    var didReinstall: Bool {
+        phase == .reinstalled
+    }
+
+    /// True only when removal *and* reinstall landed the bundled helper in the
+    /// expected state, or registration succeeded and only macOS approval remains.
+    /// An outdated helper after reinstall indicates stale state and is not success.
+    var succeeded: Bool {
+        guard phase == .reinstalled else {
+            return false
+        }
+        switch finalStatus {
+        case .installedCompatible,
+             .requiresApproval:
+            return true
+        default:
+            return false
+        }
+    }
+
+    /// Whether to offer the heavier `sfltool resetbtm` escalation next. Only after
+    /// a normal (non-BTM) attempt failed to recover — never after a user-initiated
+    /// cancel.
+    var suggestsBackgroundItemsReset: Bool {
+        switch phase {
+        case .operationInProgress:
+            false
+        case .removalFailed:
+            true
+        case .reinstalled:
+            !succeeded
+        case .removalCancelled:
+            false
+        }
+    }
+
+    /// A short, user-facing headline for the result.
+    var title: String {
+        switch phase {
+        case .operationInProgress:
+            "Helper operation already in progress"
+        case .removalCancelled:
+            "Force reset cancelled"
+        case .removalFailed:
+            "Force reset failed"
+        case .reinstalled:
+            switch finalStatus {
+            case .installedCompatible?: "Helper reset and reinstalled"
+            case .installedOutdated?: "Helper reinstalled — update available"
+            case .requiresApproval?: "Helper reinstalled — approval needed in Login Items"
+            case .unreachable?: "Helper reinstalled but not responding"
+            case .signingMismatch?: "Helper reinstalled but signature mismatched"
+            case .installedIncompatible?: "Helper reinstalled but incompatible"
+            case let .failed(reason)?: "Helper reinstall failed: \(reason)"
+            case .notInstalled?,
+                 .none: "Helper removed but reinstall didn’t complete"
+            }
+        }
+    }
+
+    /// Multi-line detail suitable for a Copy Details action.
+    var details: String {
+        var lines = [title]
+        let trimmed = removalOutput.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !trimmed.isEmpty {
+            lines.append(trimmed)
+        }
+        if let finalStatus {
+            lines.append("Final helper status: \(Self.describe(finalStatus))")
+        }
+        return lines.joined(separator: "\n")
+    }
+
+    // MARK: Private
+
+    private static func describe(_ status: HelperClient.Status) -> String {
+        switch status {
+        case .notInstalled: "not installed"
+        case .requiresApproval: "awaiting approval in Login Items"
+        case .installedCompatible: "installed and up to date"
+        case .installedOutdated: "installed, update available"
+        case .installedIncompatible: "installed, incompatible protocol"
+        case .unreachable: "registered but unreachable"
+        case .signingMismatch: "signing mismatch"
+        case let .failed(reason): "failed — \(reason)"
+        }
     }
 }

--- a/Tracexy/Core/Services/HelperClient.swift
+++ b/Tracexy/Core/Services/HelperClient.swift
@@ -15,7 +15,7 @@ final class HelperClient {
     // MARK: Internal
 
     /// Installation + compatibility state of the helper daemon.
-    enum Status: Equatable {
+    nonisolated enum Status: Equatable {
         case notInstalled
         case requiresApproval
         case installedCompatible
@@ -27,21 +27,48 @@ final class HelperClient {
     }
 
     /// The specific signing problem when `status == .signingMismatch` (sibling-app parity).
-    enum SigningIssue: Equatable {
+    nonisolated enum SigningIssue: Equatable {
         case appSignatureInvalid(detail: String)
         case identityMismatch(appSigner: String, helperSigner: String)
+    }
+
+    // MARK: Capture Start availability
+
+    /// Whether the helper can be used to start a capture right now.
+    ///
+    /// Deliberately richer than `SMAppService.Status.enabled`: "enabled" only
+    /// means launchd accepted the registration, not that the installed binary is
+    /// the one we trust or that it answers XPC. `.ready` is returned only after
+    /// signing + a bounded XPC probe agree.
+    nonisolated enum CaptureAvailability: Equatable {
+        /// Enabled, signature matches, protocol-compatible (or merely outdated).
+        case ready
+        /// Registered but not yet approved in Login Items.
+        case requiresApproval
+        /// A broken helper the user must recover — never silently hidden. The
+        /// string is a user-facing explanation.
+        case unavailable(String)
     }
 
     static let shared = HelperClient()
 
     /// Where the embedded helper binary lives inside the app bundle.
-    static let bundledHelperBinaryRelativePath = "Contents/Library/HelperTools/TracexyCaptureHelper"
+    nonisolated static let bundledHelperBinaryRelativePath = "Contents/Library/HelperTools/TracexyCaptureHelper"
 
     private(set) var status: Status = .notInstalled
     private(set) var signingIssue: SigningIssue?
     /// Version/build/protocol reported by the installed helper, when reachable.
     private(set) var installedInfo: HelperInfo?
     private(set) var isBusy = false
+    /// The user-facing reason the last XPC probe failed, set when `status` is
+    /// `.unreachable` so the UI can explain *why* a registered helper didn't
+    /// answer (timed out vs connection error) rather than just "unreachable".
+    private(set) var probeFailureDetail: String?
+
+    /// App-level hook fired before any destructive/privileged lifecycle op (force
+    /// reset) so the owning coordinator can stop active capture and invalidate its
+    /// polling first. Set once at the composition root; `nil` in tests.
+    var willBeginDestructiveReset: (@MainActor () -> Void)?
 
     // MARK: Bundled (shipped) versions — what this app build embeds
 
@@ -80,48 +107,130 @@ final class HelperClient {
         }
     }
 
-    // MARK: Capture quick-path
-
-    /// Registers the daemon if needed and returns true when it's enabled and
-    /// reachable enough to start a capture. Refreshes the version status in the
-    /// background. Kept synchronous for the capture Start path.
-    @discardableResult
-    func ensureInstalled() -> Bool {
-        let service = SMAppService.daemon(plistName: Self.plistName)
-        switch service.status {
-        case .enabled:
-            refreshStatusInBackground()
-            return true
+    /// Pure mapping from a probed `Status` to Start availability. Kept separate so
+    /// the decision is unit-testable without SMAppService or XPC.
+    nonisolated static func captureAvailability(
+        for status: Status,
+        unreachableDetail: String?
+    )
+        -> CaptureAvailability
+    {
+        switch status {
+        case .installedCompatible,
+             .installedOutdated:
+            // Outdated shares the current protocol, so it still captures.
+            .ready
         case .requiresApproval:
-            status = .requiresApproval
-            SMAppService.openSystemSettingsLoginItems()
-            return false
-        case .notRegistered,
-             .notFound:
-            do {
-                try service.register()
-                if service.status == .enabled {
-                    refreshStatusInBackground()
-                    return true
-                }
-                status = .requiresApproval
+            .requiresApproval
+        case .installedIncompatible:
+            .unavailable("the installed helper uses an incompatible protocol. Update it in Settings → Helper.")
+        case .signingMismatch:
+            .unavailable(
+                "the installed helper’s code signature doesn’t match this app. Reinstall it in Settings → Helper."
+            )
+        case .unreachable:
+            .unavailable(unreachableDetail
+                ?? "the helper is registered but isn’t responding. Recover it in Settings → Helper.")
+        case .notInstalled:
+            .unavailable("the capture helper isn’t installed. Install it in Settings → Helper.")
+        case let .failed(reason):
+            .unavailable(reason)
+        }
+    }
+
+    /// Pure compatibility decision, testable without a live bundle. Protocol
+    /// mismatch is incompatible; an older build than we ship is outdated;
+    /// otherwise compatible.
+    nonisolated static func classifyCompatibility(
+        _ info: HelperInfo,
+        expectedProtocolVersion: Int,
+        bundledBuild: Int
+    )
+        -> Status
+    {
+        if info.protocolVersion != expectedProtocolVersion {
+            return .installedIncompatible
+        }
+        return info.buildNumber >= bundledBuild ? .installedCompatible : .installedOutdated
+    }
+
+    /// Whether a registration error means the user must approve the helper in
+    /// Login Items, rather than a genuine failure. Three triggers, matching the
+    /// sibling app: SMAppService already reports `.requiresApproval`; the error is
+    /// `kSMErrorLaunchDeniedByUser`; or it's the OSStatus "operation not permitted"
+    /// early-block (`NSOSStatusErrorDomain` code `1`). Constraining that last case
+    /// to `NSOSStatusErrorDomain` avoids sweeping in unrelated code-`1` errors
+    /// (e.g. a POSIX `EPERM`).
+    nonisolated static func isApprovalRequired(serviceStatus: SMAppService.Status, error: NSError) -> Bool {
+        if serviceStatus == .requiresApproval {
+            return true
+        }
+        if error.code == kSMErrorLaunchDeniedByUser {
+            return true
+        }
+        if error.domain == NSOSStatusErrorDomain, error.code == 1 {
+            return true
+        }
+        return false
+    }
+
+    /// Registers the daemon if needed, then verifies signing + XPC reachability
+    /// before reporting whether capture can start. Never blocks indefinitely:
+    /// the probe is timeout-bounded, so a wedged helper resolves to `.unavailable`
+    /// rather than leaving the Start path spinning.
+    func prepareForCaptureViaHelper() async -> CaptureAvailability {
+        guard !isBusy else {
+            return .unavailable("another helper operation is already in progress. Wait for it to finish and try again.")
+        }
+        return await runBusyReturning { () async -> CaptureAvailability in
+            let service = SMAppService.daemon(plistName: Self.plistName)
+            switch service.status {
+            case .enabled:
+                break
+            case .requiresApproval:
+                self.status = .requiresApproval
                 SMAppService.openSystemSettingsLoginItems()
-                return false
-            } catch {
-                handleRegisterError(error, serviceStatus: service.status)
-                return status == .requiresApproval ? false : false
+                return .requiresApproval
+            case .notRegistered,
+                 .notFound:
+                if case let .incomplete(reason) = BundledHelperPackage.validateBundled(
+                    identity: TracexyIdentity.current
+                ) {
+                    self.status = .failed("Helper package is incomplete: \(reason)")
+                    return .unavailable("the helper package is incomplete: \(reason)")
+                }
+                do {
+                    try service.register()
+                    if service.status == .requiresApproval {
+                        self.status = .requiresApproval
+                        SMAppService.openSystemSettingsLoginItems()
+                        return .requiresApproval
+                    }
+                } catch {
+                    self.handleRegisterError(error, serviceStatus: service.status)
+                    return self.status == .requiresApproval
+                        ? .requiresApproval
+                        : .unavailable(error.localizedDescription)
+                }
+            @unknown default:
+                self.status = .failed("unknown SMAppService status")
+                return .unavailable("unknown helper registration status")
             }
-        @unknown default:
-            status = .failed("unknown SMAppService status")
-            return false
+            // Enabled (or freshly registered): never trust that alone. Probe
+            // signing + XPC compatibility before handing the Start path a proxy.
+            await self.performCheckStatus()
+            return Self.captureAvailability(for: self.status, unreachableDetail: self.probeFailureDetail)
         }
     }
 
     /// The XPC proxy to the helper, opening the privileged connection if needed.
     func proxy() throws -> TracexyHelperProtocol {
         let connection = openConnectionIfNeeded()
-        guard let proxy = connection.remoteObjectProxyWithErrorHandler({ error in
+        guard let proxy = connection.remoteObjectProxyWithErrorHandler({ [weak self] error in
             Self.logger.error("XPC error: \(error.localizedDescription, privacy: .public)")
+            Task { @MainActor in
+                self?.recordRuntimeConnectionFailure(error.localizedDescription)
+            }
         }) as? TracexyHelperProtocol else {
             throw NSError(domain: "Tracexy", code: 1, userInfo: [NSLocalizedDescriptionKey: "helper unreachable"])
         }
@@ -129,25 +238,35 @@ final class HelperClient {
     }
 
     func disconnect() {
-        connection?.invalidate()
-        connection = nil
+        resetConnection()
     }
 
     // MARK: Lifecycle management (sibling-app parity)
 
     /// Register the helper daemon, prompting for Login Items approval if needed.
     func install() async {
+        guard !isBusy else {
+            return
+        }
         await runBusy { await self.performInstall() }
     }
 
-    /// Uninstall (delete) the helper: tell it to stop, then unregister from launchd.
+    /// Uninstall (delete) the helper: stop its capture best-effort, then unregister
+    /// from launchd. A failed unregister is surfaced, never reported as success.
     func uninstall() async {
+        guard !isBusy else {
+            return
+        }
         await runBusy {
+            if let proxy = try? self.proxy() {
+                proxy.stopCapture {}
+            }
             self.disconnect()
             do {
                 try await SMAppService.daemon(plistName: Self.plistName).unregister()
                 self.status = .notInstalled
                 self.installedInfo = nil
+                self.probeFailureDetail = nil
                 Self.logger.info("helper uninstalled")
             } catch {
                 self.status = .failed(error.localizedDescription)
@@ -156,61 +275,131 @@ final class HelperClient {
         }
     }
 
-    /// Update the helper: unregister the old daemon, then register the new one.
-    /// Re-registration may require Login Items approval again.
+    /// Update the helper: remove the old daemon, then register the new one.
+    ///
+    /// A replacement is **never** registered over a helper we failed to remove — a
+    /// failed unregister aborts and surfaces the failure. Removal is only required
+    /// when the daemon is actually present; a `.notRegistered`/`.notFound` start
+    /// state proceeds straight to registration (this doubles as the reinstall
+    /// path for a `.failed`/signing-mismatch helper). Re-registration may require
+    /// Login Items approval again.
     func update() async {
-        await runBusy {
-            self.disconnect()
-            try? await SMAppService.daemon(plistName: Self.plistName).unregister()
-            try? await Task.sleep(nanoseconds: 500_000_000)
-            let service = SMAppService.daemon(plistName: Self.plistName)
-            do {
-                try service.register()
-                if service.status == .requiresApproval {
-                    self.status = .requiresApproval
-                    SMAppService.openSystemSettingsLoginItems()
-                } else {
-                    await self.performCheckStatus()
-                }
-            } catch {
-                self.handleRegisterError(error, serviceStatus: service.status)
-            }
+        guard !isBusy else {
+            return
         }
-    }
-
-    /// Probe the installed helper and classify its compatibility.
-    func checkStatus() async {
-        await runBusy { await self.performCheckStatus() }
-    }
-
-    /// Hard-remove the helper from launchd and the privileged-helper location,
-    /// then reinstall from the current app bundle (the recovery path).
-    /// Returns a user-facing summary of the privileged command output.
-    @discardableResult
-    func forceResetAndReinstall(resetBackgroundItems: Bool) async -> String {
-        var summary = ""
         await runBusy {
             if let proxy = try? self.proxy() {
                 proxy.stopCapture {}
             }
             self.disconnect()
+
+            let existing = SMAppService.daemon(plistName: Self.plistName)
+            if existing.status == .enabled || existing.status == .requiresApproval {
+                do {
+                    try await existing.unregister()
+                } catch {
+                    self.status = .failed("Couldn’t remove the existing helper: \(error.localizedDescription)")
+                    Self.logger.error(
+                        "helper update aborted — unregister failed: \(error.localizedDescription, privacy: .public)"
+                    )
+                    return
+                }
+                try? await Task.sleep(nanoseconds: 500_000_000)
+            }
+
+            await self.performInstall()
+        }
+    }
+
+    /// Probe the installed helper and classify its compatibility.
+    func checkStatus() async {
+        guard !isBusy else {
+            return
+        }
+        await runBusy { await self.performCheckStatus() }
+    }
+
+    /// Surface a helper connection that failed after an earlier successful probe,
+    /// such as a daemon that exits or wedges during an active capture.
+    func recordRuntimeConnectionFailure(_ detail: String) {
+        resetConnection()
+        installedInfo = nil
+        probeFailureDetail = detail
+        status = .unreachable
+    }
+
+    /// Hard-remove the helper from launchd and the privileged-helper location,
+    /// then reinstall from the current app bundle (the recovery path).
+    ///
+    /// Returns a structured, verified summary. Removal is authoritative: if the
+    /// administrator prompt is cancelled, the privileged script exits nonzero, or
+    /// its exit guards detect a still-loaded launchd job / leftover files, the
+    /// method aborts **without clearing state and without reinstalling**, then
+    /// re-probes so `finalStatus` reflects reality. Only a clean removal (script
+    /// exit 0) proceeds to reinstall, after which the summary carries the actual
+    /// post-reinstall status.
+    @discardableResult
+    func forceResetAndReinstall(resetBackgroundItems: Bool) async -> ForceResetSummary {
+        guard !isBusy else {
+            return ForceResetSummary(
+                phase: .operationInProgress,
+                removalOutput: "Another helper operation is already in progress.",
+                finalStatus: status
+            )
+        }
+        var summary = ForceResetSummary(phase: .removalFailed, removalOutput: "", finalStatus: nil)
+        await runBusy {
+            // App-level: stop active capture + invalidate polling before anything
+            // privileged runs.
+            self.willBeginDestructiveReset?()
+
+            if let proxy = try? self.proxy() {
+                proxy.stopCapture {}
+            }
+            self.disconnect()
+            // Best-effort de-registration; the privileged script is the authority.
             try? await SMAppService.daemon(plistName: Self.plistName).unregister()
 
             let script = Self.forceRemoveShellScript(
                 identity: TracexyIdentity.current,
                 resetBackgroundItems: resetBackgroundItems
             )
+            let removalOutput: String
             do {
-                let output = try await Self.runPrivilegedShellScript(script)
-                summary = output.isEmpty ? "Removed stale helper files and launchd registration." : output
+                removalOutput = try await Self.runPrivilegedShellScript(script)
+            } catch let error as ForceRemoveError {
+                // Abort: do not clear state, do not reinstall. Re-probe for truth.
+                await self.performCheckStatus()
+                summary = ForceResetSummary(
+                    phase: error.isAuthorizationCancelled ? .removalCancelled : .removalFailed,
+                    removalOutput: error.errorDescription ?? error.commandOutput,
+                    finalStatus: self.status
+                )
+                Self.logger.error("force reset removal failed: \(error.commandOutput, privacy: .public)")
+                return
             } catch {
-                summary = error.localizedDescription
+                await self.performCheckStatus()
+                summary = ForceResetSummary(
+                    phase: .removalFailed,
+                    removalOutput: error.localizedDescription,
+                    finalStatus: self.status
+                )
+                return
             }
 
+            // Removal verified by the script's exit guards (exit 0). Reinstall.
             self.status = .notInstalled
             self.installedInfo = nil
+            self.probeFailureDetail = nil
             try? await Task.sleep(nanoseconds: 1_000_000_000)
             await self.performInstall()
+            summary = ForceResetSummary(
+                phase: .reinstalled,
+                removalOutput: removalOutput.isEmpty
+                    ? "Removed stale helper files and launchd registration."
+                    : removalOutput,
+                finalStatus: self.status
+            )
         }
         return summary
     }
@@ -220,16 +409,25 @@ final class HelperClient {
     /// Classify a probed helper: protocol mismatch is incompatible; an older
     /// build than what we ship is outdated; otherwise compatible (sibling-app logic).
     func evaluateCompatibility(_ info: HelperInfo) -> Status {
-        if info.protocolVersion != expectedProtocolVersion {
-            return .installedIncompatible
-        }
-        return info.buildNumber >= bundledHelperBuild ? .installedCompatible : .installedOutdated
+        Self.classifyCompatibility(
+            info,
+            expectedProtocolVersion: expectedProtocolVersion,
+            bundledBuild: bundledHelperBuild
+        )
     }
 
     // MARK: Private
 
     private static let logger = Logger(subsystem: TracexyIdentity.current.logSubsystem, category: "HelperClient")
     private static let plistName = TracexyIdentity.current.helperPlistName
+
+    // MARK: Probe tuning + approval classification
+
+    /// Deterministic worst case ≈ `probeMaxAttempts × probeTimeout` plus the
+    /// inter-attempt delays: 3 × 3s + 2 × 750ms.
+    private static let probeTimeoutNanoseconds: UInt64 = 3_000_000_000
+    private static let probeMaxAttempts = 3
+    private static let probeRetryDelayNanoseconds: UInt64 = 750_000_000
 
     private var connection: NSXPCConnection?
 
@@ -251,15 +449,32 @@ final class HelperClient {
 
     private func runBusy(_ work: () async -> Void) async {
         isBusy = true
+        defer { isBusy = false }
         await work()
-        isBusy = false
     }
 
-    private func refreshStatusInBackground() {
-        Task { @MainActor in await performCheckStatus() }
+    private func runBusyReturning<T>(_ work: () async -> T) async -> T {
+        isBusy = true
+        defer { isBusy = false }
+        return await work()
+    }
+
+    /// Invalidate and drop the XPC connection so the next probe reconnects fresh.
+    /// Called between probe attempts and after a timeout/interruption: a wedged
+    /// connection is discarded rather than reused.
+    private func resetConnection() {
+        connection?.invalidate()
+        connection = nil
     }
 
     private func performInstall() async {
+        // Local, deterministic package preflight before touching launchd: a broken
+        // app bundle never attempts registration; it fails with a clear reason.
+        if case let .incomplete(reason) = BundledHelperPackage.validateBundled(identity: TracexyIdentity.current) {
+            status = .failed("Helper package is incomplete: \(reason)")
+            Self.logger.error("bundled helper package incomplete: \(reason, privacy: .public)")
+            return
+        }
         let service = SMAppService.daemon(plistName: Self.plistName)
         switch service.status {
         case .enabled:
@@ -309,43 +524,78 @@ final class HelperClient {
                  .diagnosticError:
                 break
             }
-            do {
-                let info = try await fetchHelperInfo()
+            switch await probeHelperInfoWithRetry() {
+            case let .success(info):
                 installedInfo = info
+                probeFailureDetail = nil
                 status = evaluateCompatibility(info)
                 Self.logger.info(
                     "helper enabled: build=\(info.buildNumber) proto=\(info.protocolVersion) → \(String(describing: self.status))"
                 )
-            } catch {
+            case let .failure(error):
                 installedInfo = nil
+                probeFailureDetail = error.detail
                 status = .unreachable
-                Self.logger.warning("helper enabled but unreachable: \(error.localizedDescription, privacy: .public)")
+                Self.logger.warning("helper enabled but unreachable: \(error.detail, privacy: .public)")
             }
         case .requiresApproval:
             status = .requiresApproval
+            probeFailureDetail = nil
         case .notRegistered,
              .notFound:
             status = .notInstalled
             installedInfo = nil
+            probeFailureDetail = nil
         @unknown default:
             status = .notInstalled
             installedInfo = nil
+            probeFailureDetail = nil
         }
     }
 
-    /// One XPC round-trip to `getHelperInfo`, resilient to the connection failing
-    /// (the error handler resumes the continuation instead of hanging forever).
-    private func fetchHelperInfo() async throws -> HelperInfo {
+    /// Probe `getHelperInfo` with a deterministic per-attempt timeout, a bounded
+    /// number of attempts, and a fresh connection between attempts. Never hangs:
+    /// a registered-but-wedged helper resolves to `.failure` within the bounded
+    /// worst case rather than blocking forever.
+    private func probeHelperInfoWithRetry() async -> Result<HelperInfo, HelperProbeError> {
+        var lastError = HelperProbeError.unreachable("The helper did not respond.")
+        for attempt in 1 ... Self.probeMaxAttempts {
+            do {
+                let info = try await fetchHelperInfo(timeoutNanoseconds: Self.probeTimeoutNanoseconds)
+                return .success(info)
+            } catch let error as HelperProbeError {
+                lastError = error
+            } catch {
+                lastError = .unreachable(error.localizedDescription)
+            }
+            // Discard the (possibly wedged) connection before the next attempt.
+            resetConnection()
+            if attempt < Self.probeMaxAttempts {
+                try? await Task.sleep(nanoseconds: Self.probeRetryDelayNanoseconds)
+            }
+        }
+        return .failure(lastError)
+    }
+
+    /// One timeout-bounded XPC round-trip to `getHelperInfo`. The reply block, the
+    /// remote-object error handler, and a cancellable deadline task all race to
+    /// resume a single one-shot continuation gate (`ResumeOnce`); whichever fires
+    /// first wins and the rest are no-ops. The deadline task is cancelled once the
+    /// continuation resumes, so a prompt reply never waits out the timeout.
+    private func fetchHelperInfo(timeoutNanoseconds: UInt64) async throws -> HelperInfo {
         let connection = openConnectionIfNeeded()
+        let deadline = DeadlineBox()
+        defer { deadline.cancel() }
         return try await withCheckedThrowingContinuation { continuation in
             let once = ResumeOnce(continuation)
+            deadline.task = Task {
+                try? await Task.sleep(nanoseconds: timeoutNanoseconds)
+                once.resume(throwing: HelperProbeError.timedOut)
+            }
             guard let proxy = connection.remoteObjectProxyWithErrorHandler({ error in
-                once.resume(throwing: error)
+                once.resume(throwing: HelperProbeError.unreachable(error.localizedDescription))
             }) as? TracexyHelperProtocol else {
-                once.resume(throwing: NSError(
-                    domain: "Tracexy", code: 1,
-                    userInfo: [NSLocalizedDescriptionKey: "helper unreachable"]
-                ))
+                once.resume(throwing: HelperProbeError.unreachable("The helper is unreachable."))
                 return
             }
             proxy.getHelperInfo { version, build, proto in
@@ -357,8 +607,7 @@ final class HelperClient {
     }
 
     private func handleRegisterError(_ error: Error, serviceStatus: SMAppService.Status) {
-        let nsError = error as NSError
-        if serviceStatus == .requiresApproval || nsError.code == kSMErrorLaunchDeniedByUser {
+        if Self.isApprovalRequired(serviceStatus: serviceStatus, error: error as NSError) {
             status = .requiresApproval
             SMAppService.openSystemSettingsLoginItems()
         } else {
@@ -368,18 +617,78 @@ final class HelperClient {
     }
 }
 
+// MARK: - OneShotGuard
+
+/// A lock-backed "first caller wins" gate. `claim()` returns `true` exactly once —
+/// for the first caller across any threads — and `false` forever after. The lock
+/// guards only the flag flip; callers do their one-shot work (resuming a
+/// continuation, cancelling a task) outside the lock so nothing runs while held.
+///
+/// Extracted from `ResumeOnce` so the race can be unit-tested without a live XPC
+/// continuation.
+final class OneShotGuard: @unchecked Sendable {
+    // MARK: Internal
+
+    /// Wins exactly once for the first caller; every later caller loses.
+    func claim() -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        guard !claimed else {
+            return false
+        }
+        claimed = true
+        return true
+    }
+
+    // MARK: Private
+
+    private let lock = NSLock()
+    private var claimed = false
+}
+
+// MARK: - HelperProbeError
+
+/// Why an XPC probe of the installed helper failed, carrying a user-facing detail
+/// so `.unreachable` can explain *why* a registered helper didn't answer.
+enum HelperProbeError: Error, Equatable {
+    case timedOut
+    case unreachable(String)
+
+    // MARK: Internal
+
+    var detail: String {
+        switch self {
+        case .timedOut: "The helper didn’t respond within the timeout."
+        case let .unreachable(message): message
+        }
+    }
+}
+
+// MARK: - DeadlineBox
+
+/// Holds the cancellable deadline task for a single timeout-bounded probe so the
+/// awaiting call can cancel it once the continuation resumes. Reference type: the
+/// task is assigned synchronously inside the continuation body (before the first
+/// suspension) and cancelled later from the caller's `defer`.
+private final class DeadlineBox {
+    var task: Task<Void, Never>?
+
+    func cancel() {
+        task?.cancel()
+    }
+}
+
 // MARK: - ResumeOnce
 
 /// Guards `fetchHelperInfo`'s checked continuation so it resumes exactly once,
-/// even though the XPC reply block and the error handler can race on different
-/// threads.
+/// even though the XPC reply block, the error handler, and the deadline task can
+/// race on different threads. Backed by `OneShotGuard`.
 ///
 /// Deliberately non-generic (specialized to `HelperInfo`): a generic version
 /// crashed the Swift 6.2 SIL optimizer (EarlyPerfInliner, in the synthesized
 /// deallocating destructor) under Release `-O -whole-module-optimization`. The
-/// concrete layout sidesteps that. The lock only guards the one-shot `claim`;
-/// the continuation is resumed outside the lock so no continuation work runs
-/// while the lock is held.
+/// concrete layout sidesteps that. The continuation is resumed outside the gate's
+/// lock so no continuation work runs while the lock is held.
 private final class ResumeOnce: @unchecked Sendable {
     // MARK: Lifecycle
 
@@ -390,14 +699,14 @@ private final class ResumeOnce: @unchecked Sendable {
     // MARK: Internal
 
     func resume(returning value: HelperInfo) {
-        guard claim() else {
+        guard gate.claim() else {
             return
         }
         continuation.resume(returning: value)
     }
 
     func resume(throwing error: Error) {
-        guard claim() else {
+        guard gate.claim() else {
             return
         }
         continuation.resume(throwing: error)
@@ -406,18 +715,126 @@ private final class ResumeOnce: @unchecked Sendable {
     // MARK: Private
 
     private let continuation: CheckedContinuation<HelperInfo, Error>
-    private let lock = NSLock()
-    private var done = false
+    private let gate = OneShotGuard()
+}
 
-    /// Wins exactly once for the first caller; every later caller loses. The
-    /// lock is released before the winner resumes the continuation.
-    private func claim() -> Bool {
-        lock.lock()
-        defer { lock.unlock() }
-        guard !done else {
-            return false
+// MARK: - BundledHelperPackage
+
+/// Deterministic, local preflight of the shipped helper package before it is
+/// registered with launchd. Split into a pure validator over an already-parsed
+/// launchd plist (unit-testable with synthetic dictionaries) and a thin live
+/// orchestrator that reads the app bundle.
+nonisolated enum BundledHelperPackage {
+    // MARK: Internal
+
+    /// What the bundled launchd plist must declare for this app build.
+    struct Requirements: Equatable {
+        let expectedLabel: String
+        let expectedBundleProgram: String
+        let expectedMachServiceName: String
+        let expectedAssociatedBundleIdentifiers: [String]
+    }
+
+    enum Validation: Equatable {
+        case ok
+        /// The package is missing or inconsistent; the string is user-facing.
+        case incomplete(reason: String)
+    }
+
+    /// Pure validation of a parsed launchd plist against the requirements. Checks
+    /// `Label`, `BundleProgram`, that the Mach service is present *and* enabled,
+    /// and that the app's bundle identifier is among `AssociatedBundleIdentifiers`.
+    static func validateLaunchdPlist(_ plist: [String: Any], requirements: Requirements) -> Validation {
+        guard let label = plist["Label"] as? String, !label.isEmpty else {
+            return .incomplete(reason: "the launch daemon plist is missing its Label.")
         }
-        done = true
-        return true
+        guard label == requirements.expectedLabel else {
+            return .incomplete(reason: "the launch daemon Label “\(label)” doesn’t match the expected helper identity.")
+        }
+        guard let program = plist["BundleProgram"] as? String, !program.isEmpty else {
+            return .incomplete(reason: "the launch daemon plist is missing its BundleProgram path.")
+        }
+        guard program == requirements.expectedBundleProgram else {
+            return .incomplete(
+                reason: "the launch daemon BundleProgram “\(program)” doesn’t point at the bundled helper."
+            )
+        }
+        guard let machServices = plist["MachServices"] as? [String: Any] else {
+            return .incomplete(reason: "the launch daemon plist declares no MachServices.")
+        }
+        switch machServices[requirements.expectedMachServiceName] {
+        case let flag as Bool where flag:
+            break
+        case let number as NSNumber where number.boolValue:
+            break
+        case .none:
+            return .incomplete(
+                reason: "the launch daemon plist doesn’t vend the “\(requirements.expectedMachServiceName)” Mach service."
+            )
+        default:
+            return .incomplete(
+                reason: "the “\(requirements.expectedMachServiceName)” Mach service is disabled in the launch daemon plist."
+            )
+        }
+        guard let associated = plist["AssociatedBundleIdentifiers"] as? [String], !associated.isEmpty else {
+            return .incomplete(reason: "the launch daemon plist is missing AssociatedBundleIdentifiers.")
+        }
+        let normalizedAssociated = normalizedIdentifiers(associated)
+        let normalizedExpected = normalizedIdentifiers(requirements.expectedAssociatedBundleIdentifiers)
+        guard normalizedAssociated == normalizedExpected else {
+            return .incomplete(
+                reason: "the launch daemon plist has unexpected AssociatedBundleIdentifiers."
+            )
+        }
+        return .ok
+    }
+
+    /// Live orchestrator: verifies the helper executable is a runnable regular
+    /// file and the launchd plist parses, then delegates to `validateLaunchdPlist`.
+    static func validateBundled(
+        identity: TracexyIdentity,
+        bundle: Bundle = .main,
+        fileManager: FileManager = .default
+    )
+        -> Validation
+    {
+        let helperBinary = bundle.bundleURL
+            .appendingPathComponent(HelperClient.bundledHelperBinaryRelativePath, isDirectory: false)
+        var isDirectory: ObjCBool = false
+        guard fileManager.fileExists(atPath: helperBinary.path, isDirectory: &isDirectory),
+              !isDirectory.boolValue else
+        {
+            return .incomplete(reason: "the bundled helper executable is missing.")
+        }
+        guard fileManager.isExecutableFile(atPath: helperBinary.path) else {
+            return .incomplete(reason: "the bundled helper executable isn’t runnable.")
+        }
+        let plistURL = bundle.bundleURL
+            .appendingPathComponent("Contents/Library/LaunchDaemons/\(identity.helperPlistName)", isDirectory: false)
+        guard let data = try? Data(contentsOf: plistURL),
+              let raw = try? PropertyListSerialization.propertyList(from: data, options: [], format: nil),
+              let plist = raw as? [String: Any] else
+        {
+            return .incomplete(reason: "the bundled launch daemon plist is missing or unreadable.")
+        }
+        return validateLaunchdPlist(plist, requirements: Requirements(
+            expectedLabel: identity.helperMachServiceName,
+            expectedBundleProgram: HelperClient.bundledHelperBinaryRelativePath,
+            expectedMachServiceName: identity.helperMachServiceName,
+            expectedAssociatedBundleIdentifiers: identity.allowedCallerIdentifiers
+        ))
+    }
+
+    // MARK: Private
+
+    private static func normalizedIdentifiers(_ identifiers: [String]) -> [String] {
+        Array(
+            Set(
+                identifiers
+                    .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+                    .filter { !$0.isEmpty }
+            )
+        )
+        .sorted()
     }
 }

--- a/Tracexy/ViewModels/MainContentCoordinator.swift
+++ b/Tracexy/ViewModels/MainContentCoordinator.swift
@@ -46,6 +46,12 @@ final class MainContentCoordinator {
         localIPv4 = NetworkInterfaces.primaryIPv4()
         pinnedHosts = Self.loadPinnedHosts()
         refreshSavedCaptures()
+        // Before any destructive/privileged helper op (force reset), stop active
+        // capture and invalidate polling so nothing keeps touching a helper that
+        // is about to be torn down.
+        helper.willBeginDestructiveReset = { [weak self] in
+            self?.stopCapture()
+        }
     }
 
     // MARK: Internal
@@ -898,8 +904,14 @@ final class MainContentCoordinator {
     }
 
     func startCapture() {
+        // Serialize: ignore a second Start while an attempt is already in flight
+        // so double-clicks can't overlap two capture backends.
+        guard !isStarting else {
+            return
+        }
         captureError = nil
         isStarting = true
+        startGeneration &+= 1
         isViewingSavedCapture = false
         liveFrames = []
         sessions = []
@@ -920,19 +932,37 @@ final class MainContentCoordinator {
             startDirect()
             return
         }
-        // Prefer the signed privileged helper (no sudo). Fall back to direct libpcap.
-        if helper.ensureInstalled() {
-            startViaHelper()
-        } else if helper.status == .requiresApproval {
-            captureError = "Approve “Tracexy” in System Settings → Login Items, then press Start again."
-            isCapturing = false
-            isStarting = false
-        } else {
-            startDirect()
+        // Prefer the signed privileged helper (no sudo). Unlike the old fast path,
+        // this verifies signing + XPC reachability before starting: a broken or
+        // wedged helper surfaces a clear error instead of spinning on "Starting"
+        // or being silently masked by an unprivileged fallback.
+        let token = startGeneration
+        Task { @MainActor in
+            let availability = await self.helper.prepareForCaptureViaHelper()
+            // The user may have stopped or restarted since; honor only the live attempt.
+            guard self.isStarting, self.startGeneration == token else {
+                return
+            }
+            switch availability {
+            case .ready:
+                self.startViaHelper(token: token)
+            case .requiresApproval:
+                self.captureError = "Approve “\(TracexyIdentity.current.displayName)” in System Settings → " +
+                    "Login Items, then press Start again."
+                self.isCapturing = false
+                self.isStarting = false
+                self.startGeneration &+= 1
+            case let .unavailable(detail):
+                self.handleCaptureError("Capture helper unavailable — \(detail)")
+            }
         }
     }
 
     func stopCapture() {
+        // Invalidate any in-flight start attempt so its watchdog/reply is ignored.
+        startGeneration &+= 1
+        helperFetchGeneration &+= 1
+        helperFetchInFlight = false
         pollTimer?.invalidate()
         pollTimer = nil
         if let proxy = try? helper.proxy() {
@@ -989,6 +1019,16 @@ final class MainContentCoordinator {
     private var pendingChartBytes = 0
     private var liveFrames: [CapturedFrame] = []
     private var pollTimer: Timer?
+    /// Bumped every time a start attempt begins or ends. A late helper reply or a
+    /// start watchdog compares its captured token against this so a stale callback
+    /// from an abandoned attempt can't revive `isCapturing`/`isStarting`.
+    private var startGeneration = 0
+    /// At most one helper frame-drain request may be outstanding. Without this
+    /// guard, a wedged helper would accumulate a new XPC request every 350 ms.
+    private var helperFetchInFlight = false
+    /// Retires late frame replies and timeout watchdogs when capture stops or a
+    /// newer drain request replaces them.
+    private var helperFetchGeneration = 0
 
     private static func loadPinnedHosts() -> [String] {
         UserDefaults.standard.stringArray(forKey: pinnedHostsKey) ?? []
@@ -1123,12 +1163,12 @@ final class MainContentCoordinator {
         UserDefaults.standard.set(mutedProtocols.map(\.rawValue), forKey: Self.mutedProtocolsKey)
     }
 
-    private func startViaHelper() {
+    private func startViaHelper(token: Int) {
         do {
             let proxy = try helper.proxy()
             proxy.startCapture(interface: captureInterface) { [weak self] started, message in
                 Task { @MainActor in
-                    guard let self else {
+                    guard let self, self.startGeneration == token else {
                         return
                     }
                     if started {
@@ -1141,27 +1181,84 @@ final class MainContentCoordinator {
                     }
                 }
             }
+            // Watchdog: even a signed, previously-reachable helper can wedge after
+            // the probe. If no reply lands, don't leave the UI stuck on "Starting".
+            Task { @MainActor in
+                try? await Task.sleep(nanoseconds: 5_000_000_000)
+                guard self.isStarting, self.startGeneration == token else {
+                    return
+                }
+                let detail = "The capture helper didn’t confirm the capture started."
+                self.helper.recordRuntimeConnectionFailure(detail)
+                self.handleCaptureError("\(detail) Recover it in Settings → Helper.")
+            }
         } catch {
-            startDirect()
+            let detail = "Couldn’t reach the capture helper: \(error.localizedDescription)"
+            helper.recordRuntimeConnectionFailure(detail)
+            handleCaptureError(detail)
         }
     }
 
     private func startPolling() {
         pollTimer?.invalidate()
+        helperFetchGeneration &+= 1
+        helperFetchInFlight = false
         pollTimer = Timer.scheduledTimer(withTimeInterval: 0.35, repeats: true) { [weak self] _ in
-            Task { @MainActor in self?.pollHelper() }
+            guard let coordinator = self else {
+                return
+            }
+            Task { @MainActor in coordinator.pollHelper() }
         }
     }
 
     private func pollHelper() {
-        guard isCapturing, let proxy = try? helper.proxy() else {
+        guard isCapturing, !helperFetchInFlight else {
             return
         }
+        guard let proxy = try? helper.proxy() else {
+            failActiveHelperCapture("The capture helper connection could not be opened.")
+            return
+        }
+
+        helperFetchInFlight = true
+        helperFetchGeneration &+= 1
+        let fetchToken = helperFetchGeneration
+        let captureToken = startGeneration
+
         proxy.fetchFrames { [weak self] datas, linkType in
             let now = Date()
             let frames = datas.map { CapturedFrame(bytes: Array($0), timestamp: now, originalLength: $0.count) }
-            Task { @MainActor in self?.ingest(frames, linkType: UInt32(truncatingIfNeeded: linkType)) }
+            Task { @MainActor in
+                guard let self,
+                      self.isCapturing,
+                      self.startGeneration == captureToken,
+                      self.helperFetchGeneration == fetchToken else
+                {
+                    return
+                }
+                self.helperFetchInFlight = false
+                self.ingest(frames, linkType: UInt32(truncatingIfNeeded: linkType))
+            }
         }
+
+        Task { @MainActor in
+            try? await Task.sleep(nanoseconds: 3_000_000_000)
+            guard self.isCapturing,
+                  self.helperFetchInFlight,
+                  self.startGeneration == captureToken,
+                  self.helperFetchGeneration == fetchToken else
+            {
+                return
+            }
+            self.failActiveHelperCapture("The capture helper stopped responding while capture was active.")
+        }
+    }
+
+    private func failActiveHelperCapture(_ detail: String) {
+        helperFetchGeneration &+= 1
+        helperFetchInFlight = false
+        helper.recordRuntimeConnectionFailure(detail)
+        handleCaptureError("\(detail) Recover it in Settings → Helper.")
     }
 
     private func startDirect() {
@@ -1237,9 +1334,15 @@ final class MainContentCoordinator {
     }
 
     private func handleCaptureError(_ message: String) {
+        pollTimer?.invalidate()
+        pollTimer = nil
+        helperFetchGeneration &+= 1
+        helperFetchInFlight = false
         captureError = message
         isCapturing = false
         isStarting = false
+        // Retire this attempt so a late reply/watchdog can't flip state back.
+        startGeneration &+= 1
         captureStartedAt = nil
     }
 

--- a/Tracexy/Views/Helper/HelperInstallPromptView.swift
+++ b/Tracexy/Views/Helper/HelperInstallPromptView.swift
@@ -23,6 +23,7 @@ struct HelperInstallPromptView: View {
 
     @Environment(\.dismiss) private var dismiss
     @State private var isInstalling = false
+    @State private var installError: String?
 
     private var header: some View {
         HStack(alignment: .top, spacing: 18) {
@@ -68,27 +69,54 @@ struct HelperInstallPromptView: View {
     }
 
     private var footer: some View {
-        HStack {
-            Button("Cancel") { dismiss() }
-                .keyboardShortcut(.cancelAction)
-            Spacer()
-            Button {
-                Task {
-                    isInstalling = true
-                    await coordinator.helper.install()
-                    isInstalling = false
-                    dismiss()
-                }
-            } label: {
-                if isInstalling {
-                    ProgressView().controlSize(.small)
-                } else {
-                    Label("Install Helper Tool", systemImage: "arrow.down.circle.fill")
-                }
+        VStack(alignment: .leading, spacing: 12) {
+            if let installError {
+                Label(installError, systemImage: "exclamationmark.triangle.fill")
+                    .font(Theme.Typography.surfaceTitle)
+                    .foregroundStyle(.red)
+                    .fixedSize(horizontal: false, vertical: true)
             }
-            .keyboardShortcut(.defaultAction)
-            .buttonStyle(.borderedProminent)
-            .disabled(isInstalling)
+
+            HStack {
+                Button("Cancel") { dismiss() }
+                    .keyboardShortcut(.cancelAction)
+                Spacer()
+                Button {
+                    Task {
+                        isInstalling = true
+                        installError = nil
+                        await coordinator.helper.install()
+                        isInstalling = false
+
+                        switch coordinator.helper.status {
+                        case .installedCompatible,
+                             .installedOutdated,
+                             .requiresApproval:
+                            dismiss()
+                        case let .failed(reason):
+                            installError = reason
+                        case .unreachable:
+                            installError = coordinator.helper.probeFailureDetail
+                                ?? "The helper was registered but did not respond."
+                        case .installedIncompatible:
+                            installError = "The installed helper is incompatible with this app build."
+                        case .signingMismatch:
+                            installError = "The app and helper signing identities do not match."
+                        case .notInstalled:
+                            installError = "The helper could not be installed."
+                        }
+                    }
+                } label: {
+                    if isInstalling {
+                        ProgressView().controlSize(.small)
+                    } else {
+                        Label("Install Helper Tool", systemImage: "arrow.down.circle.fill")
+                    }
+                }
+                .keyboardShortcut(.defaultAction)
+                .buttonStyle(.borderedProminent)
+                .disabled(isInstalling)
+            }
         }
         .padding(.horizontal, 24)
         .padding(.vertical, 16)

--- a/Tracexy/Views/Settings/HelperRecoveryPresenter.swift
+++ b/Tracexy/Views/Settings/HelperRecoveryPresenter.swift
@@ -1,0 +1,69 @@
+import AppKit
+import Observation
+
+// MARK: - HelperRecoveryPresenter
+
+/// Drives the Settings → Helper recovery flow: the normal force-reset-and-reinstall
+/// and, only after that fails, the heavier `sfltool resetbtm` escalation.
+///
+/// Owns just the presentation state (working flag, last summary, whether to offer
+/// the Background Items escalation). The privileged work and all state truth live
+/// on `HelperClient`; this type never runs a privileged operation itself beyond
+/// asking the client to.
+@MainActor
+@Observable
+final class HelperRecoveryPresenter {
+    // MARK: Lifecycle
+
+    init() {
+        helper = .shared
+    }
+
+    init(helper: HelperClient) {
+        self.helper = helper
+    }
+
+    // MARK: Internal
+
+    private(set) var isWorking = false
+    private(set) var summary: ForceResetSummary?
+
+    /// True only once a normal (non-BTM) reset has run and failed to recover the
+    /// helper. Gates the `sfltool resetbtm` escalation so it is never a casual,
+    /// always-visible checkbox.
+    private(set) var offersBackgroundItemsReset = false
+
+    /// Normal recovery: remove + reinstall without touching macOS Background Items.
+    func runNormalReset() async {
+        await run(resetBackgroundItems: false)
+    }
+
+    /// Escalated recovery: also runs `sfltool resetbtm`. Only reachable after a
+    /// normal reset failed and behind a second explicit confirmation in the UI.
+    func runBackgroundItemsReset() async {
+        await run(resetBackgroundItems: true)
+    }
+
+    /// Copies the full success/failure detail to the pasteboard for a bug report.
+    func copyDetails() {
+        guard let summary else {
+            return
+        }
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(summary.details, forType: .string)
+    }
+
+    // MARK: Private
+
+    private let helper: HelperClient
+
+    private func run(resetBackgroundItems: Bool) async {
+        isWorking = true
+        defer { isWorking = false }
+        let result = await helper.forceResetAndReinstall(resetBackgroundItems: resetBackgroundItems)
+        summary = result
+        // Only offer the BTM escalation after a *normal* attempt didn't recover;
+        // running it a second time offers no new lever, so it drops away.
+        offersBackgroundItemsReset = !resetBackgroundItems && result.suggestsBackgroundItemsReset
+    }
+}

--- a/Tracexy/Views/Settings/HelperSettingsView.swift
+++ b/Tracexy/Views/Settings/HelperSettingsView.swift
@@ -18,6 +18,11 @@ struct HelperSettingsView: View {
                     helperNote(signingIssueText(issue))
                 }
 
+                if helper.status == .unreachable, let detail = helper.probeFailureDetail {
+                    SettingsDivider()
+                    helperNote(detail)
+                }
+
                 if let info = helper.installedInfo {
                     SettingsDivider()
                     SettingsRow(label: "Installed:") {
@@ -46,36 +51,15 @@ struct HelperSettingsView: View {
                 }
             }
 
-            SettingsSection("Recovery") {
-                Toggle("Also reset macOS Login & Background Items", isOn: $resetBackgroundItems)
-                    .toggleStyle(.checkbox)
+            recoverySection
 
-                SettingsDivider()
-
-                HStack {
-                    Button("Force Reset & Reinstall…", role: .destructive) {
-                        Task { await forceReset() }
-                    }
-                    Spacer(minLength: 0)
-                }
-                helperNote(
-                    "Use this only if the helper is stuck and Install/Update don't recover it. Requires an administrator password."
-                )
-            }
-
-            if let message {
-                SettingsSection("Result") {
-                    Text(message)
-                        .font(metrics.secondaryFont())
-                        .textSelection(.enabled)
-                        .fixedSize(horizontal: false, vertical: true)
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                }
+            if let summary = recovery.summary {
+                resultSection(summary)
             }
         }
-        .disabled(helper.isBusy || isWorking)
+        .disabled(helper.isBusy || recovery.isWorking)
         .overlay(alignment: .topTrailing) {
-            if helper.isBusy || isWorking {
+            if helper.isBusy || recovery.isWorking {
                 ProgressView().controlSize(.small).padding(12)
             }
         }
@@ -85,11 +69,13 @@ struct HelperSettingsView: View {
     // MARK: Private
 
     @State private var helper = HelperClient.shared
-    @State private var resetBackgroundItems = false
-    @State private var isWorking = false
-    @State private var message: String?
+    @State private var recovery = HelperRecoveryPresenter()
+    @State private var showForceResetConfirm = false
+    @State private var showBackgroundItemsConfirm = false
 
     private let metrics = SettingsDisplayMetrics.standard
+
+    // MARK: Status
 
     private var statusAppearance: (String, Color, String) {
         switch helper.status {
@@ -101,6 +87,70 @@ struct HelperSettingsView: View {
         case .unreachable: ("Registered but unreachable", .red, "bolt.horizontal.circle")
         case .signingMismatch: ("Signing mismatch", .red, "xmark.shield.fill")
         case let .failed(reason): (reason, .red, "exclamationmark.triangle.fill")
+        }
+    }
+
+    // MARK: Recovery
+
+    private var recoverySection: some View {
+        SettingsSection("Recovery") {
+            helperNote(
+                "Use this only if the helper is stuck and Install / Update don’t recover it. It stops any active "
+                    + "capture, removes the privileged helper with administrator rights, and reinstalls it from this app. "
+                    + "Requires an administrator password."
+            )
+
+            HStack {
+                Button("Force Reset & Reinstall…", role: .destructive) {
+                    showForceResetConfirm = true
+                }
+                Spacer(minLength: 0)
+            }
+            .confirmationDialog(
+                "Force reset the capture helper?",
+                isPresented: $showForceResetConfirm,
+                titleVisibility: .visible
+            ) {
+                Button("Force Reset & Reinstall", role: .destructive) {
+                    Task { await recovery.runNormalReset() }
+                }
+                Button("Cancel", role: .cancel) {}
+            } message: {
+                Text(
+                    "This stops any active capture, removes the privileged helper with administrator rights, and "
+                        + "reinstalls it. You’ll be asked for an administrator password."
+                )
+            }
+
+            if recovery.offersBackgroundItemsReset {
+                SettingsDivider()
+                helperNote(
+                    "Normal recovery didn’t fully clear the helper. As a last resort you can also reset macOS Login & "
+                        + "Background Items. This runs “sfltool resetbtm”, which can affect Background Items for other "
+                        + "apps too — they may need re-approval."
+                )
+                HStack {
+                    Button("Reset Background Items & Reinstall…", role: .destructive) {
+                        showBackgroundItemsConfirm = true
+                    }
+                    Spacer(minLength: 0)
+                }
+                .confirmationDialog(
+                    "Also reset macOS Background Items?",
+                    isPresented: $showBackgroundItemsConfirm,
+                    titleVisibility: .visible
+                ) {
+                    Button("Reset Background Items", role: .destructive) {
+                        Task { await recovery.runBackgroundItemsReset() }
+                    }
+                    Button("Cancel", role: .cancel) {}
+                } message: {
+                    Text(
+                        "This runs “sfltool resetbtm” and can affect Login & Background Items for other apps, which may "
+                            + "need re-approval. Only continue if normal recovery didn’t work."
+                    )
+                }
+            }
         }
     }
 
@@ -135,6 +185,29 @@ struct HelperSettingsView: View {
         }
     }
 
+    private func resultSection(_ summary: ForceResetSummary) -> some View {
+        SettingsSection("Result") {
+            Label(
+                summary.title,
+                systemImage: summary.succeeded ? "checkmark.seal.fill" : "exclamationmark.triangle.fill"
+            )
+            .font(metrics.font())
+            .foregroundStyle(summary.succeeded ? Color.green : Color.orange)
+
+            Text(summary.details)
+                .font(metrics.secondaryFont())
+                .foregroundStyle(.secondary)
+                .textSelection(.enabled)
+                .fixedSize(horizontal: false, vertical: true)
+                .frame(maxWidth: .infinity, alignment: .leading)
+
+            HStack {
+                Button("Copy Details") { recovery.copyDetails() }
+                Spacer(minLength: 0)
+            }
+        }
+    }
+
     private func versionText(_ text: String) -> some View {
         Text(text)
             .font(metrics.secondaryFont())
@@ -158,11 +231,5 @@ struct HelperSettingsView: View {
         case let .identityMismatch(appSigner, helperSigner):
             "The app is signed by “\(appSigner)” but the installed helper was signed by “\(helperSigner)”. Reinstall the helper from this build."
         }
-    }
-
-    private func forceReset() async {
-        isWorking = true
-        defer { isWorking = false }
-        message = await helper.forceResetAndReinstall(resetBackgroundItems: resetBackgroundItems)
     }
 }

--- a/TracexyTests/Core/Services/BundledHelperPackageTests.swift
+++ b/TracexyTests/Core/Services/BundledHelperPackageTests.swift
@@ -1,0 +1,111 @@
+import Foundation
+import Testing
+@testable import Tracexy
+
+@Suite("Bundled helper package preflight (launchd plist)")
+struct BundledHelperPackageTests {
+    // MARK: Internal
+
+    @Test("A well-formed plist validates")
+    func valid() {
+        #expect(BundledHelperPackage.validateLaunchdPlist(Self.plist(), requirements: Self.requirements) == .ok)
+    }
+
+    @Test("A missing or mismatched Label is incomplete")
+    func label() {
+        var missing = Self.plist()
+        missing["Label"] = nil
+        var wrong = Self.plist()
+        wrong["Label"] = "com.other.helper"
+
+        expectIncomplete(BundledHelperPackage.validateLaunchdPlist(missing, requirements: Self.requirements))
+        expectIncomplete(BundledHelperPackage.validateLaunchdPlist(wrong, requirements: Self.requirements))
+    }
+
+    @Test("A missing or mismatched BundleProgram is incomplete")
+    func bundleProgram() {
+        var missing = Self.plist()
+        missing["BundleProgram"] = nil
+        var wrong = Self.plist()
+        wrong["BundleProgram"] = "Contents/Library/HelperTools/SomethingElse"
+
+        expectIncomplete(BundledHelperPackage.validateLaunchdPlist(missing, requirements: Self.requirements))
+        expectIncomplete(BundledHelperPackage.validateLaunchdPlist(wrong, requirements: Self.requirements))
+    }
+
+    @Test("A missing, absent, or disabled Mach service is incomplete")
+    func machServices() {
+        var noDict = Self.plist()
+        noDict["MachServices"] = nil
+        var wrongName = Self.plist()
+        wrongName["MachServices"] = ["com.other.helper": true]
+        var disabled = Self.plist()
+        disabled["MachServices"] = [Self.machServiceName: false]
+
+        expectIncomplete(BundledHelperPackage.validateLaunchdPlist(noDict, requirements: Self.requirements))
+        expectIncomplete(BundledHelperPackage.validateLaunchdPlist(wrongName, requirements: Self.requirements))
+        expectIncomplete(BundledHelperPackage.validateLaunchdPlist(disabled, requirements: Self.requirements))
+    }
+
+    @Test("Missing, empty, or non-matching AssociatedBundleIdentifiers is incomplete")
+    func associatedBundleIdentifiers() {
+        var missing = Self.plist()
+        missing["AssociatedBundleIdentifiers"] = nil
+        var empty = Self.plist()
+        empty["AssociatedBundleIdentifiers"] = [String]()
+        var unrelated = Self.plist()
+        unrelated["AssociatedBundleIdentifiers"] = ["com.other.app"]
+
+        expectIncomplete(BundledHelperPackage.validateLaunchdPlist(missing, requirements: Self.requirements))
+        expectIncomplete(BundledHelperPackage.validateLaunchdPlist(empty, requirements: Self.requirements))
+        expectIncomplete(BundledHelperPackage.validateLaunchdPlist(unrelated, requirements: Self.requirements))
+    }
+
+    @Test("Unexpected AssociatedBundleIdentifiers are rejected even when this app is included")
+    func associatedSupersetIsRejected() {
+        var superset = Self.plist()
+        superset["AssociatedBundleIdentifiers"] = [Self.appIdentifier, "\(Self.appIdentifier).pro"]
+        expectIncomplete(BundledHelperPackage.validateLaunchdPlist(superset, requirements: Self.requirements))
+    }
+
+    @Test("AssociatedBundleIdentifiers compare as a normalized set")
+    func associatedSetNormalization() {
+        var reordered = Self.plist()
+        reordered["AssociatedBundleIdentifiers"] = [
+            Self.communityAppIdentifier,
+            Self.appIdentifier,
+            Self.appIdentifier,
+        ]
+        #expect(BundledHelperPackage.validateLaunchdPlist(reordered, requirements: Self.requirements) == .ok)
+    }
+
+    // MARK: Private
+
+    private static let machServiceName = "com.example.tracexy.helper"
+    private static let bundleProgram = "Contents/Library/HelperTools/TracexyCaptureHelper"
+    private static let appIdentifier = "com.example.tracexy"
+    private static let communityAppIdentifier = "com.example.tracexy.community"
+
+    private static let requirements = BundledHelperPackage.Requirements(
+        expectedLabel: machServiceName,
+        expectedBundleProgram: bundleProgram,
+        expectedMachServiceName: machServiceName,
+        expectedAssociatedBundleIdentifiers: [appIdentifier, communityAppIdentifier]
+    )
+
+    private static func plist() -> [String: Any] {
+        [
+            "Label": machServiceName,
+            "BundleProgram": bundleProgram,
+            "MachServices": [machServiceName: true],
+            "AssociatedBundleIdentifiers": [appIdentifier, communityAppIdentifier],
+        ]
+    }
+
+    private func expectIncomplete(_ validation: BundledHelperPackage.Validation) {
+        guard case .incomplete = validation else {
+            Issue.record("expected .incomplete, got \(validation)")
+            return
+        }
+    }
+}

--- a/TracexyTests/Core/Services/HelperClientDecisionTests.swift
+++ b/TracexyTests/Core/Services/HelperClientDecisionTests.swift
@@ -1,0 +1,189 @@
+import Foundation
+import ServiceManagement
+import Testing
+@testable import Tracexy
+
+// MARK: - OneShotGuardTests
+
+// Pure, deterministic coverage for the helper-lifecycle decision points that must
+// never touch real XPC, registration, or privileged commands.
+
+@Suite("Helper one-shot resume gate")
+struct OneShotGuardTests {
+    @Test("Admits exactly one claimant under heavy contention")
+    func admitsExactlyOne() {
+        let gate = OneShotGuard()
+        let winners = LockedCounter()
+
+        // Many threads race to claim; the gate must let exactly one through — this
+        // is the invariant that keeps the probe continuation resumed exactly once
+        // when reply / error / timeout fire together.
+        DispatchQueue.concurrentPerform(iterations: 4_000) { _ in
+            if gate.claim() {
+                winners.increment()
+            }
+        }
+
+        #expect(winners.value == 1)
+    }
+
+    @Test("A second sequential claim always loses")
+    func secondClaimLoses() {
+        let gate = OneShotGuard()
+        #expect(gate.claim())
+        #expect(!gate.claim())
+        #expect(!gate.claim())
+    }
+}
+
+// MARK: - LockedCounter
+
+private final class LockedCounter: @unchecked Sendable {
+    // MARK: Internal
+
+    var value: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return count
+    }
+
+    func increment() {
+        lock.lock()
+        defer { lock.unlock() }
+        count += 1
+    }
+
+    // MARK: Private
+
+    private let lock = NSLock()
+    private var count = 0
+}
+
+// MARK: - HelperCompatibilityTests
+
+@Suite("Helper compatibility classification")
+struct HelperCompatibilityTests {
+    @Test("Same protocol and at-or-above the bundled build is compatible")
+    func compatible() {
+        let atBuild = HelperClient.classifyCompatibility(
+            HelperInfo(binaryVersion: "1.0.0", buildNumber: 10, protocolVersion: 3),
+            expectedProtocolVersion: 3,
+            bundledBuild: 10
+        )
+        let aboveBuild = HelperClient.classifyCompatibility(
+            HelperInfo(binaryVersion: "1.0.1", buildNumber: 11, protocolVersion: 3),
+            expectedProtocolVersion: 3,
+            bundledBuild: 10
+        )
+        #expect(atBuild == .installedCompatible)
+        #expect(aboveBuild == .installedCompatible)
+    }
+
+    @Test("Same protocol but an older build is outdated")
+    func outdated() {
+        let result = HelperClient.classifyCompatibility(
+            HelperInfo(binaryVersion: "0.9.0", buildNumber: 9, protocolVersion: 3),
+            expectedProtocolVersion: 3,
+            bundledBuild: 10
+        )
+        #expect(result == .installedOutdated)
+    }
+
+    @Test("A different protocol is incompatible regardless of build")
+    func incompatible() {
+        let older = HelperClient.classifyCompatibility(
+            HelperInfo(binaryVersion: "1.0.0", buildNumber: 100, protocolVersion: 2),
+            expectedProtocolVersion: 3,
+            bundledBuild: 10
+        )
+        #expect(older == .installedIncompatible)
+    }
+}
+
+// MARK: - CaptureAvailabilityTests
+
+@Suite("Capture Start availability mapping")
+struct CaptureAvailabilityTests {
+    @Test("Compatible and outdated are both ready to capture")
+    func ready() {
+        #expect(HelperClient.captureAvailability(for: .installedCompatible, unreachableDetail: nil) == .ready)
+        #expect(HelperClient.captureAvailability(for: .installedOutdated, unreachableDetail: nil) == .ready)
+    }
+
+    @Test("Approval maps through, not to ready")
+    func approval() {
+        #expect(HelperClient.captureAvailability(for: .requiresApproval, unreachableDetail: nil) == .requiresApproval)
+    }
+
+    @Test("Broken helpers are surfaced as unavailable, never ready")
+    func unavailable() {
+        for status in [
+            HelperClient.Status.installedIncompatible,
+            .signingMismatch,
+            .notInstalled,
+            .failed("boom"),
+        ] {
+            let availability = HelperClient.captureAvailability(for: status, unreachableDetail: nil)
+            guard case .unavailable = availability else {
+                Issue.record("expected .unavailable for \(status)")
+                continue
+            }
+        }
+    }
+
+    @Test("Unreachable carries the probe detail so the user learns why")
+    func unreachableDetail() {
+        let availability = HelperClient.captureAvailability(
+            for: .unreachable,
+            unreachableDetail: "The helper didn’t respond within the timeout."
+        )
+        guard case let .unavailable(detail) = availability else {
+            Issue.record("expected .unavailable")
+            return
+        }
+        #expect(detail == "The helper didn’t respond within the timeout.")
+    }
+}
+
+// MARK: - HelperApprovalClassificationTests
+
+@Suite("Helper approval-error classification")
+struct HelperApprovalClassificationTests {
+    @Test("SMAppService already reporting requiresApproval is approval")
+    func statusRequiresApproval() {
+        let unrelated = NSError(domain: NSCocoaErrorDomain, code: NSFileNoSuchFileError)
+        #expect(HelperClient.isApprovalRequired(serviceStatus: .requiresApproval, error: unrelated))
+    }
+
+    @Test("kSMErrorLaunchDeniedByUser is approval")
+    func launchDeniedByUser() {
+        let error = NSError(domain: NSOSStatusErrorDomain, code: kSMErrorLaunchDeniedByUser)
+        #expect(HelperClient.isApprovalRequired(serviceStatus: .enabled, error: error))
+    }
+
+    @Test("The OSStatus operation-not-permitted early block is approval")
+    func operationNotPermitted() {
+        let error = NSError(domain: NSOSStatusErrorDomain, code: 1)
+        #expect(HelperClient.isApprovalRequired(serviceStatus: .enabled, error: error))
+    }
+
+    @Test("Unrelated errors are not misclassified as approval")
+    func doesNotMisclassify() {
+        let cocoa = NSError(domain: NSCocoaErrorDomain, code: NSFileNoSuchFileError)
+        // A POSIX EPERM (code 1) in a different domain must not trip the OSStatus rule.
+        let posix = NSError(domain: NSPOSIXErrorDomain, code: 1)
+        #expect(!HelperClient.isApprovalRequired(serviceStatus: .enabled, error: cocoa))
+        #expect(!HelperClient.isApprovalRequired(serviceStatus: .enabled, error: posix))
+    }
+}
+
+// MARK: - HelperProbeErrorTests
+
+@Suite("Helper probe error detail")
+struct HelperProbeErrorTests {
+    @Test("Timeout describes the timeout; unreachable passes its message through")
+    func detail() {
+        #expect(HelperProbeError.timedOut.detail.localizedCaseInsensitiveContains("timeout"))
+        #expect(HelperProbeError.unreachable("connection invalid").detail == "connection invalid")
+    }
+}

--- a/TracexyTests/Core/Services/HelperForceResetTests.swift
+++ b/TracexyTests/Core/Services/HelperForceResetTests.swift
@@ -1,0 +1,157 @@
+import Foundation
+import Testing
+@testable import Tracexy
+
+// MARK: - ForceRemoveScriptTests
+
+// The force-reset path is exercised only through its pure builders and result
+// types. No test ever runs the privileged script, invokes osascript, or registers
+// / unregisters the helper.
+
+@Suite("Force-remove shell script builder")
+struct ForceRemoveScriptTests {
+    // MARK: Internal
+
+    @Test("Removes the launchd job, process, helper binary, and launch daemon plist")
+    func removesEverything() {
+        let script = HelperClient.forceRemoveShellScript(identity: Self.identity, resetBackgroundItems: false)
+
+        #expect(script.contains("/bin/launchctl bootout system/'com.example.helper'"))
+        #expect(script.contains("/bin/rm -f '/Library/PrivilegedHelperTools/com.example.helper'"))
+        #expect(script.contains("/bin/rm -f '/Library/LaunchDaemons/com.example.helper.plist'"))
+    }
+
+    @Test("pkill uses the bracket form so it cannot match itself")
+    func bracketedPkill() {
+        let script = HelperClient.forceRemoveShellScript(identity: Self.identity, resetBackgroundItems: false)
+        #expect(script.contains("/usr/bin/pkill -f '[T]racexyCaptureHelper'"))
+        // The naive, self-matching form must not appear.
+        #expect(!script.contains("pkill -f 'TracexyCaptureHelper'"))
+    }
+
+    @Test("Exit guards fail loudly if the job or files remain")
+    func exitGuards() {
+        let script = HelperClient.forceRemoveShellScript(identity: Self.identity, resetBackgroundItems: false)
+        #expect(script.contains("exit 20"))
+        #expect(script.contains("exit 21"))
+        #expect(script.contains("exit 22"))
+    }
+
+    @Test("sfltool resetbtm is gated behind the flag")
+    func sfltoolGated() {
+        let without = HelperClient.forceRemoveShellScript(identity: Self.identity, resetBackgroundItems: false)
+        let with = HelperClient.forceRemoveShellScript(identity: Self.identity, resetBackgroundItems: true)
+        #expect(!without.contains("sfltool resetbtm"))
+        #expect(with.contains("/usr/bin/sfltool resetbtm"))
+    }
+
+    // MARK: Private
+
+    private static let identity = TracexyIdentity(infoDictionary: [
+        "TracexyHelperBundleIdentifier": "com.example.helper",
+        "TracexyHelperMachServiceName": "com.example.helper",
+        "TracexyHelperPlistName": "com.example.helper.plist",
+    ])
+}
+
+// MARK: - ForceRemoveErrorTests
+
+@Suite("Force-remove error classification")
+struct ForceRemoveErrorTests {
+    @Test("A cancelled administrator prompt is recognised and does not read as a failure")
+    func cancelled() {
+        let cancelled = HelperClient.ForceRemoveError.commandFailed(exitCode: 1, output: "User canceled. (-128)")
+        #expect(cancelled.isAuthorizationCancelled)
+        #expect(cancelled.errorDescription == "The administrator authorization prompt was cancelled.")
+    }
+
+    @Test("A tripped exit guard is a real failure, not a cancellation")
+    func guardTrip() {
+        let tripped = HelperClient.ForceRemoveError.commandFailed(
+            exitCode: 20,
+            output: "Tracexy helper launchd job is still loaded."
+        )
+        #expect(!tripped.isAuthorizationCancelled)
+        #expect(tripped.errorDescription?.contains("exit code 20") == true)
+        #expect(tripped.commandOutput == "Tracexy helper launchd job is still loaded.")
+    }
+
+    @Test("A signal termination is described and is not a cancellation")
+    func terminated() {
+        let terminated = HelperClient.ForceRemoveError.commandTerminated(signal: 15, output: "")
+        #expect(!terminated.isAuthorizationCancelled)
+        #expect(terminated.errorDescription?.contains("signal 15") == true)
+    }
+}
+
+// MARK: - ForceResetSummaryTests
+
+@Suite("Force-reset result summary")
+struct ForceResetSummaryTests {
+    @Test("A clean reinstall to a compatible helper is a success and needs no escalation")
+    func reinstalledCompatible() {
+        let summary = ForceResetSummary(
+            phase: .reinstalled,
+            removalOutput: "removed",
+            finalStatus: .installedCompatible
+        )
+        #expect(summary.didReinstall)
+        #expect(summary.succeeded)
+        #expect(!summary.suggestsBackgroundItemsReset)
+        #expect(summary.details.contains("removed"))
+        #expect(summary.details.localizedCaseInsensitiveContains("up to date"))
+    }
+
+    @Test("Reinstall that only needs Login-Items approval is still a success")
+    func reinstalledRequiresApproval() {
+        let summary = ForceResetSummary(phase: .reinstalled, removalOutput: "", finalStatus: .requiresApproval)
+        #expect(summary.succeeded)
+    }
+
+    @Test("Reinstall that lands unreachable is not success and suggests escalation")
+    func reinstalledUnreachable() {
+        let summary = ForceResetSummary(phase: .reinstalled, removalOutput: "", finalStatus: .unreachable)
+        #expect(!summary.succeeded)
+        #expect(summary.suggestsBackgroundItemsReset)
+    }
+
+    @Test("Reinstall that still reports an outdated helper is not success")
+    func reinstalledOutdated() {
+        let summary = ForceResetSummary(phase: .reinstalled, removalOutput: "", finalStatus: .installedOutdated)
+        #expect(!summary.succeeded)
+        #expect(summary.suggestsBackgroundItemsReset)
+    }
+
+    @Test("A failed removal keeps escalation available and never reads as success")
+    func removalFailed() {
+        let summary = ForceResetSummary(
+            phase: .removalFailed,
+            removalOutput: "job still loaded",
+            finalStatus: .installedCompatible
+        )
+        #expect(!summary.didReinstall)
+        #expect(!summary.succeeded)
+        #expect(summary.suggestsBackgroundItemsReset)
+        #expect(summary.title == "Force reset failed")
+    }
+
+    @Test("A cancelled removal is not a success and does not push escalation")
+    func removalCancelled() {
+        let summary = ForceResetSummary(phase: .removalCancelled, removalOutput: "cancelled", finalStatus: nil)
+        #expect(!summary.succeeded)
+        #expect(!summary.suggestsBackgroundItemsReset)
+        #expect(summary.title == "Force reset cancelled")
+    }
+
+    @Test("An overlapping lifecycle action does not trigger destructive escalation")
+    func operationInProgress() {
+        let summary = ForceResetSummary(
+            phase: .operationInProgress,
+            removalOutput: "Another helper operation is already in progress.",
+            finalStatus: .installedCompatible
+        )
+        #expect(!summary.didReinstall)
+        #expect(!summary.succeeded)
+        #expect(!summary.suggestsBackgroundItemsReset)
+    }
+}

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -16,6 +16,13 @@ are dropped once it is full), so a long capture stays memory-stable but is not a
 the helper is not yet approved, Tracexy tells you to approve it in System Settings → Login Items and
 press Start again.
 
+**Settings → Helper** shows the registration, reachability, bundled version, and installed version.
+From there you can install, update, uninstall, or recheck the helper. If a registered helper stops
+answering, Tracexy times out the request, reports it as unreachable, and ends an affected live capture
+instead of leaving the UI stuck. **Force Reset & Reinstall** is a confirmed recovery action for stale
+launchd/helper state; the broader macOS Background Items reset is offered only as an explicitly
+confirmed last resort after normal recovery fails.
+
 ## Opening saved captures
 
 Open a `.pcap` (classic libpcap) or `.pcapng` file from disk — no helper or admin rights required.


### PR DESCRIPTION
## Summary

- detect unavailable, outdated, and unhealthy privileged helper installations
- support guided install, update, uninstall, and force-reset recovery flows
- surface actionable recovery states in setup and settings
- add focused lifecycle tests and update helper usage documentation

## Validation

- `xcodebuild -project Tracexy.xcodeproj -scheme Tracexy -destination "platform=macOS" build`
- `xcodebuild -project Tracexy.xcodeproj -scheme Tracexy -destination "platform=macOS" test -only-testing:TracexyTests`
- `xcodebuild -project Tracexy.xcodeproj -scheme Tracexy -destination "platform=macOS" test`
- `swiftformat --lint .`
- `swiftlint lint --strict`

## Notes

Helper changes require uninstalling the existing privileged helper, rebuilding the app, and reinstalling the helper before runtime verification.