### PR TITLE
fix(helper): make force reset authorization-safe

### DIFF
--- a/Tracexy/Core/Services/HelperClient+ForceRemove.swift
+++ b/Tracexy/Core/Services/HelperClient+ForceRemove.swift
@@ -54,38 +54,32 @@ extension HelperClient {
 
     // MARK: Shell scripting (osascript "with administrator privileges")
 
-    nonisolated static func forceRemoveShellScript(
-        identity: TracexyIdentity,
-        resetBackgroundItems: Bool
-    )
-        -> String
-    {
+    /// The privileged, **app-specific** cleanup script: terminate this helper's
+    /// launchd job by its exact service label, bootout that same job, remove only
+    /// this app's legacy helper binary and launch-daemon plist, then verify with
+    /// exit guards.
+    ///
+    /// The job is killed by its exact `system/<label>` service target — never a
+    /// broad `pkill` on the shared executable name, which a debug build and a
+    /// production build both carry and which could terminate a different app's
+    /// helper. It never touches global Background Items — that is manual guidance
+    /// the user runs themselves, never something Tracexy elevates.
+    nonisolated static func forceRemoveShellScript(identity: TracexyIdentity) -> String {
         let label = shellQuote(identity.helperMachServiceName)
         let helperPath = shellQuote("/Library/PrivilegedHelperTools/\(identity.helperBundleIdentifier)")
         let launchDaemonPath = shellQuote("/Library/LaunchDaemons/\(identity.helperPlistName)")
-        let processPattern = shellQuote("[T]racexyCaptureHelper")
 
-        var commands = [
+        let commands = [
+            "/bin/launchctl kill SIGTERM system/\(label) 2>/dev/null || true",
             "/bin/launchctl bootout system/\(label) 2>/dev/null || true",
-            "/usr/bin/pkill -f \(processPattern) 2>/dev/null || true",
             "/bin/rm -f \(helperPath)",
             "/bin/rm -f \(launchDaemonPath)",
-        ]
-
-        if resetBackgroundItems {
-            commands.append(
-                "if ! /usr/bin/sfltool resetbtm; then " +
-                    "echo 'macOS Background Items reset failed.' >&2; exit 23; fi"
-            )
-        }
-
-        commands.append(contentsOf: [
             "if /bin/launchctl print system/\(label) >/dev/null 2>&1; then " +
                 "echo 'Tracexy helper launchd job is still loaded.' >&2; exit 20; fi",
             "if [ -e \(helperPath) ]; then echo 'Tracexy helper binary still exists.' >&2; exit 21; fi",
             "if [ -e \(launchDaemonPath) ]; then echo 'Tracexy launch daemon plist still exists.' >&2; exit 22; fi",
-            "echo 'Tracexy helper registration files were removed.'",
-        ])
+            "echo 'Tracexy helper launchd job and legacy files were cleared.'",
+        ]
 
         return commands.joined(separator: "; ")
     }
@@ -144,18 +138,19 @@ struct ForceResetSummary: Equatable {
     enum Phase: Equatable {
         /// A lifecycle action was already running, so no reset was attempted.
         case operationInProgress
-        /// The administrator prompt was cancelled; nothing was removed or reinstalled.
+        /// The administrator prompt was cancelled before the privileged cleanup
+        /// ran, so nothing was removed, the SMAppService registration was left
+        /// untouched, and no reinstall was attempted.
         case removalCancelled
-        /// The privileged removal failed (nonzero exit / exit-guard tripped);
-        /// state was left untouched and no reinstall was attempted.
+        /// The privileged removal failed (nonzero exit / exit-guard tripped), or it
+        /// succeeded but the follow-up SMAppService unregister then failed. Either
+        /// way state may be partially changed — the re-probed `finalStatus` is
+        /// authoritative — and no reinstall was attempted.
         case removalFailed
-        /// Removal succeeded (script exit 0) and a reinstall was attempted;
-        /// `finalStatus` carries the real post-reinstall state.
+        /// Removal succeeded (script exit 0, then SMAppService unregister) and a
+        /// reinstall was attempted; `finalStatus` carries the real post-reinstall
+        /// state.
         case reinstalled
-        /// Removal succeeded and macOS Background Items were reset (`sfltool
-        /// resetbtm`). The helper was intentionally NOT reinstalled: a restart is
-        /// required before re-registering into the freshly-reset BTM store.
-        case restartRequired
     }
 
     let phase: Phase
@@ -166,12 +161,6 @@ struct ForceResetSummary: Equatable {
 
     var didReinstall: Bool {
         phase == .reinstalled
-    }
-
-    /// The BTM reset landed and the user must restart before reinstalling. Not a
-    /// failure and not a success — a required manual step.
-    var requiresRestart: Bool {
-        phase == .restartRequired
     }
 
     /// True only when removal *and* reinstall landed the bundled helper in the
@@ -190,10 +179,11 @@ struct ForceResetSummary: Equatable {
         }
     }
 
-    /// Whether to offer the heavier `sfltool resetbtm` escalation next. Only after
-    /// a normal (non-BTM) attempt failed to recover — never after a user-initiated
-    /// cancel.
-    var suggestsBackgroundItemsReset: Bool {
+    /// Whether to surface the manual, last-resort Background Items guidance next —
+    /// a copyable Terminal command the user runs themselves, never an action
+    /// Tracexy elevates. Only after a normal reset failed to recover the helper;
+    /// never after a user-initiated cancel.
+    var suggestsManualBackgroundItemsGuidance: Bool {
         switch phase {
         case .operationInProgress:
             false
@@ -202,10 +192,6 @@ struct ForceResetSummary: Equatable {
         case .reinstalled:
             !succeeded
         case .removalCancelled:
-            false
-        case .restartRequired:
-            // BTM was already reset — the heaviest lever we have. Nothing further
-            // to escalate; the user must restart, then install.
             false
         }
     }
@@ -219,8 +205,6 @@ struct ForceResetSummary: Equatable {
             "Force reset cancelled"
         case .removalFailed:
             "Force reset failed"
-        case .restartRequired:
-            "Background Items reset — restart your Mac, then install the helper"
         case .reinstalled:
             switch finalStatus {
             case .installedCompatible?: "Helper reset and reinstalled"

--- a/Tracexy/Core/Services/HelperClient.swift
+++ b/Tracexy/Core/Services/HelperClient.swift
@@ -50,6 +50,28 @@ final class HelperClient {
         case unavailable(String)
     }
 
+    /// What to do with this app's SMAppService registration *after* the privileged,
+    /// app-specific cleanup has already removed the launchd job and legacy files.
+    ///
+    /// The registration record is separate from those files: the script's exit
+    /// guards prove the job and files are gone, but the SMAppService registration
+    /// may still be live, already absent, or in a status this SDK doesn't model. An
+    /// absent registration is a valid end state that must not block reinstall; a
+    /// live one must be unregistered; an unknown one must be reported truthfully
+    /// rather than guessed away. Kept pure so the decision is unit-testable without
+    /// mutating a live registration.
+    nonisolated enum PostCleanupRegistrationAction: Equatable {
+        /// The registration is live (`.enabled`/`.requiresApproval`): unregister it,
+        /// aborting the reinstall if that unregister fails.
+        case unregister
+        /// The registration is already absent (`.notRegistered`/`.notFound`):
+        /// proceed straight to settle + reinstall without unregistering.
+        case alreadyAbsent
+        /// The status is unknown to this SDK: abort and re-probe with a truthful
+        /// removal-incomplete result rather than assuming it is gone.
+        case abortUnknown
+    }
+
     static let shared = HelperClient()
 
     /// Where the embedded helper binary lives inside the app bundle.
@@ -169,6 +191,23 @@ final class HelperClient {
             return .installedIncompatible
         }
         return info.buildNumber >= bundledBuild ? .installedCompatible : .installedOutdated
+    }
+
+    nonisolated static func postCleanupRegistrationAction(
+        for status: SMAppService.Status
+    )
+        -> PostCleanupRegistrationAction
+    {
+        switch status {
+        case .enabled,
+             .requiresApproval:
+            .unregister
+        case .notRegistered,
+             .notFound:
+            .alreadyAbsent
+        @unknown default:
+            .abortUnknown
+        }
     }
 
     /// Whether a registration error means the user must approve the helper in
@@ -337,8 +376,8 @@ final class HelperClient {
     /// reports success without confirming the helper actually answers.
     ///
     /// Non-destructive: it touches only this app's own SMAppService registration —
-    /// no administrator prompt, no `sfltool`, no file removal. It is offered before
-    /// the privileged hard reset, which stays the last resort.
+    /// no administrator prompt, no global Background Items reset, no file removal. It
+    /// is offered before the privileged hard reset, which stays the last resort.
     func repairRegistration() async {
         guard !isBusy else {
             return
@@ -363,21 +402,31 @@ final class HelperClient {
         status = .unreachable
     }
 
-    /// Hard-remove the helper from launchd and the privileged-helper location.
-    /// A normal reset then reinstalls from the current app bundle; a Background
-    /// Items reset deliberately stops after removal and requires a Mac restart
-    /// before the user installs again.
+    /// Hard-remove the helper from launchd and the privileged-helper location, then
+    /// reinstall it from the current app bundle and verify over XPC. Never resets
+    /// global macOS Background Items — that stays manual, presentation-only guidance
+    /// the user runs themselves from the Settings recovery UI, never something the
+    /// app elevates.
     ///
-    /// Returns a structured, verified summary. Removal is authoritative: if the
-    /// administrator prompt is cancelled, the privileged script exits nonzero, or
-    /// its exit guards detect a still-loaded launchd job / leftover files, the
-    /// method aborts **without clearing state and without reinstalling**, then
-    /// re-probes so `finalStatus` reflects reality. A clean normal removal proceeds
-    /// to reinstall and reports the probed state. A clean Background Items reset
-    /// reports `.restartRequired` without racing a new registration into the reset
-    /// BTM database.
+    /// Ordering is load-bearing for both safety and honesty:
+    /// 1. Stop active capture and drop the XPC connection (app-level).
+    /// 2. Run the **app-specific** privileged cleanup (launchd bootout + this app's
+    ///    file removal). Its exit guards are the authority that the job and files
+    ///    are gone.
+    /// 3. **Only after** that cleanup returns success, unregister this app's
+    ///    SMAppService registration. The administrator prompt therefore always
+    ///    precedes any registration mutation — a cancelled prompt leaves the
+    ///    registration untouched and reinstalls nothing.
+    /// 4. Settle, re-register the bundled helper, and run the real status/XPC probe.
+    ///
+    /// Returns a structured, verified summary. If the administrator prompt is
+    /// cancelled, the privileged script exits nonzero, an exit guard trips, or the
+    /// post-cleanup unregister fails, the method aborts **without reinstalling** and
+    /// re-probes so `finalStatus` reflects reality. Because the cleanup may have
+    /// already removed files before a later step failed, a failure never claims the
+    /// state was left untouched; the re-probed status is authoritative.
     @discardableResult
-    func forceResetAndReinstall(resetBackgroundItems: Bool) async -> ForceResetSummary {
+    func forceResetAndReinstall() async -> ForceResetSummary {
         guard !isBusy else {
             return ForceResetSummary(
                 phase: .operationInProgress,
@@ -395,18 +444,17 @@ final class HelperClient {
                 proxy.stopCapture {}
             }
             self.disconnect()
-            // Best-effort de-registration; the privileged script is the authority.
-            try? await SMAppService.daemon(plistName: Self.plistName).unregister()
 
-            let script = Self.forceRemoveShellScript(
-                identity: TracexyIdentity.current,
-                resetBackgroundItems: resetBackgroundItems
-            )
+            // Privileged, app-specific cleanup FIRST. The administrator prompt must
+            // precede any SMAppService mutation, so the registration is unregistered
+            // only after this returns success — a cancelled prompt touches nothing.
+            let script = Self.forceRemoveShellScript(identity: TracexyIdentity.current)
             let removalOutput: String
             do {
                 removalOutput = try await Self.runPrivilegedShellScript(script)
             } catch let error as ForceRemoveError {
-                // Abort: do not clear state, do not reinstall. Re-probe for truth.
+                // Cancelled prompt or failed removal: do not unregister, do not
+                // reinstall. Re-probe for truth.
                 await self.performCheckStatus()
                 summary = ForceResetSummary(
                     phase: error.isAuthorizationCancelled ? .removalCancelled : .removalFailed,
@@ -425,29 +473,59 @@ final class HelperClient {
                 return
             }
 
-            // Removal verified by the script's exit guards (exit 0).
+            // Privileged cleanup verified by the script's exit guards (exit 0). The
+            // launchd job and legacy files are gone; this app's SMAppService
+            // registration record is a *separate* thing. Inspect its current status
+            // and act truthfully: unregister only a live registration, treat an
+            // already-absent one as a valid end state that must not block reinstall,
+            // and refuse to guess an unknown one away.
+            let service = SMAppService.daemon(plistName: Self.plistName)
+            switch Self.postCleanupRegistrationAction(for: service.status) {
+            case .unregister:
+                // A failed unregister aborts the reinstall and is reported truthfully:
+                // the files are already gone, so state is NOT untouched — the
+                // re-probed status is authoritative.
+                do {
+                    try await service.unregister()
+                } catch {
+                    await self.performCheckStatus()
+                    let base = removalOutput.isEmpty ? "" : removalOutput + "\n"
+                    summary = ForceResetSummary(
+                        phase: .removalFailed,
+                        removalOutput: base
+                            + "Removed the helper files, but couldn’t unregister the launchd service: "
+                            + error.localizedDescription,
+                        finalStatus: self.status
+                    )
+                    Self.logger.error(
+                        "force reset aborted — unregister failed after cleanup: \(error.localizedDescription, privacy: .public)"
+                    )
+                    return
+                }
+            case .alreadyAbsent:
+                // No registration to remove — proceed straight to settle + reinstall.
+                Self.logger.info(
+                    "force reset: SMAppService registration already absent after cleanup; proceeding to reinstall"
+                )
+            case .abortUnknown:
+                await self.performCheckStatus()
+                let base = removalOutput.isEmpty ? "" : removalOutput + "\n"
+                summary = ForceResetSummary(
+                    phase: .removalFailed,
+                    removalOutput: base
+                        + "Removed the helper files, but the launchd service registration is in an "
+                        + "unknown state, so the reinstall was not attempted.",
+                    finalStatus: self.status
+                )
+                Self.logger.error("force reset aborted — unknown SMAppService status after cleanup")
+                return
+            }
+
+            // Removal fully verified. Reinstall from the current bundle and verify.
             self.status = .notInstalled
             self.installedInfo = nil
             self.probeFailureDetail = nil
 
-            if resetBackgroundItems {
-                // `sfltool resetbtm` wiped Background Task Management. Re-registering
-                // now would race a freshly-reset BTM store and re-enter the drift we
-                // just cleared — macOS requires a restart before the reset fully
-                // takes effect. Do NOT reinstall; tell the user to restart, then
-                // install from Settings (status is .notInstalled, so Install is offered).
-                summary = ForceResetSummary(
-                    phase: .restartRequired,
-                    removalOutput: removalOutput.isEmpty
-                        ? "Removed the helper and reset macOS Background Items."
-                        : removalOutput,
-                    finalStatus: .notInstalled
-                )
-                Self.logger.info("force reset with BTM reset complete — restart required before reinstall")
-                return
-            }
-
-            // Normal (non-BTM) reset: reinstall from the current bundle and verify.
             try? await Task.sleep(nanoseconds: Self.btmSettleNanoseconds)
             await self.performInstall()
             summary = ForceResetSummary(

--- a/Tracexy/Views/Settings/HelperRecoveryPresenter.swift
+++ b/Tracexy/Views/Settings/HelperRecoveryPresenter.swift
@@ -4,12 +4,14 @@ import Observation
 // MARK: - HelperRecoveryPresenter
 
 /// Drives the Settings → Helper recovery flow: the normal force-reset-and-reinstall
-/// and, only after that fails, the heavier `sfltool resetbtm` escalation.
+/// and, only after that fails, the *manual* Background Items guidance — a copyable
+/// Terminal command the user runs themselves, never an action Tracexy elevates.
 ///
 /// Owns just the presentation state (working flag, last summary, whether to offer
-/// the Background Items escalation). The privileged work and all state truth live
-/// on `HelperClient`; this type never runs a privileged operation itself beyond
-/// asking the client to.
+/// the manual Background Items guidance). The privileged work and all state truth
+/// live on `HelperClient`; this type never runs a privileged operation itself
+/// beyond asking the client to force-reset, and it never executes the manual
+/// command — it only copies it to the pasteboard.
 @MainActor
 @Observable
 final class HelperRecoveryPresenter {
@@ -25,23 +27,42 @@ final class HelperRecoveryPresenter {
 
     // MARK: Internal
 
+    /// The exact command a user can run manually, in Terminal, to reset macOS
+    /// Background Task Management as a global last resort.
+    ///
+    /// Presentation-only and deliberately confined to this presentation layer:
+    /// Tracexy never executes this, feeds it to `osascript`, or spawns it via
+    /// `Process` — it is only ever displayed or copied to the pasteboard. Nesting a
+    /// global BTM reset inside an already-elevated `osascript` shell was the v0.1.3
+    /// regression: the global reset requested `com.apple.auth.admin`, could not
+    /// present a second interaction, returned NSOSStatus -60007, and exited *after*
+    /// the helper had been unregistered. Keeping the string out of Core/Services
+    /// guarantees no privileged executor can ever reach it.
+    nonisolated static let manualBackgroundItemsResetCommand = "sudo /usr/bin/sfltool resetbtm"
+
     private(set) var isWorking = false
     private(set) var summary: ForceResetSummary?
 
-    /// True only once a normal (non-BTM) reset has run and failed to recover the
-    /// helper. Gates the `sfltool resetbtm` escalation so it is never a casual,
-    /// always-visible checkbox.
-    private(set) var offersBackgroundItemsReset = false
+    /// True only once a normal reset has run and failed to recover the helper.
+    /// Gates the manual Background Items guidance so the last-resort command is
+    /// never an always-visible affordance.
+    private(set) var offersManualBackgroundItemsGuidance = false
 
-    /// Normal recovery: remove + reinstall without touching macOS Background Items.
-    func runNormalReset() async {
-        await run(resetBackgroundItems: false)
+    /// The exact command shown/copied for the manual, global Background Items
+    /// reset. Presentation-only — Tracexy never runs it.
+    var manualBackgroundItemsCommand: String {
+        Self.manualBackgroundItemsResetCommand
     }
 
-    /// Escalated recovery: also runs `sfltool resetbtm`. Only reachable after a
-    /// normal reset failed and behind a second explicit confirmation in the UI.
-    func runBackgroundItemsReset() async {
-        await run(resetBackgroundItems: true)
+    /// Normal recovery: remove + reinstall. Never touches global Background Items.
+    func runNormalReset() async {
+        isWorking = true
+        defer { isWorking = false }
+        let result = await helper.forceResetAndReinstall()
+        summary = result
+        // Only surface the manual last-resort guidance after a normal attempt
+        // didn't recover the helper.
+        offersManualBackgroundItemsGuidance = result.suggestsManualBackgroundItemsGuidance
     }
 
     /// Copies the full success/failure detail to the pasteboard for a bug report.
@@ -53,17 +74,14 @@ final class HelperRecoveryPresenter {
         NSPasteboard.general.setString(summary.details, forType: .string)
     }
 
+    /// Copies the manual Background Items reset command to the pasteboard. Tracexy
+    /// never executes this command; the user pastes it into Terminal themselves.
+    func copyManualBackgroundItemsCommand() {
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(manualBackgroundItemsCommand, forType: .string)
+    }
+
     // MARK: Private
 
     private let helper: HelperClient
-
-    private func run(resetBackgroundItems: Bool) async {
-        isWorking = true
-        defer { isWorking = false }
-        let result = await helper.forceResetAndReinstall(resetBackgroundItems: resetBackgroundItems)
-        summary = result
-        // Only offer the BTM escalation after a *normal* attempt didn't recover;
-        // running it a second time offers no new lever, so it drops away.
-        offersBackgroundItemsReset = !resetBackgroundItems && result.suggestsBackgroundItemsReset
-    }
 }

--- a/Tracexy/Views/Settings/HelperSettingsView.swift
+++ b/Tracexy/Views/Settings/HelperSettingsView.swift
@@ -71,7 +71,6 @@ struct HelperSettingsView: View {
     @State private var helper = HelperClient.shared
     @State private var recovery = HelperRecoveryPresenter()
     @State private var showForceResetConfirm = false
-    @State private var showBackgroundItemsConfirm = false
 
     private let metrics = SettingsDisplayMetrics.standard
 
@@ -122,37 +121,31 @@ struct HelperSettingsView: View {
                 )
             }
 
-            if recovery.offersBackgroundItemsReset {
+            if recovery.offersManualBackgroundItemsGuidance {
                 SettingsDivider()
-                helperNote(
-                    "Normal recovery didn’t fully clear the helper. As a last resort you can also reset macOS Login & "
-                        + "Background Items. This runs “sfltool resetbtm”, which can affect Background Items for other "
-                        + "apps too — they may need re-approval. You must restart your Mac before installing the helper "
-                        + "again."
-                )
-                HStack {
-                    Button("Reset Background Items…", role: .destructive) {
-                        showBackgroundItemsConfirm = true
-                    }
-                    Spacer(minLength: 0)
-                }
-                .confirmationDialog(
-                    "Also reset macOS Background Items?",
-                    isPresented: $showBackgroundItemsConfirm,
-                    titleVisibility: .visible
-                ) {
-                    Button("Reset Background Items", role: .destructive) {
-                        Task { await recovery.runBackgroundItemsReset() }
-                    }
-                    Button("Cancel", role: .cancel) {}
-                } message: {
-                    Text(
-                        "This runs “sfltool resetbtm” and can affect Login & Background Items for other apps, which may "
-                            + "need re-approval. Tracexy will remove the helper but will not reinstall it immediately; "
-                            + "restart your Mac, then install it from Settings. Only continue if normal recovery didn’t work."
-                    )
-                }
+                manualBackgroundItemsGuidance
             }
+        }
+    }
+
+    /// Last-resort *manual* guidance shown only after a normal reset fails. This is
+    /// pure instruction plus a Copy Command action: Tracexy never runs the global
+    /// Background Items reset (nesting it in an elevated shell was the v0.1.3
+    /// regression). The user runs it themselves in Terminal, restarts, and returns.
+    @ViewBuilder private var manualBackgroundItemsGuidance: some View {
+        helperNote(
+            "Normal recovery didn’t fully clear the helper. As a last resort you can reset macOS Login & Background "
+                + "Items yourself. This affects Background Items for other apps too — they may need re-approval — so "
+                + "Tracexy won’t run it for you. Open Terminal and run the command below with sudo, restart your Mac, "
+                + "then return here and choose Install Helper."
+        )
+        HStack(spacing: 12) {
+            Text(recovery.manualBackgroundItemsCommand)
+                .font(metrics.secondaryFont().monospaced())
+                .foregroundStyle(.secondary)
+                .textSelection(.enabled)
+            Button("Copy Command") { recovery.copyManualBackgroundItemsCommand() }
+            Spacer(minLength: 0)
         }
     }
 
@@ -168,16 +161,7 @@ struct HelperSettingsView: View {
         case .installedCompatible:
             Label("No action needed", systemImage: "checkmark").foregroundStyle(.secondary)
         case .notInstalled:
-            // After a Background Items reset the helper is removed but a restart is
-            // required before it can be installed again. Suppress the Install button
-            // while that summary is active so the user restarts first instead of
-            // hitting an install that cannot succeed yet.
-            if recovery.summary?.requiresRestart == true {
-                Label("Restart your Mac before installing", systemImage: "arrow.clockwise.circle.fill")
-                    .foregroundStyle(.secondary)
-            } else {
-                Button("Install Helper") { Task { await helper.install() } }
-            }
+            Button("Install Helper") { Task { await helper.install() } }
         case .requiresApproval:
             Button("Open Login Items") { SMAppService.openSystemSettingsLoginItems() }
         case .installedOutdated,
@@ -207,8 +191,6 @@ struct HelperSettingsView: View {
     private func resultSection(_ summary: ForceResetSummary) -> some View {
         let (symbol, tint): (String, Color) = if summary.succeeded {
             ("checkmark.seal.fill", .green)
-        } else if summary.requiresRestart {
-            ("arrow.clockwise.circle.fill", .blue)
         } else {
             ("exclamationmark.triangle.fill", .orange)
         }

--- a/TracexyTests/Core/Services/HelperForceResetTests.swift
+++ b/TracexyTests/Core/Services/HelperForceResetTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import ServiceManagement
 import Testing
 @testable import Tracexy
 
@@ -12,39 +13,76 @@ import Testing
 struct ForceRemoveScriptTests {
     // MARK: Internal
 
-    @Test("Removes the launchd job, process, helper binary, and launch daemon plist")
+    @Test("Boots out the launchd job and removes the helper binary and launch daemon plist")
     func removesEverything() {
-        let script = HelperClient.forceRemoveShellScript(identity: Self.identity, resetBackgroundItems: false)
+        let script = HelperClient.forceRemoveShellScript(identity: Self.identity)
 
         #expect(script.contains("/bin/launchctl bootout system/'com.example.helper'"))
         #expect(script.contains("/bin/rm -f '/Library/PrivilegedHelperTools/com.example.helper'"))
         #expect(script.contains("/bin/rm -f '/Library/LaunchDaemons/com.example.helper.plist'"))
     }
 
-    @Test("pkill uses the bracket form so it cannot match itself")
-    func bracketedPkill() {
-        let script = HelperClient.forceRemoveShellScript(identity: Self.identity, resetBackgroundItems: false)
-        #expect(script.contains("/usr/bin/pkill -f '[T]racexyCaptureHelper'"))
-        // The naive, self-matching form must not appear.
-        #expect(!script.contains("pkill -f 'TracexyCaptureHelper'"))
+    @Test("Terminates the job by its exact service label, ordered before bootout, with no broad pkill")
+    func killsByExactServiceLabel() {
+        let script = HelperClient.forceRemoveShellScript(identity: Self.identity)
+
+        // The job is killed by its exact `system/<label>` service target.
+        #expect(script.contains("/bin/launchctl kill SIGTERM system/'com.example.helper'"))
+
+        // The kill must run before the bootout so the process is signalled while its
+        // launchd job still exists.
+        let killRange = script.range(of: "launchctl kill SIGTERM system/'com.example.helper'")
+        let bootoutRange = script.range(of: "launchctl bootout system/'com.example.helper'")
+        #expect(killRange != nil)
+        #expect(bootoutRange != nil)
+        if let killRange, let bootoutRange {
+            #expect(killRange.lowerBound < bootoutRange.lowerBound)
+        }
+
+        // The broad, executable-name pkill — which a debug and a production helper
+        // share and which could kill a different app's helper — must be gone entirely.
+        #expect(!script.contains("pkill"))
+        #expect(!script.contains("TracexyCaptureHelper"))
     }
 
     @Test("Exit guards fail loudly if the job or files remain")
     func exitGuards() {
-        let script = HelperClient.forceRemoveShellScript(identity: Self.identity, resetBackgroundItems: false)
+        let script = HelperClient.forceRemoveShellScript(identity: Self.identity)
         #expect(script.contains("exit 20"))
         #expect(script.contains("exit 21"))
         #expect(script.contains("exit 22"))
     }
 
-    @Test("sfltool resetbtm is gated behind the flag")
-    func sfltoolGated() {
-        let without = HelperClient.forceRemoveShellScript(identity: Self.identity, resetBackgroundItems: false)
-        let with = HelperClient.forceRemoveShellScript(identity: Self.identity, resetBackgroundItems: true)
-        #expect(!without.contains("sfltool resetbtm"))
-        #expect(with.contains("/usr/bin/sfltool resetbtm"))
-        #expect(with.contains("exit 23"))
-        #expect(!with.contains("sfltool resetbtm 2>/dev/null || true"))
+    @Test("The privileged script never touches global Background Items")
+    func neverResetsBackgroundItems() {
+        // The v0.1.3 regression nested `sfltool resetbtm` inside an already-elevated
+        // osascript shell (exit 23 guard) after the helper was unregistered. The
+        // app-specific cleanup must never contain any of that machinery.
+        let script = HelperClient.forceRemoveShellScript(identity: Self.identity)
+        #expect(!script.contains("sfltool"))
+        #expect(!script.contains("resetbtm"))
+        #expect(!script.contains("exit 23"))
+    }
+
+    @Test("The completion message describes only what the script verified, not registration removal")
+    func completionMessageIsTruthful() {
+        let script = HelperClient.forceRemoveShellScript(identity: Self.identity)
+        // The script verifies the launchd job and legacy files are gone; it does NOT
+        // remove the SMAppService registration (that happens later, in Swift). Its
+        // completion echo must not claim registration files were removed.
+        #expect(script.contains("Tracexy helper launchd job and legacy files were cleared."))
+        #expect(!script.contains("registration files were removed"))
+    }
+
+    @Test("The manual Background Items command lives in the presenter, not Core/Services")
+    func manualCommandLivesInPresenter() {
+        // Presentation-only: this string is displayed/copied, never executed. It now
+        // lives on the presenter — the one place `sfltool resetbtm` may appear, and
+        // only as guidance text — never beside the privileged executor.
+        #expect(HelperRecoveryPresenter.manualBackgroundItemsResetCommand == "sudo /usr/bin/sfltool resetbtm")
+        // It must not be wired into the privileged script or any || true swallowing.
+        let script = HelperClient.forceRemoveShellScript(identity: Self.identity)
+        #expect(!script.contains(HelperRecoveryPresenter.manualBackgroundItemsResetCommand))
     }
 
     // MARK: Private
@@ -86,6 +124,30 @@ struct ForceRemoveErrorTests {
     }
 }
 
+// MARK: - PostCleanupRegistrationActionTests
+
+// The decision the reset takes for this app's SMAppService registration *after* the
+// privileged cleanup has removed the launchd job and files. Exercised as a pure
+// mapping from a real `SMAppService.Status`, so absent-registration semantics are
+// covered without registering or unregistering anything live.
+
+@Suite("Post-cleanup SMAppService registration decision")
+struct PostCleanupRegistrationActionTests {
+    @Test("A live registration is unregistered")
+    func liveRegistrationUnregisters() {
+        #expect(HelperClient.postCleanupRegistrationAction(for: .enabled) == .unregister)
+        #expect(HelperClient.postCleanupRegistrationAction(for: .requiresApproval) == .unregister)
+    }
+
+    @Test("An absent registration proceeds to reinstall without unregistering")
+    func absentRegistrationProceeds() {
+        // The crux: a missing registration is an acceptable end state and must not
+        // block the reinstall, so no unregister is attempted.
+        #expect(HelperClient.postCleanupRegistrationAction(for: .notRegistered) == .alreadyAbsent)
+        #expect(HelperClient.postCleanupRegistrationAction(for: .notFound) == .alreadyAbsent)
+    }
+}
+
 // MARK: - ForceResetSummaryTests
 
 @Suite("Force-reset result summary")
@@ -99,7 +161,7 @@ struct ForceResetSummaryTests {
         )
         #expect(summary.didReinstall)
         #expect(summary.succeeded)
-        #expect(!summary.suggestsBackgroundItemsReset)
+        #expect(!summary.suggestsManualBackgroundItemsGuidance)
         #expect(summary.details.contains("removed"))
         #expect(summary.details.localizedCaseInsensitiveContains("up to date"))
     }
@@ -110,58 +172,47 @@ struct ForceResetSummaryTests {
         #expect(summary.succeeded)
     }
 
-    @Test("Reinstall that lands unreachable is not success and suggests escalation")
+    @Test("Reinstall that lands unreachable is not success and suggests manual guidance")
     func reinstalledUnreachable() {
         let summary = ForceResetSummary(phase: .reinstalled, removalOutput: "", finalStatus: .unreachable)
         #expect(!summary.succeeded)
-        #expect(summary.suggestsBackgroundItemsReset)
+        #expect(summary.suggestsManualBackgroundItemsGuidance)
     }
 
     @Test("Reinstall that still reports an outdated helper is not success")
     func reinstalledOutdated() {
         let summary = ForceResetSummary(phase: .reinstalled, removalOutput: "", finalStatus: .installedOutdated)
         #expect(!summary.succeeded)
-        #expect(summary.suggestsBackgroundItemsReset)
+        #expect(summary.suggestsManualBackgroundItemsGuidance)
     }
 
-    @Test("A failed removal keeps escalation available and never reads as success")
+    @Test("A failed removal surfaces the re-probed final status and never reads as success")
     func removalFailed() {
+        // The re-probed status is authoritative. Because cleanup may have already
+        // removed files before a later step failed, the summary must NOT claim the
+        // state was left untouched — it reports what the re-probe actually found.
         let summary = ForceResetSummary(
             phase: .removalFailed,
-            removalOutput: "job still loaded",
-            finalStatus: .installedCompatible
+            removalOutput: "Removed the helper files, but couldn’t unregister the launchd service: boom",
+            finalStatus: .unreachable
         )
         #expect(!summary.didReinstall)
         #expect(!summary.succeeded)
-        #expect(summary.suggestsBackgroundItemsReset)
+        #expect(summary.suggestsManualBackgroundItemsGuidance)
         #expect(summary.title == "Force reset failed")
+        #expect(summary.details.localizedCaseInsensitiveContains("registered but unreachable"))
+        #expect(!summary.details.localizedCaseInsensitiveContains("untouched"))
     }
 
-    @Test("A cancelled removal is not a success and does not push escalation")
+    @Test("A cancelled removal is not a success and does not push manual guidance")
     func removalCancelled() {
         let summary = ForceResetSummary(phase: .removalCancelled, removalOutput: "cancelled", finalStatus: nil)
         #expect(!summary.succeeded)
-        #expect(!summary.suggestsBackgroundItemsReset)
+        #expect(!summary.suggestsManualBackgroundItemsGuidance)
         #expect(summary.title == "Force reset cancelled")
     }
 
-    @Test("A BTM reset requires a restart — never a success and never a reinstall")
-    func restartRequired() {
-        let summary = ForceResetSummary(
-            phase: .restartRequired,
-            removalOutput: "Removed the helper and reset macOS Background Items.",
-            finalStatus: .notInstalled
-        )
-        #expect(summary.requiresRestart)
-        #expect(!summary.didReinstall)
-        #expect(!summary.succeeded)
-        // Already the heaviest lever — do not loop back into another BTM reset.
-        #expect(!summary.suggestsBackgroundItemsReset)
-        #expect(summary.title.localizedCaseInsensitiveContains("restart"))
-        #expect(summary.details.localizedCaseInsensitiveContains("not installed"))
-    }
-
-    @Test("An overlapping lifecycle action does not trigger destructive escalation")
+    @Test("An overlapping lifecycle action does not trigger manual guidance")
     func operationInProgress() {
         let summary = ForceResetSummary(
             phase: .operationInProgress,
@@ -170,6 +221,6 @@ struct ForceResetSummaryTests {
         )
         #expect(!summary.didReinstall)
         #expect(!summary.succeeded)
-        #expect(!summary.suggestsBackgroundItemsReset)
+        #expect(!summary.suggestsManualBackgroundItemsGuidance)
     }
 }

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -26,10 +26,14 @@ instead of leaving the UI stuck. When the helper is unreachable, the first-line 
 Registration** — a non-destructive step that re-submits the registration from the current app bundle
 (no admin password) and then re-probes, which clears the launchd/Background-Items drift that can follow
 an in-place update. **Force Reset & Reinstall** is the next, confirmed recovery action for stale
-launchd/helper state, and the broader macOS Background Items reset is offered only as an explicitly
-confirmed last resort after normal recovery fails. Because that reset wipes Background Task Management,
-Tracexy does **not** reinstall immediately afterward: it asks you to restart your Mac, then install the
-helper again from Settings.
+launchd/helper state: it asks for an administrator password, removes only Tracexy's own privileged
+helper and launch daemon, and — only after that succeeds — unregisters and reinstalls the bundled
+helper before re-probing it, so the result always reflects the real final status. If the administrator
+prompt is cancelled, nothing is removed and no reinstall is attempted. If normal recovery still can't
+clear the helper, Tracexy shows last-resort guidance to reset macOS Login & Background Items yourself.
+Because that global reset affects Background Items for other apps too, Tracexy never runs it for you:
+it displays the exact command (`sudo /usr/bin/sfltool resetbtm`) with a Copy Command action, and you
+run it in Terminal, restart your Mac, then install the helper again from Settings.
 
 ## Opening saved captures
 


### PR DESCRIPTION
## Summary

- remove the automatic global Background Items reset from the privileged helper recovery flow
- preserve the existing service registration when authorization is cancelled and handle already-absent registrations safely
- terminate only the exact launchd service label and expose the global reset solely as copyable manual recovery guidance
- add regression coverage for command scope, lifecycle decisions, cancellation, and recovery summaries

## Root cause

The v0.1.3 force-reset path invoked `sfltool resetbtm` from an already elevated script after mutating helper state. `sfltool` requested a separate authorization interaction that could not be presented, returned `errAuthorizationInteractionNotAllowed`, and could leave the helper uninstalled.

## Validation

- `xcodebuild -project Tracexy.xcodeproj -scheme Tracexy -destination platform=macOS test`
- full unit and UI test suite passed, including all four UI tests
- `swiftformat --lint` passed for the changed Swift files
- `swiftlint lint --strict` passed with zero violations
- Developer ID Release archive/export and code-signing verification passed for the app and bundled helper
- production app identity, helper label, team identifier, and helper allowlist were verified

## Operational note

The automated validation does not mutate the currently installed privileged helper. A final install, force-reset, and reinstall exercise with a signed release build is recommended before publishing the next production update. The manual `sfltool resetbtm` fallback remains explicitly user-run because it affects Background Items for other applications.