### PR TITLE
fix(ui): stabilize live session table updates

### DIFF
--- a/Tracexy/Core/Session/Activity.swift
+++ b/Tracexy/Core/Session/Activity.swift
@@ -1,3 +1,4 @@
+import CryptoKit
 import Foundation
 
 // MARK: - ConfidenceTier
@@ -86,11 +87,15 @@ enum ActivityEvidence: Hashable, Sendable {
 struct Activity: Identifiable, Hashable, Sendable {
     // MARK: Lifecycle
 
-    init(id: UUID = UUID(), sessions: [SessionSummary], evidence: [ActivityEvidence], competingNames: [String] = []) {
-        self.id = id
-        self.sessions = sessions.sorted { $0.startTime < $1.startTime }
+    init(id: UUID? = nil, sessions: [SessionSummary], evidence: [ActivityEvidence], competingNames: [String] = []) {
+        let ordered = sessions.sorted { $0.startTime < $1.startTime }
+        self.sessions = ordered
         self.evidence = evidence
         self.competingNames = competingNames
+        // A caller-supplied id wins (the coordinator recreates filtered survivor
+        // activities with the original id); otherwise derive a stable one from
+        // the oldest member so the same action keeps the same row across rebuilds.
+        self.id = id ?? Self.identifier(anchor: ordered.first?.id)
     }
 
     // MARK: Internal
@@ -171,5 +176,34 @@ struct Activity: Identifiable, Hashable, Sendable {
             }
         }
         return path
+    }
+
+    // MARK: Private
+
+    /// A stable identity derived from the oldest member rather than a fresh
+    /// `UUID()`.
+    ///
+    /// The activity list is rebuilt on every capture tick, so a random id would
+    /// hand `Table` a brand-new action row each second: disclosure and selection
+    /// state would drop, and the grouped rows would churn while traffic was live.
+    /// Anchoring on the oldest session keeps an action the *same* row for as long
+    /// as its first step persists, and adding a later member leaves it unchanged.
+    ///
+    /// The `activity:` namespace is deliberate: action roots and their disclosure
+    /// children share one `Table` hierarchy, so this must never collide with a
+    /// child session id — hashing a namespaced anchor guarantees it cannot.
+    private static func identifier(anchor: UUID?) -> UUID {
+        let seed = anchor?.uuidString ?? "—"
+        let digest = SHA256.hash(data: Data("activity:\(seed)".utf8))
+        var bytes = Array(digest.prefix(16))
+        // Stamp RFC 4122 version 4 / variant bits so this is a well-formed UUID.
+        bytes[6] = (bytes[6] & 0x0F) | 0x40
+        bytes[8] = (bytes[8] & 0x3F) | 0x80
+        return UUID(uuid: (
+            bytes[0], bytes[1], bytes[2], bytes[3],
+            bytes[4], bytes[5], bytes[6], bytes[7],
+            bytes[8], bytes[9], bytes[10], bytes[11],
+            bytes[12], bytes[13], bytes[14], bytes[15]
+        ))
     }
 }

--- a/Tracexy/Core/Session/SessionBuilder.swift
+++ b/Tracexy/Core/Session/SessionBuilder.swift
@@ -38,8 +38,13 @@ nonisolated enum SessionBuilder {
             groups[key, default: []].append(packet)
         }
 
+        // Emit in first-seen order. Frames arrive in capture order, so this is
+        // chronological (oldest→newest). Preserving the order already collected in
+        // `order` — rather than re-sorting on every rebuild — keeps existing rows
+        // fixed in place: a rebuild with later packets for known five-tuples leaves
+        // them at their indices, and a genuinely new session appends at the tail
+        // instead of shifting the whole table down.
         return order.compactMap { summary(for: groups[$0] ?? [], key: $0, resolved: resolved) }
-            .sorted { $0.startTime > $1.startTime }
     }
 
     // MARK: Private

--- a/Tracexy/ViewModels/MainContentCoordinator.swift
+++ b/Tracexy/ViewModels/MainContentCoordinator.swift
@@ -1325,7 +1325,11 @@ final class MainContentCoordinator {
         Task { @MainActor in
             self.sessions = snapshot
             if self.activeWorkspace.autoSelectLatest,
-               let latest = snapshot.max(by: { $0.startTime < $1.startTime }),
+               // Newest by timestamp, tie-broken by id so the choice never depends
+               // on the array's (now first-seen) order.
+               let latest = snapshot.max(by: {
+                   ($0.startTime, $0.id.uuidString) < ($1.startTime, $1.id.uuidString)
+               }),
                self.activeWorkspace.selectedSessionID != latest.id
             {
                 self.activeWorkspace.selectedSessionID = latest.id

--- a/TracexyTests/Core/Session/ActivityBuilderTests.swift
+++ b/TracexyTests/Core/Session/ActivityBuilderTests.swift
@@ -154,6 +154,91 @@ struct ActivityBuilderTests {
         #expect(abs(activity.duration - 0.29) < 0.005)
     }
 
+    @Test("Rebuilding from the same sessions yields the same activity id")
+    func activityIdIsStableAcrossRebuilds() throws {
+        let base = Date()
+        let dns = Self.session(
+            host: "dns.google", at: base, process: "MyApp",
+            stack: [.udp, .dns], dnsQuery: "api.example.com", dnsAnswers: ["93.184.16.34"]
+        )
+        let tcp = Self.session(
+            host: "api.example.com", at: base.addingTimeInterval(0.02), process: "MyApp",
+            stack: [.tcp, .tls], destination: "93.184.16.34:443", sni: "api.example.com"
+        )
+
+        // Same session values (crucially the same ids, as the store hands back on
+        // every capture tick) must produce the identical action row identity.
+        let first = try #require(ActivityBuilder.build(from: [dns, tcp]).activities.first)
+        let second = try #require(ActivityBuilder.build(from: [dns, tcp]).activities.first)
+
+        #expect(first.id == second.id)
+    }
+
+    @Test("Adding a later member preserves the activity id while the anchor remains")
+    func activityIdSurvivesLaterMember() throws {
+        let base = Date()
+        let dns = Self.session(
+            host: "dns.google", at: base, process: "MyApp",
+            stack: [.udp, .dns], dnsQuery: "api.example.com", dnsAnswers: ["93.184.16.34"]
+        )
+        let tcp = Self.session(
+            host: "api.example.com", at: base.addingTimeInterval(0.02), process: "MyApp",
+            stack: [.tcp], destination: "93.184.16.34:443", sni: "api.example.com"
+        )
+        let tls = Self.session(
+            host: "api.example.com", at: base.addingTimeInterval(0.05), process: "MyApp",
+            stack: [.tcp, .tls], destination: "93.184.16.34:443", sni: "api.example.com"
+        )
+
+        let before = try #require(ActivityBuilder.build(from: [dns, tcp]).activities.first)
+        // The oldest member (the DNS lookup) is unchanged, so the action keeps its
+        // row identity even though a third session joined it.
+        let after = try #require(ActivityBuilder.build(from: [dns, tcp, tls]).activities.first)
+
+        #expect(after.sessions.count == 3)
+        #expect(before.id == after.id)
+    }
+
+    @Test("An activity id never collides with one of its child session ids")
+    func activityIdDoesNotCollideWithChildren() throws {
+        let base = Date()
+        let dns = Self.session(
+            host: "dns.google", at: base, process: "MyApp",
+            stack: [.udp, .dns], dnsQuery: "api.example.com", dnsAnswers: ["93.184.16.34"]
+        )
+        let tcp = Self.session(
+            host: "api.example.com", at: base.addingTimeInterval(0.02), process: "MyApp",
+            stack: [.tcp, .tls], destination: "93.184.16.34:443", sni: "api.example.com"
+        )
+
+        let activity = try #require(ActivityBuilder.build(from: [dns, tcp]).activities.first)
+
+        // Action roots and disclosure children coexist in one Table hierarchy, so
+        // the root id must differ from every member — including the anchor it is
+        // derived from.
+        #expect(!activity.sessions.contains { $0.id == activity.id })
+    }
+
+    @Test("An explicitly supplied id is preserved, not recomputed")
+    func explicitIdIsPreserved() {
+        let base = Date()
+        let dns = Self.session(
+            host: "dns.google", at: base, process: "MyApp",
+            stack: [.udp, .dns], dnsQuery: "api.example.com", dnsAnswers: ["93.184.16.34"]
+        )
+        let tcp = Self.session(
+            host: "api.example.com", at: base.addingTimeInterval(0.02), process: "MyApp",
+            stack: [.tcp, .tls], destination: "93.184.16.34:443"
+        )
+        let pinned = UUID()
+
+        // The coordinator recreates filtered survivor activities with the original
+        // id; that override must win over the derived identity.
+        let activity = Activity(id: pinned, sessions: [dns, tcp], evidence: [])
+
+        #expect(activity.id == pinned)
+    }
+
     // MARK: Private
 
     private static func session(

--- a/TracexyTests/Core/Session/SessionBuilderTests.swift
+++ b/TracexyTests/Core/Session/SessionBuilderTests.swift
@@ -74,7 +74,106 @@ struct SessionBuilderTests {
         #expect(first.map(\.id) == second.map(\.id))
     }
 
+    @Test
+    func outputIsChronologicalOldestFirst() {
+        // Frames arrive in capture order; the session list must read oldest→newest
+        // so the live table appends at the tail instead of shifting downward.
+        let result = SessionBuilder.build(from: TwoSessions.batchOne, linkType: LinkType.ethernet)
+        #expect(result.count == 2)
+        let starts = result.map(\.startTime)
+        #expect(starts == starts.sorted())
+        #expect(result.first?.sni == "one.example")
+        #expect(result.last?.sni == "two.example")
+    }
+
+    @Test
+    func rebuildKeepsPriorIDsAsPrefixAndAppendsNew() {
+        // A later batch that extends an existing five-tuple and introduces a new
+        // one must keep the prior ids in the same relative order (a prefix) and
+        // place the genuinely new session at the tail.
+        let first = SessionBuilder.build(from: TwoSessions.batchOne, linkType: LinkType.ethernet)
+        let second = SessionBuilder.build(from: TwoSessions.batchTwo, linkType: LinkType.ethernet)
+
+        let priorIDs = first.map(\.id)
+        #expect(priorIDs.count == 2)
+        #expect(second.count == 3)
+        // Prior ids are an exact prefix of the rebuilt result…
+        #expect(Array(second.map(\.id).prefix(2)) == priorIDs)
+        // …and the new session lands at the last index.
+        #expect(second.last?.sni == "three.example")
+        #expect(!priorIDs.contains(second[2].id))
+    }
+
+    @Test
+    func existingSessionSummaryUpdatesOnRebuild() {
+        // Extending an existing five-tuple with a later packet must update its
+        // mutable summary in place rather than freezing the first-seen values.
+        let first = SessionBuilder.build(from: TwoSessions.batchOne, linkType: LinkType.ethernet)
+        let second = SessionBuilder.build(from: TwoSessions.batchTwo, linkType: LinkType.ethernet)
+
+        guard let before = first.first(where: { $0.sni == "one.example" }),
+              let after = second.first(where: { $0.sni == "one.example" }) else
+        {
+            Issue.record("missing one.example session")
+            return
+        }
+        #expect(before.id == after.id)
+        // A second packet joined the session: more bytes and a real duration.
+        #expect(after.totalBytes > before.totalBytes)
+        #expect(before.duration == 0)
+        #expect(after.duration > 0)
+    }
+
     // MARK: Private
+
+    /// Two live five-tuples with controlled timestamps, plus a second batch that
+    /// extends the first session and introduces a third — enough to prove
+    /// chronological ordering and incremental prefix/append stability.
+    private enum TwoSessions {
+        // MARK: Internal
+
+        static let client = "10.0.0.5"
+        static let base = Date(timeIntervalSince1970: 1_700_000_000)
+
+        /// Session one (oldest) then session two.
+        static let batchOne: [CapturedFrame] = [
+            frame(
+                PacketBuilder.tlsClientHelloFrame(
+                    sni: "one.example", src: client, dst: "203.0.113.1", srcPort: 40_001
+                ),
+                at: base
+            ),
+            frame(
+                PacketBuilder.tlsClientHelloFrame(
+                    sni: "two.example", src: client, dst: "203.0.113.2", srcPort: 40_002
+                ),
+                at: base.addingTimeInterval(1)
+            ),
+        ]
+
+        /// The same two frames, then a later packet for session one (same
+        /// five-tuple) and a brand-new session three at the tail.
+        static let batchTwo: [CapturedFrame] = batchOne + [
+            frame(
+                PacketBuilder.tlsClientHelloFrame(
+                    sni: "one.example", src: client, dst: "203.0.113.1", srcPort: 40_001
+                ),
+                at: base.addingTimeInterval(2)
+            ),
+            frame(
+                PacketBuilder.tlsClientHelloFrame(
+                    sni: "three.example", src: client, dst: "203.0.113.3", srcPort: 40_003
+                ),
+                at: base.addingTimeInterval(3)
+            ),
+        ]
+
+        // MARK: Private
+
+        private static func frame(_ bytes: [UInt8], at timestamp: Date) -> CapturedFrame {
+            CapturedFrame(bytes: bytes, timestamp: timestamp, originalLength: bytes.count)
+        }
+    }
 
     private func sessions() -> [SessionSummary] {
         SessionBuilder.build(from: SampleCapture.frames(now: Date()), linkType: LinkType.ethernet)

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -11,10 +11,13 @@ on launch**, Tracexy starts capture after launch setup completes. Starting a cap
 previous live buffer and switches you to the live session list so traffic is visible as it arrives.
 
 The helper streams raw frames to the app in batches; the app decodes them, groups them into sessions,
-and refreshes the list a few times a second while capturing. The live buffer is bounded (older frames
-are dropped once it is full), so a long capture stays memory-stable but is not a complete archive. If
-the helper is not yet approved, Tracexy tells you to approve it in System Settings → Login Items and
-press Start again.
+and refreshes the list a few times a second while capturing. The list is ordered oldest→newest and stays
+stable as traffic arrives: sessions you are already looking at keep their positions and update in place
+(their byte counts, duration, and status), while a genuinely new session appears at the bottom rather
+than pushing the whole table down. **Auto-select latest** (in the status bar) follows the newest session
+by time regardless of where it sits. The live buffer is bounded (older frames are dropped once it is
+full), so a long capture stays memory-stable but is not a complete archive. If the helper is not yet
+approved, Tracexy tells you to approve it in System Settings → Login Items and press Start again.
 
 **Settings → Helper** shows the registration, reachability, bundled version, and installed version.
 From there you can install, update, uninstall, or recheck the helper. If a registered helper stops


### PR DESCRIPTION
## Summary

- preserve first-seen session order so existing live rows remain in place and new sessions append at the bottom
- give correlated activity rows deterministic identities across capture rebuilds
- keep Auto Select Latest tied to the newest timestamp rather than array position
- document the live-table behavior and add packet-level regression coverage

## Root cause

The session builder sorted every rebuilt batch newest-first, which inserted new sessions at index zero and shifted the visible table. Correlated actions also received fresh UUIDs on every rebuild, so grouped rows were treated as replacements even when their logical activity was unchanged.

## Validation

- `swiftformat --lint .`
- `swiftlint lint --strict`
- `xcodebuild -project Tracexy.xcodeproj -scheme Tracexy -destination platform=macOS test -only-testing:TracexyTests`
- full test suite attempted; all unit tests passed, while the macOS UI runner timed out enabling automation mode before launching UI tests, matching the existing UI-test infrastructure issue

## Scope

Six files changed across session ordering, activity identity, focused tests, and usage documentation. No helper, capture trust-boundary, identity, dependency, or project configuration changes.