### PR TITLE
feat(ui): complete native capture investigation workflow

### DIFF
--- a/Configuration/Versions.xcconfig
+++ b/Configuration/Versions.xcconfig
@@ -10,8 +10,11 @@
 TRACEXY_APP_VERSION = 0.1.4
 TRACEXY_APP_BUILD = 5
 
-TRACEXY_HELPER_VERSION = 0.1.2
-TRACEXY_HELPER_BUILD = 3
-// Protocol v2: typed NSSecureCoding frame/batch drain surface (was v1's [Data]).
-// A v1 helper is classified installedIncompatible and Start is gated — no fallback.
-TRACEXY_HELPER_PROTOCOL_VERSION = 2
+TRACEXY_HELPER_VERSION = 0.1.3
+TRACEXY_HELPER_BUILD = 4
+// Protocol v3: typed NSSecureCoding CaptureConfiguration start surface (interface,
+// snap length, promiscuous, optional BPF) replaced v2's bare interface string.
+// v2 kept the typed frame/batch drain surface (was v1's [Data]). Any helper below
+// v3 is classified installedIncompatible and Start is gated — no fallback, so an
+// old helper must be reinstalled (uninstall → rebuild → reinstall).
+TRACEXY_HELPER_PROTOCOL_VERSION = 3

--- a/Shared/CaptureFrameTransport.swift
+++ b/Shared/CaptureFrameTransport.swift
@@ -196,6 +196,153 @@ nonisolated struct HelperCaptureStats: Sendable, Equatable {
     var droppedByInterface: UInt32
 }
 
+// MARK: - CaptureConfigurationError
+
+/// Why an immutable capture configuration was rejected. Carries a user-facing
+/// `message` so the app can surface *why* a capture never started, and the helper
+/// can fail the start reply with the same explanation.
+nonisolated enum CaptureConfigurationError: Error, Equatable {
+    case emptyInterface
+    case interfaceTooLong
+    case bpfTooLong
+
+    // MARK: Internal
+
+    var message: String {
+        switch self {
+        case .emptyInterface:
+            "no capture interface was specified."
+        case .interfaceTooLong:
+            "the capture interface name is too long."
+        case .bpfTooLong:
+            "the BPF filter expression is too long."
+        }
+    }
+}
+
+// MARK: - CaptureConfiguration
+
+/// The immutable capture parameters ferried across the app↔helper XPC boundary as
+/// a typed, `NSSecureCoding` object: the interface to open, the snap length, the
+/// promiscuous flag, and an optional BPF filter expression.
+///
+/// This is the *only* privileged command surface — a fixed, validated description
+/// of a capture, never an arbitrary command. Both the app (before it asks the
+/// helper to start) and the helper (before it opens libpcap) run the same
+/// ``validated()`` so bounds are enforced on both sides: the snap length is
+/// clamped into a supported range, the interface must be present and reasonable,
+/// and an over-long BPF expression is rejected with a clear message. Syntactic BPF
+/// validation happens against libpcap at open time — a bad expression fails the
+/// start *before* any capture is reported running.
+///
+/// Decoding is deliberately total: `init(coder:)` never traps. Whatever crosses
+/// the wire is validated by ``validated()`` on receipt, so a malformed message is
+/// rejected truthfully rather than trusted.
+@objc(TracexyCaptureConfiguration)
+nonisolated final class CaptureConfiguration: NSObject, NSSecureCoding, @unchecked Sendable {
+    // MARK: Lifecycle
+
+    init(interface: String, snapLength: Int, promiscuous: Bool, bpf: String?) {
+        self.interface = interface
+        self.snapLength = snapLength
+        self.promiscuous = promiscuous
+        self.bpf = bpf
+    }
+
+    required init?(coder: NSCoder) {
+        interface = (coder.decodeObject(of: NSString.self, forKey: Key.interface) as String?) ?? ""
+        // A snap length written as Int64; a nonsensical value is caught by `validated()`.
+        snapLength = Int(coder.decodeInt64(forKey: Key.snapLength))
+        promiscuous = coder.decodeBool(forKey: Key.promiscuous)
+        // A missing/empty BPF string decodes to `nil` — no filter.
+        let decodedBPF = coder.decodeObject(of: NSString.self, forKey: Key.bpf) as String?
+        bpf = (decodedBPF?.isEmpty ?? true) ? nil : decodedBPF
+    }
+
+    // MARK: Internal
+
+    /// Supported snap-length range. The floor keeps enough of a frame for L2–L4
+    /// headers; the ceiling matches the largest preset the UI offers and is well
+    /// above any real frame, so a larger persisted value is clamped rather than
+    /// trusted into an oversized buffer.
+    static let snapLengthRange: ClosedRange<Int> = 64 ... 262_144
+    /// Full-frame default used when a persisted snap length is missing or unusable.
+    static let defaultSnapLength = 65_536
+    /// Upper bound on a BPF expression's length. A real filter is short; anything
+    /// longer is rejected rather than handed to `pcap_compile`.
+    static let maxBPFLength = 1_024
+    /// Upper bound on an interface name's length (BSD names are a handful of chars).
+    static let maxInterfaceLength = 128
+
+    static var supportsSecureCoding: Bool {
+        true
+    }
+
+    let interface: String
+    let snapLength: Int
+    let promiscuous: Bool
+    /// Trimmed BPF expression, or `nil` for "capture everything". Never an empty
+    /// string — an empty filter is normalized to `nil` so it is unambiguous.
+    let bpf: String?
+
+    /// Clamp a raw snap length into the supported range. A non-positive value is
+    /// treated as unset and becomes the full-frame default; anything else is
+    /// clamped to the nearest supported bound.
+    static func clampedSnapLength(_ raw: Int) -> Int {
+        guard raw > 0 else {
+            return defaultSnapLength
+        }
+        return min(max(raw, snapLengthRange.lowerBound), snapLengthRange.upperBound)
+    }
+
+    /// Validate and normalize. Returns a copy with a clamped snap length and a
+    /// trimmed/normalized BPF, or the reason it was rejected. Never traps.
+    func validated() -> Result<CaptureConfiguration, CaptureConfigurationError> {
+        let trimmedInterface = interface.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedInterface.isEmpty else {
+            return .failure(.emptyInterface)
+        }
+        guard trimmedInterface.count <= Self.maxInterfaceLength else {
+            return .failure(.interfaceTooLong)
+        }
+        var normalizedBPF: String?
+        if let bpf {
+            let trimmed = bpf.trimmingCharacters(in: .whitespacesAndNewlines)
+            if trimmed.isEmpty {
+                normalizedBPF = nil
+            } else if trimmed.count > Self.maxBPFLength {
+                return .failure(.bpfTooLong)
+            } else {
+                normalizedBPF = trimmed
+            }
+        }
+        return .success(CaptureConfiguration(
+            interface: trimmedInterface,
+            snapLength: Self.clampedSnapLength(snapLength),
+            promiscuous: promiscuous,
+            bpf: normalizedBPF
+        ))
+    }
+
+    func encode(with coder: NSCoder) {
+        coder.encode(interface as NSString, forKey: Key.interface)
+        coder.encode(Int64(snapLength), forKey: Key.snapLength)
+        coder.encode(promiscuous, forKey: Key.promiscuous)
+        if let bpf {
+            coder.encode(bpf as NSString, forKey: Key.bpf)
+        }
+    }
+
+    // MARK: Private
+
+    private enum Key {
+        static let interface = "if"
+        static let snapLength = "sl"
+        static let promiscuous = "pr"
+        static let bpf = "bpf"
+    }
+}
+
 // MARK: - TracexyHelperInterface
 
 /// Builds the `NSXPCInterface` for `TracexyHelperProtocol` with the secure-coding
@@ -225,6 +372,17 @@ nonisolated enum TracexyHelperInterface {
                 for: #selector(TracexyHelperProtocol.stopCapture(withReply:)),
                 argumentIndex: 0,
                 ofReply: true
+            )
+        }
+        // The immutable capture configuration is the one typed object the app
+        // *sends* to the helper, so its allow-list is set on the request argument
+        // (`ofReply: false`) rather than a reply.
+        if let allowedConfig = NSSet(array: [CaptureConfiguration.self, NSString.self]) as? Set<AnyHashable> {
+            interface.setClasses(
+                allowedConfig,
+                for: #selector(TracexyHelperProtocol.startCapture(configuration:withReply:)),
+                argumentIndex: 0,
+                ofReply: false
             )
         }
         return interface

--- a/Shared/TracexyHelperProtocol.swift
+++ b/Shared/TracexyHelperProtocol.swift
@@ -7,8 +7,17 @@ protocol TracexyHelperProtocol {
     /// Helper binary version, build number, protocol version.
     func getHelperInfo(withReply reply: @escaping (String, Int, Int) -> Void)
 
-    /// Begin capturing on `interface`. Reply: (started, errorMessage).
-    func startCapture(interface: String, withReply reply: @escaping (Bool, String) -> Void)
+    /// Begin capturing with a typed, validated `configuration` (interface, snap
+    /// length, promiscuous mode, optional BPF). Reply: (started, errorMessage).
+    ///
+    /// The helper re-validates the configuration and compiles any BPF against
+    /// libpcap *before* replying, so an out-of-bounds value or a bad filter
+    /// expression fails closed with a clear message and no capture is reported
+    /// started. This is protocol v3 — the immutable `CaptureConfiguration` command
+    /// surface replaced v2's bare `interface: String`. The app fails closed against
+    /// an older helper (`getHelperInfo` classifies the protocol mismatch) rather
+    /// than downgrading the start request.
+    func startCapture(configuration: CaptureConfiguration, withReply reply: @escaping (Bool, String) -> Void)
 
     /// Stop the active capture and return the worker's final flushed batch plus
     /// final accounting. Returning this atomically avoids a stop→fetch race with

--- a/Tracexy/Core/Capture/CaptureActivity.swift
+++ b/Tracexy/Core/Capture/CaptureActivity.swift
@@ -1,0 +1,129 @@
+import Foundation
+
+// MARK: - CaptureActivityBucket
+
+/// One column of the Overview's "frames over capture time" chart: a bounded slice
+/// of capture time carrying how many frames and on-wire bytes landed in it. Only
+/// aggregate counts cross this seam — never the captured packet bytes themselves.
+nonisolated struct CaptureActivityBucket: Identifiable, Equatable {
+    /// Position of this bucket in the ordered sequence (`0` is the earliest).
+    let index: Int
+    /// Seconds from the first captured frame to the start of this bucket.
+    let startOffset: TimeInterval
+    let frameCount: Int
+    let byteCount: Int
+
+    var id: Int {
+        index
+    }
+}
+
+// MARK: - CaptureActivity
+
+/// A bounded, deterministic aggregation of a capture's frames over time, derived
+/// from real frame timestamps and on-wire lengths. Built once at the open/import
+/// boundary (see ``MainContentCoordinator.savedCaptureActivity``) so the Overview
+/// chart never re-scans frames on each SwiftUI body update, and never receives
+/// packet payloads — only these per-bucket totals.
+nonisolated struct CaptureActivity: Equatable {
+    /// Ordered time buckets, earliest first. Empty only for an empty capture.
+    let buckets: [CaptureActivityBucket]
+    /// Wall-clock span from the first to the last captured frame, in seconds.
+    let duration: TimeInterval
+    let totalFrames: Int
+    let totalBytes: Int
+    /// Width of each bucket in seconds (`0` for an empty or single-instant capture).
+    let bucketWidth: TimeInterval
+
+    var isEmpty: Bool {
+        buckets.isEmpty
+    }
+
+    /// The largest per-bucket frame count, for normalizing bar heights. `0` when
+    /// empty, so callers can guard division without a special case.
+    var peakFrameCount: Int {
+        buckets.map(\.frameCount).max() ?? 0
+    }
+}
+
+// MARK: - CaptureActivityBuilder
+
+/// Pure aggregator that folds captured frames into a bounded set of time buckets.
+///
+/// Deterministic and total: it handles the empty capture, a single frame (or many
+/// frames sharing one instant), and a normal multi-frame span without ever
+/// dividing by zero or producing more buckets than the cap. The bucket count is
+/// `min(cap, frameCount)`, so a tiny capture is not padded with empty columns and
+/// a huge one is bounded to `cap` regardless of size.
+nonisolated enum CaptureActivityBuilder {
+    /// Upper bound on bucket count. Small enough to read as a compact bar strip,
+    /// large enough to show shape; the visualization stays bounded on any capture.
+    static let defaultBucketCap = 24
+
+    static func build(frames: [CapturedFrame], maxBuckets: Int = defaultBucketCap) -> CaptureActivity {
+        let cap = max(1, maxBuckets)
+        guard let firstFrame = frames.first else {
+            return CaptureActivity(buckets: [], duration: 0, totalFrames: 0, totalBytes: 0, bucketWidth: 0)
+        }
+
+        var minTime = firstFrame.timestamp
+        var maxTime = firstFrame.timestamp
+        var totalBytes = 0
+        for frame in frames {
+            if frame.timestamp < minTime {
+                minTime = frame.timestamp
+            }
+            if frame.timestamp > maxTime {
+                maxTime = frame.timestamp
+            }
+            totalBytes += frame.originalLength
+        }
+
+        let frameCount = frames.count
+        let span = max(0, maxTime.timeIntervalSince(minTime))
+
+        // A single frame, or many frames sharing one instant: no span to divide,
+        // so everything collapses into one truthful bucket rather than trapping.
+        guard span > 0 else {
+            let bucket = CaptureActivityBucket(
+                index: 0, startOffset: 0, frameCount: frameCount, byteCount: totalBytes
+            )
+            return CaptureActivity(
+                buckets: [bucket], duration: 0, totalFrames: frameCount, totalBytes: totalBytes, bucketWidth: 0
+            )
+        }
+
+        // `span > 0` implies at least two distinct timestamps, so `frameCount >= 2`
+        // and `bucketCount >= 1`; `width` is therefore strictly positive.
+        let bucketCount = min(cap, frameCount)
+        let width = span / Double(bucketCount)
+        var frameCounts = [Int](repeating: 0, count: bucketCount)
+        var byteCounts = [Int](repeating: 0, count: bucketCount)
+        for frame in frames {
+            let offset = frame.timestamp.timeIntervalSince(minTime)
+            var index = Int(offset / width)
+            // The final frame lands exactly on the trailing edge; clamp it into the
+            // last bucket rather than spilling past the array.
+            if index >= bucketCount {
+                index = bucketCount - 1
+            }
+            if index < 0 {
+                index = 0
+            }
+            frameCounts[index] += 1
+            byteCounts[index] += frame.originalLength
+        }
+
+        let buckets = (0 ..< bucketCount).map { index in
+            CaptureActivityBucket(
+                index: index,
+                startOffset: Double(index) * width,
+                frameCount: frameCounts[index],
+                byteCount: byteCounts[index]
+            )
+        }
+        return CaptureActivity(
+            buckets: buckets, duration: span, totalFrames: frameCount, totalBytes: totalBytes, bucketWidth: width
+        )
+    }
+}

--- a/Tracexy/Core/Capture/CaptureImporter.swift
+++ b/Tracexy/Core/Capture/CaptureImporter.swift
@@ -1,0 +1,87 @@
+import Foundation
+
+/// Lossless, idempotent import of an external capture file into the app's
+/// managed Captures directory.
+///
+/// Two invariants make this safe against the "import ate the source" failure
+/// mode:
+///
+///  * **Same-file short-circuit.** If the source already *is* the computed
+///    managed destination (equivalent path, symlink, or same on-disk identity),
+///    nothing is removed or copied — the file is simply reported back so the
+///    caller can refresh and reopen it in place.
+///  * **Copy-to-temp then atomic replace.** When a genuinely external source
+///    collides with an existing managed file of the same name, the source is
+///    copied to a temporary sibling first and only swapped in with an atomic
+///    replace once that copy has fully succeeded. A failure removes just the
+///    temporary artifact and leaves both the source and the pre-existing
+///    destination untouched.
+nonisolated enum CaptureImporter {
+    // MARK: Internal
+
+    /// Imports `source` into `directory`, returning the managed file URL.
+    ///
+    /// - Returns: the destination URL inside `directory`. On the same-file path
+    ///   this is the source's own location; otherwise it is
+    ///   `directory/<source filename>`.
+    /// - Throws: any `FileManager` error from the copy/replace. On throw, the
+    ///   source and any pre-existing destination are left intact and only the
+    ///   temporary artifact (if one was created) is removed.
+    @discardableResult
+    static func importCapture(from source: URL, intoDirectory directory: URL) throws -> URL {
+        let destination = directory.appendingPathComponent(source.lastPathComponent)
+
+        // Already the managed file: never mutate it. This is the case that
+        // previously removed the destination and then failed the copy with
+        // ENOENT, destroying the only copy of the capture.
+        if isSameFile(source, destination) {
+            return destination
+        }
+
+        let fileManager = FileManager.default
+
+        // No collision: a plain copy is already lossless — the source stays put
+        // and nothing pre-existing can be overwritten.
+        guard fileManager.fileExists(atPath: destination.path) else {
+            try fileManager.copyItem(at: source, to: destination)
+            return destination
+        }
+
+        // Collision with a different existing managed file. Stage the copy in a
+        // temporary sibling so the existing file is only replaced once the copy
+        // is complete; on any failure the existing file survives.
+        let temporary = directory.appendingPathComponent(
+            ".\(source.lastPathComponent).import-\(UUID().uuidString).tmp"
+        )
+        do {
+            try fileManager.copyItem(at: source, to: temporary)
+            _ = try fileManager.replaceItemAt(destination, withItemAt: temporary)
+        } catch {
+            try? fileManager.removeItem(at: temporary)
+            throw error
+        }
+        return destination
+    }
+
+    // MARK: Private
+
+    /// Whether two URLs point at the same underlying file. Compares resolved,
+    /// standardized paths first (covers identical and symlinked paths), then
+    /// falls back to on-disk file identity so hardlinks or otherwise-equivalent
+    /// paths still count as the same file.
+    private static func isSameFile(_ lhs: URL, _ rhs: URL) -> Bool {
+        let resolvedLhs = lhs.resolvingSymlinksInPath().standardizedFileURL
+        let resolvedRhs = rhs.resolvingSymlinksInPath().standardizedFileURL
+        if resolvedLhs == resolvedRhs {
+            return true
+        }
+        guard let idLhs = fileIdentifier(lhs), let idRhs = fileIdentifier(rhs) else {
+            return false
+        }
+        return idLhs.isEqual(idRhs)
+    }
+
+    private static func fileIdentifier(_ url: URL) -> (any NSObjectProtocol)? {
+        (try? url.resourceValues(forKeys: [.fileResourceIdentifierKey]))?.fileResourceIdentifier
+    }
+}

--- a/Tracexy/Core/Capture/LiveCapture.swift
+++ b/Tracexy/Core/Capture/LiveCapture.swift
@@ -15,6 +15,12 @@ nonisolated final class LiveCapture: @unchecked Sendable {
         // Optional: `pcap_stats` is unsupported on some sources (notably when
         // reading a savefile), so a missing symbol must not fail the capture.
         stats = try? LiveCapture.symbol(library, "pcap_stats", as: StatsFn.self)
+        // Optional: only needed when a BPF filter is configured. A no-filter
+        // capture never fails on these; a requested filter with them missing does.
+        compileFilter = try? LiveCapture.symbol(library, "pcap_compile", as: CompileFn.self)
+        setFilter = try? LiveCapture.symbol(library, "pcap_setfilter", as: SetFilterFn.self)
+        freeCode = try? LiveCapture.symbol(library, "pcap_freecode", as: FreeCodeFn.self)
+        getError = try? LiveCapture.symbol(library, "pcap_geterr", as: GetErrFn.self)
     }
 
     // MARK: Internal
@@ -28,22 +34,47 @@ nonisolated final class LiveCapture: @unchecked Sendable {
         var len: UInt32
     }
 
-    /// Start capturing on `interface`. `onBatch` and `onError` fire on a
-    /// background thread; the caller hops to the main actor.
+    /// Start capturing with a validated `configuration` (interface, snap length,
+    /// promiscuous mode, optional BPF). `onBatch` fires on a background thread; the
+    /// caller hops to the main actor.
+    ///
+    /// Opening the handle and compiling any BPF happen synchronously: this throws
+    /// on an out-of-bounds value, an interface that can't be opened, or a bad
+    /// filter, so the caller never reports a started capture that isn't running or
+    /// silently dropped its filter. On success it returns the interface's real
+    /// link type before the worker starts.
+    @discardableResult
     func start(
-        interface: String,
+        configuration: CaptureConfiguration,
         onBatch: @escaping @Sendable ([CapturedFrame], UInt32) -> Void,
-        onError: @escaping @Sendable (String) -> Void,
         onStatistics: (@Sendable (CaptureStatistics) -> Void)? = nil
-    ) {
+    )
+        throws -> UInt32
+    {
         stop()
+        let config: CaptureConfiguration
+        switch configuration.validated() {
+        case let .success(normalized):
+            config = normalized
+        case let .failure(error):
+            throw Failure(message: error.message)
+        }
         var errbuf = [CChar](repeating: 0, count: 256)
-        let handle = interface.withCString { name in
-            openLive(name, 65_536, 1, 100, &errbuf)
+        let snaplen = Int32(config.snapLength)
+        let promisc: Int32 = config.promiscuous ? 1 : 0
+        let handle = config.interface.withCString { name in
+            openLive(name, snaplen, promisc, 100, &errbuf)
         }
         guard let handle else {
-            onError(String(cString: errbuf))
-            return
+            throw Failure(message: String(cString: errbuf))
+        }
+        if let expression = config.bpf {
+            do {
+                try applyFilter(expression, handle: handle)
+            } catch {
+                closeHandle(handle)
+                throw error
+            }
         }
         self.handle = handle
         let linkType = UInt32(bitPattern: dataLink(handle))
@@ -64,6 +95,7 @@ nonisolated final class LiveCapture: @unchecked Sendable {
         worker.stackSize = 1 << 20
         thread = worker
         worker.start()
+        return linkType
     }
 
     /// Stops capture and blocks until the worker thread has left `pcap_next_ex`
@@ -101,6 +133,17 @@ nonisolated final class LiveCapture: @unchecked Sendable {
     private typealias CloseFn = @convention(c) (OpaquePointer?) -> Void
     private typealias DataLinkFn = @convention(c) (OpaquePointer?) -> Int32
     private typealias StatsFn = @convention(c) (OpaquePointer?, UnsafeMutableRawPointer?) -> Int32
+    /// `int pcap_compile(pcap_t*, struct bpf_program*, const char*, int optimize, bpf_u_int32 netmask)`.
+    private typealias CompileFn = @convention(c) (
+        OpaquePointer?, UnsafeMutableRawPointer?, UnsafePointer<CChar>?, Int32, UInt32
+    )
+        -> Int32
+    /// `int pcap_setfilter(pcap_t*, struct bpf_program*)`.
+    private typealias SetFilterFn = @convention(c) (OpaquePointer?, UnsafeMutableRawPointer?) -> Int32
+    /// `void pcap_freecode(struct bpf_program*)`.
+    private typealias FreeCodeFn = @convention(c) (UnsafeMutableRawPointer?) -> Void
+    /// `char *pcap_geterr(pcap_t*)`.
+    private typealias GetErrFn = @convention(c) (OpaquePointer?) -> UnsafePointer<CChar>?
 
     private let library: UnsafeMutableRawPointer
     private let openLive: OpenLiveFn
@@ -108,6 +151,10 @@ nonisolated final class LiveCapture: @unchecked Sendable {
     private let closeHandle: CloseFn
     private let dataLink: DataLinkFn
     private let stats: StatsFn?
+    private let compileFilter: CompileFn?
+    private let setFilter: SetFilterFn?
+    private let freeCode: FreeCodeFn?
+    private let getError: GetErrFn?
 
     private var handle: OpaquePointer?
     private var thread: Thread?
@@ -121,6 +168,44 @@ nonisolated final class LiveCapture: @unchecked Sendable {
             throw Failure(message: "missing symbol \(name)")
         }
         return unsafeBitCast(pointer, to: T.self)
+    }
+
+    /// Compile and install a BPF filter on an open handle, freeing the compiled
+    /// program on every path. Throws with libpcap's own error text (via
+    /// `pcap_geterr`) so a bad expression surfaces the real reason.
+    private func applyFilter(_ expression: String, handle: OpaquePointer) throws {
+        guard let compileFilter, let setFilter, let freeCode else {
+            throw Failure(message: "BPF filtering is unavailable on this system.")
+        }
+        // `struct bpf_program { u_int bf_len; struct bpf_insn *bf_insns; }` is 16
+        // bytes on LP64. Zero it so a failed compile leaves nothing to free.
+        let programSize = 16
+        let program = UnsafeMutableRawPointer.allocate(byteCount: programSize, alignment: 8)
+        program.initializeMemory(as: UInt8.self, repeating: 0, count: programSize)
+        defer { program.deallocate() }
+        let netmaskUnknown: UInt32 = 0xFFFFFFFF
+        let compiled = expression.withCString { cstr in
+            compileFilter(handle, program, cstr, 1, netmaskUnknown)
+        }
+        guard compiled == 0 else {
+            throw Failure(message: filterErrorMessage(handle: handle, fallback: "invalid BPF filter expression."))
+        }
+        // Once compiled, free the program regardless of how setfilter goes — the
+        // kernel/handle keeps its own copy after a successful install.
+        defer { freeCode(program) }
+        guard setFilter(handle, program) == 0 else {
+            throw Failure(message: filterErrorMessage(handle: handle, fallback: "could not apply the BPF filter."))
+        }
+    }
+
+    private func filterErrorMessage(handle: OpaquePointer, fallback: String) -> String {
+        if let getError, let cstr = getError(handle) {
+            let message = String(cString: cstr)
+            if !message.isEmpty {
+                return message
+            }
+        }
+        return fallback
     }
 
     /// Sampled by the worker thread itself. `pcap_stats` needs the same handle

--- a/Tracexy/Core/Capture/LiveCaptureSpool.swift
+++ b/Tracexy/Core/Capture/LiveCaptureSpool.swift
@@ -1,0 +1,197 @@
+import Foundation
+
+/// Disk-backed, append-only pcapng spool for the current live capture.
+///
+/// The UI keeps only a bounded frame window in memory, while this actor preserves
+/// every accepted frame for complete save/session export. All file IO is actor-
+/// isolated and therefore stays off `@MainActor`. The spool is local, temporary,
+/// and replaced only at an explicit capture boundary.
+actor LiveCaptureSpool {
+    // MARK: Lifecycle
+
+    init(directoryName: String) {
+        let base = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first
+            ?? FileManager.default.temporaryDirectory
+        directory = base
+            .appendingPathComponent(directoryName, isDirectory: true)
+            .appendingPathComponent("LiveCaptureSpool", isDirectory: true)
+    }
+
+    deinit {
+        try? handle?.close()
+    }
+
+    // MARK: Internal
+
+    enum Failure: Error, LocalizedError {
+        case unavailable(String)
+        case empty
+
+        // MARK: Internal
+
+        var errorDescription: String? {
+            switch self {
+            case let .unavailable(message): message
+            case .empty: "The live capture spool has no frames."
+            }
+        }
+    }
+
+    func reset(epoch: Int) throws {
+        try handle?.close()
+        handle = nil
+        if let url {
+            try? FileManager.default.removeItem(at: url)
+        }
+        self.epoch = epoch
+        url = nil
+        interfaceIDs.removeAll(keepingCapacity: false)
+        frameCount = 0
+        failure = nil
+        do {
+            try prepareFile()
+        } catch {
+            failure = error.localizedDescription
+            throw error
+        }
+    }
+
+    func append(_ frames: [CapturedFrame], defaultLinkType: UInt32, epoch: Int) throws {
+        guard epoch == self.epoch, !frames.isEmpty else {
+            return
+        }
+        guard failure == nil, let handle else {
+            throw Failure.unavailable(failure ?? "The local capture spool is unavailable.")
+        }
+        do {
+            for frame in frames {
+                let linkType = frame.linkType ?? defaultLinkType
+                let interfaceID: UInt32
+                if let existing = interfaceIDs[linkType] {
+                    interfaceID = existing
+                } else {
+                    guard linkType <= UInt32(UInt16.max) else {
+                        throw Failure.unavailable("Capture link type \(linkType) cannot be written to pcapng.")
+                    }
+                    interfaceID = UInt32(interfaceIDs.count)
+                    try handle.write(contentsOf: Self.interfaceDescriptionBlock(linkType: linkType))
+                    interfaceIDs[linkType] = interfaceID
+                }
+                try handle.write(contentsOf: Self.enhancedPacketBlock(frame: frame, interfaceID: interfaceID))
+                frameCount += 1
+            }
+        } catch {
+            let message = error.localizedDescription
+            failure = message
+            throw Failure.unavailable(message)
+        }
+    }
+
+    func capture() throws -> (linkType: UInt32, frames: [CapturedFrame]) {
+        guard frameCount > 0, let url else {
+            throw Failure.empty
+        }
+        try handle?.synchronize()
+        return try CaptureFileReader.read(contentsOf: url)
+    }
+
+    func copy(to destination: URL) throws {
+        guard frameCount > 0, let url else {
+            throw Failure.empty
+        }
+        try handle?.synchronize()
+        try FileManager.default.copyItem(at: url, to: destination)
+    }
+
+    /// Non-nil means the file is a valid recoverable prefix, not a complete
+    /// capture. Callers keep this warning visible after an explicit save/export.
+    func incompletenessReason() -> String? {
+        failure
+    }
+
+    // MARK: Private
+
+    private let directory: URL
+    private var epoch = -1
+    private var url: URL?
+    private var handle: FileHandle?
+    private var interfaceIDs: [UInt32: UInt32] = [:]
+    private var frameCount = 0
+    private var failure: String?
+
+    private static func sectionHeaderBlock() -> Data {
+        block(type: 0x0A0D0D0A) { body in
+            append32(0x1A2B3C4D, to: &body)
+            append16(1, to: &body)
+            append16(0, to: &body)
+            append64(UInt64.max, to: &body)
+        }
+    }
+
+    private static func interfaceDescriptionBlock(linkType: UInt32) -> Data {
+        block(type: 0x00000001) { body in
+            append16(UInt16(linkType), to: &body)
+            append16(0, to: &body)
+            append32(PcapWriter.snapLength, to: &body)
+        }
+    }
+
+    private static func enhancedPacketBlock(frame: CapturedFrame, interfaceID: UInt32) -> Data {
+        block(type: 0x00000006) { body in
+            let microseconds = timestampMicroseconds(frame.timestamp)
+            append32(interfaceID, to: &body)
+            append32(UInt32(microseconds >> 32), to: &body)
+            append32(UInt32(microseconds & UInt64(UInt32.max)), to: &body)
+            append32(UInt32(frame.bytes.count), to: &body)
+            append32(UInt32(max(frame.originalLength, frame.bytes.count)), to: &body)
+            body.append(contentsOf: frame.bytes)
+        }
+    }
+
+    private static func block(type: UInt32, body build: (inout Data) -> Void) -> Data {
+        var body = Data()
+        build(&body)
+        while body.count % 4 != 0 {
+            body.append(0)
+        }
+        var data = Data()
+        let totalLength = UInt32(12 + body.count)
+        append32(type, to: &data)
+        append32(totalLength, to: &data)
+        data.append(body)
+        append32(totalLength, to: &data)
+        return data
+    }
+
+    private static func timestampMicroseconds(_ date: Date) -> UInt64 {
+        let interval = max(0, date.timeIntervalSince1970)
+        return UInt64(min((interval * 1_000_000).rounded(), Double(UInt64.max)))
+    }
+
+    private static func append16(_ value: UInt16, to data: inout Data) {
+        var little = value.littleEndian
+        withUnsafeBytes(of: &little) { data.append(contentsOf: $0) }
+    }
+
+    private static func append32(_ value: UInt32, to data: inout Data) {
+        var little = value.littleEndian
+        withUnsafeBytes(of: &little) { data.append(contentsOf: $0) }
+    }
+
+    private static func append64(_ value: UInt64, to data: inout Data) {
+        var little = value.littleEndian
+        withUnsafeBytes(of: &little) { data.append(contentsOf: $0) }
+    }
+
+    private func prepareFile() throws {
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let nextURL = directory.appendingPathComponent("capture-\(UUID().uuidString).pcapng")
+        guard FileManager.default.createFile(atPath: nextURL.path, contents: nil) else {
+            throw Failure.unavailable("Couldn’t create the local capture spool.")
+        }
+        let nextHandle = try FileHandle(forWritingTo: nextURL)
+        try nextHandle.write(contentsOf: Self.sectionHeaderBlock())
+        url = nextURL
+        handle = nextHandle
+    }
+}

--- a/Tracexy/Core/Capture/RetainedFrameBuffer.swift
+++ b/Tracexy/Core/Capture/RetainedFrameBuffer.swift
@@ -32,6 +32,13 @@ nonisolated struct RetainedFrameBuffer {
     /// never make the truncation *look smaller* than it was.
     private(set) var evictionCount: UInt64 = 0
 
+    /// Sum of the captured (on-disk) lengths of the frames currently retained.
+    /// Maintained incrementally on append/evict/replace so the Overview can show a
+    /// truthful "estimated save size" without re-summing the window on every UI
+    /// refresh. Tracks captured length — the bytes a `.pcap`/`.pcapng` save writes
+    /// — not the original on-wire length.
+    private(set) var capturedByteCount: Int = 0
+
     /// The most frames retained at once.
     let capacity: Int
 
@@ -50,8 +57,10 @@ nonisolated struct RetainedFrameBuffer {
             return
         }
         frames.append(contentsOf: newFrames)
+        capturedByteCount += newFrames.reduce(0) { $0 + $1.capturedLength }
         if frames.count > capacity {
             let overflow = frames.count - capacity
+            capturedByteCount -= frames.prefix(overflow).reduce(0) { $0 + $1.capturedLength }
             frames.removeFirst(overflow)
             let (sum, overflowed) = evictionCount.addingReportingOverflow(UInt64(overflow))
             evictionCount = overflowed ? UInt64.max : sum
@@ -65,6 +74,7 @@ nonisolated struct RetainedFrameBuffer {
     mutating func replace(with newFrames: [CapturedFrame]) {
         frames = newFrames
         evictionCount = 0
+        capturedByteCount = newFrames.reduce(0) { $0 + $1.capturedLength }
     }
 
     /// Clears both retained frames and the cumulative eviction count. Called at
@@ -72,5 +82,6 @@ nonisolated struct RetainedFrameBuffer {
     mutating func reset() {
         frames.removeAll(keepingCapacity: false)
         evictionCount = 0
+        capturedByteCount = 0
     }
 }

--- a/Tracexy/Core/Capture/SampleCapture.swift
+++ b/Tracexy/Core/Capture/SampleCapture.swift
@@ -91,11 +91,17 @@ nonisolated enum SampleCapture {
             payload: PacketBuilder.udp(
                 srcPort: 54_321,
                 dstPort: 443,
-                payload: [0xC3, 0x00, 0x00, 0x00, 0x01, 0x08]
+                payload: [
+                    0xC0, 0x00, 0x00, 0x00, 0x01,
+                    0x08, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+                    0x04, 0xAA, 0xBB, 0xCC, 0xDD, 0x00,
+                ]
             )
         ))
 
-        // Incomplete handshake — SYN with no response (warning).
+        // A bare SYN with no response. It stays a visible, ordinary session:
+        // an unanswered handshake is not observed evidence of a problem, so no
+        // warning is fabricated from the absence of later packets.
         push(PacketBuilder.tcpSynFrame(src: client, dst: "203.0.113.9", srcPort: 51_000, dstPort: 443))
 
         return frames

--- a/Tracexy/Core/Protocol/DecodedPacket.swift
+++ b/Tracexy/Core/Protocol/DecodedPacket.swift
@@ -116,9 +116,15 @@ nonisolated struct DecodedPacket {
     var dnsAnswers: [String]
     var sourceEndpoint: IPEndpoint?
     var destinationEndpoint: IPEndpoint?
+    /// Sequence number of the first TCP payload byte and its captured bytes.
+    /// Session accumulation uses this bounded handoff for metadata-only stream
+    /// reassembly; packet decoding itself remains stateless.
+    var tcpPayloadSequence: UInt32?
+    var tcpPayloadBytes: [UInt8] = []
 
     /// Protocol stack outer→inner, e.g. [.tcp, .tls]. Used by the session list.
     var protocolStack: [ProtocolKind] {
-        layers.map(\.proto).filter { $0 != .ethernet }
+        var seen = Set<ProtocolKind>()
+        return layers.map(\.proto).filter { $0 != .ethernet && seen.insert($0).inserted }
     }
 }

--- a/Tracexy/Core/Protocol/PacketBuilder.swift
+++ b/Tracexy/Core/Protocol/PacketBuilder.swift
@@ -40,6 +40,32 @@ nonisolated enum PacketBuilder {
         )
     }
 
+    /// Ethernet+IPv4+TCP frame carrying a single raw TLS record. `declaredLength`
+    /// overrides the record's length field (defaulting to the actual body length),
+    /// so a test can model a fragment whose declared body exceeds the captured
+    /// bytes — TCP reassembly does not exist, so records legitimately arrive split.
+    static func tlsRecordFrame(
+        contentType: UInt8,
+        version: UInt16 = 0x0303,
+        body: [UInt8],
+        declaredLength: UInt16? = nil,
+        src: String,
+        dst: String,
+        srcPort: UInt16 = 50_000,
+        dstPort: UInt16 = 443
+    )
+        -> [UInt8]
+    {
+        let length = declaredLength ?? UInt16(body.count)
+        let record = [contentType] + be16(version) + be16(length) + body
+        return ethernetIPv4(
+            proto: 6,
+            src: src,
+            dst: dst,
+            payload: tcp(srcPort: srcPort, dstPort: dstPort, flags: 0x18, payload: record)
+        )
+    }
+
     static func httpRequestFrame(
         host: String,
         path: String,
@@ -133,9 +159,17 @@ nonisolated enum PacketBuilder {
         [nextHeader, 0x00, 0x01, 0x04, 0x00, 0x00, 0x00, 0x00]
     }
 
-    static func tcp(srcPort: UInt16, dstPort: UInt16, flags: UInt8, payload: [UInt8]) -> [UInt8] {
+    static func tcp(
+        srcPort: UInt16,
+        dstPort: UInt16,
+        flags: UInt8,
+        payload: [UInt8],
+        sequence: UInt32 = 1
+    )
+        -> [UInt8]
+    {
         var header = be16(srcPort) + be16(dstPort)
-        header += be32(1) + be32(0) // seq, ack
+        header += be32(sequence) + be32(0) // seq, ack
         header += [0x50, flags] // data offset (5 words), flags
         header += [0xFF, 0xFF, 0x00, 0x00, 0x00, 0x00] // window, checksum, urgent
         return header + payload

--- a/Tracexy/Core/Protocol/PacketDecoder.swift
+++ b/Tracexy/Core/Protocol/PacketDecoder.swift
@@ -13,6 +13,15 @@ nonisolated enum LinkType {
 nonisolated enum PacketDecoder {
     // MARK: Internal
 
+    struct ReassembledTCPApplication: Sendable {
+        let appProtocol: ProtocolKind
+        let layers: [DecodedLayer]
+        let sni: String?
+        let dnsQuery: String?
+        let dnsAnswers: [String]
+        let isComplete: Bool
+    }
+
     static func decode(_ frame: PacketBuffer, linkType: UInt32, timestamp: Date, originalLength: Int) -> DecodedPacket {
         var packet = DecodedPacket(timestamp: timestamp, originalLength: originalLength)
         do {
@@ -30,10 +39,68 @@ nonisolated enum PacketDecoder {
         return packet
     }
 
+    /// Classifies a bounded, contiguous TCP prefix assembled by the Session
+    /// layer. Returned layers deliberately carry no frame byte ranges: their
+    /// bytes can span multiple packets and must never highlight offsets in one
+    /// representative frame.
+    static func decodeReassembledTCPPayload(
+        _ bytes: [UInt8], sourcePort: UInt16, destinationPort: UInt16
+    )
+        -> ReassembledTCPApplication?
+    {
+        let buffer = PacketBuffer(bytes)
+        var packet = DecodedPacket(timestamp: .distantPast, originalLength: bytes.count)
+        let complete: Bool
+        do {
+            if isTLS(buffer) {
+                try tlsRecords(buffer, into: &packet)
+                let declared = try 5 + Int(buffer.u16(3))
+                complete = bytes.count >= declared
+            } else if sourcePort == 53 || destinationPort == 53,
+                      bytes.count >= 2
+            {
+                let declared = try Int(buffer.u16(0))
+                guard declared > 0, bytes.count >= 2 + declared else {
+                    return nil
+                }
+                try dns(buffer, into: &packet, tcp: true)
+                complete = true
+            } else if isHTTP(buffer) {
+                try http(buffer, into: &packet)
+                complete = containsHTTPHeaderTerminator(bytes)
+            } else {
+                return nil
+            }
+        } catch {
+            return nil
+        }
+        guard let appProtocol = packet.appProtocol else {
+            return nil
+        }
+        return ReassembledTCPApplication(
+            appProtocol: appProtocol,
+            layers: packet.layers.map(withoutByteRanges),
+            sni: packet.sni,
+            dnsQuery: packet.dnsQuery,
+            dnsAnswers: packet.dnsAnswers,
+            isComplete: complete
+        )
+    }
+
     // MARK: Private
 
     /// IPv6 extension-header protocol numbers (RFC 8200 order).
     private static let ipv6ExtensionHeaders: Set<UInt8> = [0, 43, 44, 51, 60, 135]
+
+    /// STUN magic cookie (RFC 5389 §6): the fixed value at header offset 4 that
+    /// disambiguates STUN from other UDP payloads regardless of port.
+    private static let stunMagicCookie: UInt32 = 0x2112A442
+
+    /// Largest plausible TLS record body: the 2^14 plaintext limit plus the
+    /// ciphertext-expansion allowance (RFC 5246 §6.2.3 / RFC 8446 §5.2), i.e.
+    /// 2^14 + 2048. A declared length beyond this cannot be a real TLS record, so
+    /// it is rejected to bound false positives.
+    private static let tlsMaxRecordLength = 16_384 + 2_048
 
     /// Decodes a tunnel/raw frame whose link-layer header is unknown: a bare IP
     /// packet, or one prefixed with a 4-byte BSD address family (NULL/LOOP).
@@ -351,6 +418,9 @@ nonisolated enum PacketDecoder {
         let dstPort = try buf.u16(2)
         let seq = try buf.u32(4)
         let dataOffset = try Int(buf.u8(12) >> 4) * 4
+        guard dataOffset >= 20, dataOffset <= buf.length else {
+            throw PacketError.malformed("Invalid TCP data offset")
+        }
         let flags = try buf.u8(13)
         packet.transport = .tcp
         packet.sourceEndpoint = IPEndpoint(ip: src, port: srcPort)
@@ -382,8 +452,10 @@ nonisolated enum PacketDecoder {
         if payload.isEmpty {
             return
         }
+        packet.tcpPayloadSequence = seq &+ ((flags & 0x02) == 0 ? 0 : 1)
+        packet.tcpPayloadBytes = try payload.bytes(0, payload.length)
         if isTLS(payload) {
-            try tls(payload, into: &packet)
+            try tlsRecords(payload, into: &packet)
         } else if srcPort == 53 || dstPort == 53 {
             try dns(payload, into: &packet, tcp: true)
         } else if isHTTP(payload) {
@@ -463,10 +535,15 @@ nonisolated enum PacketDecoder {
             byteRange: span(buf, 8)
         ))
         let payload = try buf.subset(from: 8)
-        if srcPort == 53 || dstPort == 53 {
+        if isSTUN(payload) {
+            // Content-detected (magic cookie), so port-independent — STUN rides on
+            // ephemeral ICE ports, not a well-known one. The UDP five-tuple/session
+            // grouping set above is preserved; this only enriches the app layer.
+            try stun(payload, into: &packet)
+        } else if srcPort == 53 || dstPort == 53 {
             try dns(payload, into: &packet, tcp: false)
         } else if srcPort == 443 || dstPort == 443, isQUIC(payload) {
-            quicLayer(&packet)
+            quic(payload, into: &packet)
         }
     }
 
@@ -585,16 +662,73 @@ nonisolated enum PacketDecoder {
         }
     }
 
+    /// Walk all complete coalesced TLS records in one TCP payload. A final
+    /// truncated record is still emitted once with an honest fragment label.
+    private static func tlsRecords(_ buf: PacketBuffer, into packet: inout DecodedPacket) throws {
+        var offset = 0
+        var recordCount = 0
+        while offset + 5 <= buf.length, recordCount < 32 {
+            let record = try buf.subset(from: offset)
+            guard isTLS(record) else {
+                break
+            }
+            try tls(record, into: &packet)
+            recordCount += 1
+            let recordLength = try 5 + Int(record.u16(3))
+            guard recordLength <= record.length else {
+                break
+            }
+            offset += recordLength
+        }
+    }
+
     private static func tls(_ buf: PacketBuffer, into packet: inout DecodedPacket) throws {
+        let contentType = try buf.u8(0)
         let recordVersion = try buf.u16(1)
-        let handshakeType = try buf.u8(5)
-        let recordLength = (try? buf.u16(3)).map { 5 + Int($0) } ?? buf.length
+        let declaredBody = try Int(buf.u16(3))
+        let recordLength = 5 + declaredBody // declared record length (header + body)
+        let capturedBody = max(0, min(recordLength, buf.length) - 5)
+        let typeName = tlsContentTypeName(contentType)
         var layer = DecodedLayer(
             proto: .tls, title: "Transport Layer Security", summary: tlsVersionName(recordVersion),
             byteRange: span(buf, recordLength)
         )
-        layer.fields.append(ranged("Content Type", "Handshake (22)", in: buf, at: 0, 1))
+        layer.fields.append(ranged("Content Type", "\(typeName) (\(contentType))", in: buf, at: 0, 1))
+        layer.fields.append(ranged("Version", tlsVersionName(recordVersion), in: buf, at: 1, 2))
+        // A packet — or even the bounded session prefix — may still contain only
+        // part of a record. Label captured-vs-declared honestly.
+        if capturedBody < declaredBody {
+            layer.fields.append(ranged(
+                "Record Length", "\(declaredBody) declared, \(capturedBody) captured (fragment)",
+                in: buf, at: 3, 2
+            ))
+        } else {
+            layer.fields.append(ranged("Record Length", "\(declaredBody)", in: buf, at: 3, 2))
+        }
         packet.appProtocol = .tls
+        // Only a Handshake record carries a handshake message; never read a handshake
+        // byte for Application Data / Alert / Change Cipher Spec / Heartbeat records.
+        // A truncated or malformed handshake leaves the record-level layer intact
+        // (metadata only — this is not decryption or stream reassembly).
+        if contentType == 22 {
+            try? enrichTLSHandshake(
+                buf, recordVersion: recordVersion, recordLength: recordLength, layer: &layer, packet: &packet
+            )
+        }
+        packet.layers.append(layer)
+    }
+
+    /// Enriches a TLS *Handshake* record with ClientHello (SNI/ALPN/version/ciphers)
+    /// or ServerHello (version/cipher) detail. Bounds-checked; a truncated handshake
+    /// throws and the caller keeps the record-level layer. The caller gates this on
+    /// the Handshake content type, so a handshake byte is never read for other records.
+    private static func enrichTLSHandshake(
+        _ buf: PacketBuffer, recordVersion: UInt16, recordLength: Int,
+        layer: inout DecodedLayer, packet: inout DecodedPacket
+    )
+        throws
+    {
+        let handshakeType = try buf.u8(5)
         // Parse ClientHello for SNI + ALPN + version/ciphers.
         if handshakeType == 0x01 {
             var hello = DecodedLayer(
@@ -664,7 +798,6 @@ nonisolated enum PacketDecoder {
             layer.summary = "\(tlsVersionName(serverVersion)) · Server Hello"
             layer.children.append(serverHello)
         }
-        packet.layers.append(layer)
     }
 
     /// Parses a TLS ALPN protocol-name list into a comma-joined string.
@@ -718,18 +851,209 @@ nonisolated enum PacketDecoder {
         ))
     }
 
-    private static func quicLayer(_ packet: inout DecodedPacket) {
+    /// Surfaces the clear-text QUIC long-header fields (RFC 9000 §17.2): packet
+    /// type, version, and the destination/source connection IDs. The caller's
+    /// `isQUIC` gate proved the long-header form bit; the fixed bit, packet-number
+    /// space, and everything after the source CID are encrypted and never guessed.
+    /// A version of 0 is Version Negotiation (§17.2.1). Any bounds failure — a
+    /// short header slipping the gate, a CID length over the 20-byte cap, or a
+    /// truncated header — falls back to honest identification only.
+    private static func quic(_ buf: PacketBuffer, into packet: inout DecodedPacket) {
         packet.appProtocol = .quic
-        packet.layers.append(DecodedLayer(proto: .quic, title: "QUIC", summary: "encrypted transport"))
+        guard let first = try? buf.u8(0),
+              let version = try? buf.u32(1),
+              let dcidLen = try? Int(buf.u8(5)), dcidLen <= 20,
+              let dcid = try? buf.bytes(6, dcidLen),
+              let scidLen = try? Int(buf.u8(6 + dcidLen)), scidLen <= 20,
+              let scid = try? buf.bytes(7 + dcidLen, scidLen) else
+        {
+            packet.layers.append(DecodedLayer(proto: .quic, title: "QUIC", summary: "encrypted transport"))
+            return
+        }
+        let scidLenOffset = 6 + dcidLen
+        let isVersionNegotiation = version == 0
+        let typeName = isVersionNegotiation ? "Version Negotiation" : quicLongPacketType(first, version: version)
+        let versionText = isVersionNegotiation ? "Version Negotiation (0x00000000)" : String(format: "0x%08x", version)
+        let summary = isVersionNegotiation ? "Version Negotiation" : "\(typeName) · encrypted transport"
+        packet.layers.append(DecodedLayer(
+            proto: .quic, title: "QUIC", summary: summary,
+            fields: [
+                ranged("Packet Type", typeName, in: buf, at: 0, 1),
+                ranged("Version", versionText, in: buf, at: 1, 4),
+                ranged(
+                    "Destination CID", dcid.isEmpty ? "(zero-length)" : hexString(dcid),
+                    in: buf, at: 5, 1 + dcidLen
+                ),
+                ranged(
+                    "Source CID", scid.isEmpty ? "(zero-length)" : hexString(scid),
+                    in: buf, at: scidLenOffset, 1 + scidLen
+                ),
+            ],
+            byteRange: span(buf, scidLenOffset + 1 + scidLen)
+        ))
+    }
+
+    /// Names a QUIC v1 long-header packet type from the two type bits (RFC 9000
+    /// §17.2). The type-bit meaning is version-specific, so any non-v1 version
+    /// renders the raw type value rather than assuming the v1 mapping.
+    private static func quicLongPacketType(_ firstByte: UInt8, version: UInt32) -> String {
+        let type = (firstByte >> 4) & 0x03
+        guard version == 0x00000001 else {
+            return "Long Header (type \(type))"
+        }
+        switch type {
+        case 0x00: return "Initial"
+        case 0x01: return "0-RTT"
+        case 0x02: return "Handshake"
+        default: return "Retry"
+        }
+    }
+
+    /// Decodes the fixed 20-byte STUN header (RFC 5389 §6) and then walks the
+    /// declared attribute TLVs. Metadata only — ICE negotiation state and TURN
+    /// allocation state are deliberately not tracked; attributes are surfaced by
+    /// name, with MAPPED-ADDRESS / XOR-MAPPED-ADDRESS IPv4 reflexive addresses
+    /// decoded when fully present. `isSTUN` already proved the magic cookie and
+    /// that the declared attribute region is 4-byte aligned and fully captured.
+    private static func stun(_ buf: PacketBuffer, into packet: inout DecodedPacket) throws {
+        let messageType = try buf.u16(0)
+        let messageLength = try Int(buf.u16(2))
+        let cookie = try buf.u32(4)
+        let transactionID = try buf.bytes(8, 12)
+        let typeName = stunMessageTypeName(messageType)
+        packet.appProtocol = .stun
+        var fields: [DecodedField] = [
+            ranged("Message Type", "\(typeName) (\(String(format: "0x%04x", messageType)))", in: buf, at: 0, 2),
+            ranged("Message Length", "\(messageLength)", in: buf, at: 2, 2),
+            ranged("Magic Cookie", String(format: "0x%08x", cookie), in: buf, at: 4, 4),
+            ranged("Transaction ID", hexString(transactionID), in: buf, at: 8, 12),
+        ]
+        fields += stunAttributes(buf, messageLength: messageLength)
+        packet.layers.append(DecodedLayer(
+            proto: .stun, title: "Session Traversal Utilities for NAT", summary: typeName,
+            fields: fields,
+            byteRange: span(buf, 20 + messageLength)
+        ))
+    }
+
+    /// Walks the STUN attribute TLVs (RFC 5389 §15): 2-byte type, 2-byte value
+    /// length, value padded to a 4-byte boundary, starting at offset 20. Every
+    /// read is bounds-checked; a truncated or over-declared attribute stops the
+    /// walk and keeps the header-level record intact rather than trapping.
+    private static func stunAttributes(_ buf: PacketBuffer, messageLength: Int) -> [DecodedField] {
+        var fields: [DecodedField] = []
+        let end = min(20 + messageLength, buf.length)
+        var offset = 20
+        var guardCounter = 0
+        while offset + 4 <= end, guardCounter < 64 {
+            guardCounter += 1
+            guard let type = try? buf.u16(offset),
+                  let valueLength = try? Int(buf.u16(offset + 2)),
+                  offset + 4 + valueLength <= end else
+            {
+                break
+            }
+            let valueStart = offset + 4
+            let name = stunAttributeName(type)
+            let value = stunAttributeValue(type: type, buf: buf, at: valueStart, length: valueLength)
+            fields.append(DecodedField(
+                name: "Attribute: \(name)", value: value,
+                byteRange: (buf.start + offset) ..< (buf.start + valueStart + valueLength)
+            ))
+            // Advance past the value plus its 4-byte-boundary padding.
+            offset = valueStart + ((valueLength + 3) & ~0x03)
+        }
+        return fields
+    }
+
+    /// Readable names for the RFC 5389 §18.2 attribute registry. Any other type
+    /// (including ICE/TURN extensions we deliberately do not interpret) falls back
+    /// to an honest hex rendering rather than a guessed label.
+    private static func stunAttributeName(_ type: UInt16) -> String {
+        switch type {
+        case 0x0001: "MAPPED-ADDRESS"
+        case 0x0006: "USERNAME"
+        case 0x0008: "MESSAGE-INTEGRITY"
+        case 0x0009: "ERROR-CODE"
+        case 0x000A: "UNKNOWN-ATTRIBUTES"
+        case 0x0014: "REALM"
+        case 0x0015: "NONCE"
+        case 0x0020: "XOR-MAPPED-ADDRESS"
+        case 0x8022: "SOFTWARE"
+        case 0x8023: "ALTERNATE-SERVER"
+        case 0x8028: "FINGERPRINT"
+        default: String(format: "0x%04x", type)
+        }
+    }
+
+    /// Renders an attribute's value. MAPPED-ADDRESS / XOR-MAPPED-ADDRESS surface a
+    /// decoded IPv4 `address:port` when the family is IPv4 and the value is fully
+    /// present; every other attribute (and IPv6 or malformed address families)
+    /// stays a metadata-only byte count — never a fabricated value.
+    private static func stunAttributeValue(type: UInt16, buf: PacketBuffer, at offset: Int, length: Int) -> String {
+        switch type {
+        case 0x0001: stunMappedAddress(buf, at: offset, length: length, xor: false) ?? "\(length) bytes"
+        case 0x0020: stunMappedAddress(buf, at: offset, length: length, xor: true) ?? "\(length) bytes"
+        default: "\(length) bytes"
+        }
+    }
+
+    /// Decodes a STUN (XOR-)MAPPED-ADDRESS value (RFC 5389 §15.1–15.2) for the
+    /// IPv4 family only: reserved byte, family, port, 4-byte address. XOR form
+    /// un-masks the port with the cookie's high half and the address with the full
+    /// magic cookie. Returns nil for the IPv6 family or any short/malformed value.
+    private static func stunMappedAddress(_ buf: PacketBuffer, at offset: Int, length: Int, xor: Bool) -> String? {
+        guard length >= 8,
+              let family = try? buf.u8(offset + 1), family == 0x01,
+              var port = try? buf.u16(offset + 2),
+              var octets = try? buf.bytes(offset + 4, 4) else
+        {
+            return nil
+        }
+        if xor {
+            port ^= UInt16(stunMagicCookie >> 16)
+            octets[0] ^= UInt8((stunMagicCookie >> 24) & 0xFF)
+            octets[1] ^= UInt8((stunMagicCookie >> 16) & 0xFF)
+            octets[2] ^= UInt8((stunMagicCookie >> 8) & 0xFF)
+            octets[3] ^= UInt8(stunMagicCookie & 0xFF)
+        }
+        return "\(octets.map { "\($0)" }.joined(separator: ".")):\(port)"
+    }
+
+    /// Readable names for the canonical Binding method classes; any other valid
+    /// STUN type falls back to an honest hex rendering rather than a guess.
+    private static func stunMessageTypeName(_ type: UInt16) -> String {
+        switch type {
+        case 0x0001: "Binding Request"
+        case 0x0011: "Binding Indication"
+        case 0x0101: "Binding Success Response"
+        case 0x0111: "Binding Error Response"
+        default: String(format: "0x%04x", type)
+        }
     }
 
     // MARK: Heuristics
 
+    /// Content-based TLS record recognition (RFC 8446 §5.1), independent of port.
+    /// A recognized record needs a *complete* 5-byte record header: a defined
+    /// content type (20…24 — CCS/Alert/Handshake/ApplicationData/Heartbeat), the
+    /// record-layer major version 3, a plausible minor (SSL 3.0 … TLS 1.3), and a
+    /// declared body length within the 2^14 + 2048 ciphertext allowance. The
+    /// declared body is deliberately *not* required to be fully present — TCP
+    /// reassembly does not exist, so a packet may carry only a record fragment;
+    /// `tls` labels captured-vs-declared honestly. Rejecting invalid
+    /// type/version/length bounds false positives on arbitrary TCP payloads.
     private static func isTLS(_ buf: PacketBuffer) -> Bool {
-        guard let type = try? buf.u8(0), let major = try? buf.u8(1) else {
+        guard buf.length >= 5,
+              let type = try? buf.u8(0), (20 ... 24).contains(type),
+              let major = try? buf.u8(1), major == 0x03,
+              let minor = try? buf.u8(2), minor <= 0x04,
+              let length = try? Int(buf.u16(3)),
+              length >= 1, length <= tlsMaxRecordLength else
+        {
             return false
         }
-        return type == 0x16 && major == 0x03
+        return true
     }
 
     private static func isHTTP(_ buf: PacketBuffer) -> Bool {
@@ -740,11 +1064,65 @@ nonisolated enum PacketDecoder {
         return ["GET ", "POST", "PUT ", "HEAD", "DELE", "PATC", "OPTI", "HTTP"].contains { prefix.hasPrefix($0) }
     }
 
-    private static func isQUIC(_ buf: PacketBuffer) -> Bool {
-        guard let first = try? buf.u8(0) else {
+    private static func containsHTTPHeaderTerminator(_ bytes: [UInt8]) -> Bool {
+        guard bytes.count >= 4 else {
             return false
         }
-        return (first & 0x80) != 0 // long-header form
+        for index in 0 ... (bytes.count - 4)
+            where bytes[index] == 13 && bytes[index + 1] == 10
+            && bytes[index + 2] == 13 && bytes[index + 3] == 10
+        {
+            return true
+        }
+        return false
+    }
+
+    private static func withoutByteRanges(_ layer: DecodedLayer) -> DecodedLayer {
+        DecodedLayer(
+            proto: layer.proto,
+            title: layer.title,
+            summary: layer.summary,
+            fields: layer.fields.map { DecodedField(name: $0.name, value: $0.value) },
+            children: layer.children.map(withoutByteRanges)
+        )
+    }
+
+    /// Conservative QUIC long-header recognition. A high bit by itself is far
+    /// too weak on busy UDP/443 traffic, so require the complete clear-text
+    /// prefix and RFC-bounded connection IDs. Non-zero versions also carry the
+    /// fixed bit; Version Negotiation deliberately does not require it because
+    /// those unused header bits are randomized.
+    private static func isQUIC(_ buf: PacketBuffer) -> Bool {
+        guard buf.length >= 7,
+              let first = try? buf.u8(0), (first & 0x80) != 0,
+              let version = try? buf.u32(1),
+              version == 0 || (first & 0x40) != 0,
+              let dcidLength = try? Int(buf.u8(5)), dcidLength <= 20,
+              (try? buf.bytes(6, dcidLength)) != nil,
+              let scidLength = try? Int(buf.u8(6 + dcidLength)), scidLength <= 20,
+              (try? buf.bytes(7 + dcidLength, scidLength)) != nil else
+        {
+            return false
+        }
+        return true
+    }
+
+    /// STUN detection (RFC 5389): a ≥20-byte payload whose two leading type bits
+    /// are zero, whose offset-4 word is the magic cookie, and whose declared
+    /// attribute length is 4-byte aligned and fully present in the capture. All
+    /// three together make a false positive on arbitrary UDP effectively impossible;
+    /// truncated or oversized-length payloads fail the last check and stay UDP.
+    private static func isSTUN(_ buf: PacketBuffer) -> Bool {
+        guard buf.length >= 20,
+              let typeByte = try? buf.u8(0), (typeByte & 0xC0) == 0,
+              let cookie = try? buf.u32(4), cookie == stunMagicCookie,
+              let messageLength = try? Int(buf.u16(2)),
+              messageLength % 4 == 0,
+              20 + messageLength <= buf.length else
+        {
+            return false
+        }
+        return true
     }
 
     // MARK: Byte-range helpers
@@ -776,6 +1154,11 @@ nonisolated enum PacketDecoder {
 
     private static func mac(_ buf: PacketBuffer, _ offset: Int) throws -> String {
         try (0 ..< 6).map { try String(format: "%02x", buf.u8(offset + $0)) }.joined(separator: ":")
+    }
+
+    /// Lower-case contiguous hex (e.g. a STUN transaction ID), no separators.
+    private static func hexString(_ bytes: [UInt8]) -> String {
+        bytes.map { String(format: "%02x", $0) }.joined()
     }
 
     private static func ipv4Address(_ buf: PacketBuffer, _ offset: Int) throws -> String {
@@ -852,6 +1235,19 @@ nonisolated enum PacketDecoder {
             parts.append("RST")
         }
         return parts.isEmpty ? "·" : parts.joined(separator: ", ")
+    }
+
+    /// Human-readable TLS record content-type name (RFC 8446 §5.1). Only 20…24 are
+    /// defined; anything else is rendered honestly rather than guessed.
+    private static func tlsContentTypeName(_ type: UInt8) -> String {
+        switch type {
+        case 20: "Change Cipher Spec"
+        case 21: "Alert"
+        case 22: "Handshake"
+        case 23: "Application Data"
+        case 24: "Heartbeat"
+        default: "type \(type)"
+        }
     }
 
     private static func tlsVersionName(_ version: UInt16) -> String {

--- a/Tracexy/Core/Session/Activity.swift
+++ b/Tracexy/Core/Session/Activity.swift
@@ -52,7 +52,10 @@ enum ActivityEvidence: Hashable, Sendable {
     nonisolated var tier: ConfidenceTier {
         switch self {
         case .dnsAnswerToConnection: .causal
-        case .sameProcessAtConnect: .causal
+        // A shared owner is strong attribution, but it does not prove that one
+        // connection caused another. Only an observed protocol transition earns
+        // the causal tier.
+        case .sameProcessAtConnect: .strong
         case .canonicalNameMatch: .strong
         // Deliberately weak: things that merely happen at the same moment are
         // not related, and on a busy interface almost everything is adjacent.

--- a/Tracexy/Core/Session/ActivityBuilder.swift
+++ b/Tracexy/Core/Session/ActivityBuilder.swift
@@ -26,6 +26,12 @@ enum ActivityBuilder {
     /// deliberately short causal window rather than an attempt to model TTL.
     static let dnsCausalWindow: TimeInterval = 30
 
+    /// How close in time two identifier-only sessions must sit to be treated as
+    /// one action. The second pass has *no* observed causal step — only agreeing
+    /// process and name — so it earns a far tighter window than the DNS pass: a
+    /// process talking to a host every few seconds is many actions, not one.
+    static let sameIdentityAdjacencyWindow: TimeInterval = 2
+
     static func build(from sessions: [SessionSummary], window: TimeInterval = dnsCausalWindow) -> Result {
         guard !sessions.isEmpty else {
             return Result()
@@ -116,11 +122,21 @@ enum ActivityBuilder {
 
         // Second pass: sessions with no DNS link, but the same process talking to
         // the same name close together. Strong, not causal — no observed step
-        // ties them, only agreeing identifiers.
+        // ties them, only agreeing identifiers. Because the only signal here is
+        // identity, the bar is deliberately high: a session needs a *real*
+        // observed process AND a shared canonical name to even be a candidate.
+        // Sessions whose process attribution is nil/empty are never second-pass
+        // grouped — an absent process is not a matching process.
         let remaining = ordered.filter { !consumed.contains($0.id) }
         var buckets: [String: [SessionSummary]] = [:]
         for session in remaining {
-            let key = "\(session.processName ?? "—")\u{1}\(Self.canonicalName([session]) ?? session.host)"
+            guard let process = Self.attributedProcess(of: session),
+                  let canonical = Self.canonicalName([session]) else
+            {
+                result.ungrouped.append(session)
+                continue
+            }
+            let key = "\(process)\u{1}\(canonical)"
             buckets[key, default: []].append(session)
         }
 
@@ -131,7 +147,7 @@ enum ActivityBuilder {
             }
             // Only group what is actually adjacent in time; a process talking to
             // one host all day is not one action.
-            for run in Self.runs(in: bucket, window: window) {
+            for run in Self.runs(in: bucket, window: Self.sameIdentityAdjacencyWindow) {
                 if run.count == 1 {
                     result.ungrouped.append(contentsOf: run)
                     continue
@@ -171,6 +187,19 @@ enum ActivityBuilder {
         }
         let host = String(endpoint[endpoint.startIndex ..< separator])
         return host.isEmpty ? nil : host
+    }
+
+    /// A session's process attribution, only when it is a real non-empty name.
+    /// A nil or empty `processName` is unknown, not a value to correlate on.
+    private static func attributedProcess(of session: SessionSummary) -> String? {
+        guard let rawName = session.processName else {
+            return nil
+        }
+        let name = rawName.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !name.isEmpty else {
+            return nil
+        }
+        return name
     }
 
     private static func sharedProcess(_ sessions: [SessionSummary]) -> String? {

--- a/Tracexy/Core/Session/SessionAccumulator.swift
+++ b/Tracexy/Core/Session/SessionAccumulator.swift
@@ -76,10 +76,14 @@ private extension SessionAccumulator {
         // MARK: Lifecycle
 
         init(first packet: DecodedPacket) {
+            var enriched = packet
             earliest = packet
             latestTime = packet.timestamp
             rich = packet
-            fold(packet)
+            _ = enrichFromTCPStream(&enriched)
+            earliest = enriched
+            rich = enriched
+            fold(enriched)
         }
 
         // MARK: Internal
@@ -87,7 +91,9 @@ private extension SessionAccumulator {
         /// Fold a subsequent packet of the same five-tuple. `merge` also updates
         /// the representatives; the first packet is folded via `fold` directly
         /// from `init`, where the representatives are already seeded.
-        mutating func merge(_ packet: DecodedPacket) {
+        mutating func merge(_ incoming: DecodedPacket) {
+            var packet = incoming
+            let hasReassembledApplication = enrichFromTCPStream(&packet)
             // Earliest packet: a strictly-smaller timestamp wins, so equal
             // timestamps keep the first-seen packet — matching `sorted.first`.
             if packet.timestamp < earliest.timestamp {
@@ -100,7 +106,9 @@ private extension SessionAccumulator {
             }
             // Richest representative: only a strictly-greater layer count wins, so
             // ties keep the first-seen packet — matching `packets.max(by:)`.
-            if rich.layers.count < packet.layers.count {
+            if rich.layers.count < packet.layers.count
+                || (hasReassembledApplication && applicationRichness(packet) > applicationRichness(rich))
+            {
                 rich = packet
             }
             fold(packet)
@@ -177,17 +185,21 @@ private extension SessionAccumulator {
         private var dnsQueryTime: Date?
         private var dnsResponseTime: Date?
 
-        private var anyAppProtocol = false
         private var anyTCPRST = false
 
+        /// At most one 16 KiB prefix per direction. Once a complete first
+        /// application record/header is classified, the bytes are released and
+        /// only the decoded metadata remains in the summary state.
+        private var tcpDirections: [IPEndpoint: TCPDirectionState] = [:]
+
         private var status: SessionStatus {
-            if anyTCPRST {
-                return .error
-            }
-            if !anyAppProtocol, rich.transport == .tcp {
-                return .warning
-            }
-            return .ok
+            // Only observed evidence sets status. An explicit TCP RST is a real
+            // reset and reads as an error. The absence of a decoded application
+            // protocol is *not* evidence of anything — a bare SYN, a midstream
+            // TCP payload we could not classify, or a tunnel we do not parse are
+            // all normal traffic, so they stay `.ok` rather than being invented
+            // into a warning that then feeds Security/findings.
+            anyTCPRST ? .error : .ok
         }
 
         private var latency: Double? {
@@ -201,6 +213,76 @@ private extension SessionAccumulator {
             packet.layers.contains { layer in
                 layer.proto == .tcp && (layer.fields.first { $0.name == "Flags" }?.value.contains("RST") ?? false)
             }
+        }
+
+        /// Reassembles only enough of one TCP direction to classify its first
+        /// TLS/HTTP/DNS record. The connection/session seam owns ordering state;
+        /// the protocol decoder stays stateless and receives a bounded prefix.
+        private mutating func enrichFromTCPStream(_ packet: inout DecodedPacket) -> Bool {
+            guard packet.transport == .tcp,
+                  let source = packet.sourceEndpoint,
+                  let destination = packet.destinationEndpoint,
+                  let sequence = packet.tcpPayloadSequence,
+                  !packet.tcpPayloadBytes.isEmpty else
+            {
+                return false
+            }
+
+            var direction = tcpDirections[source] ?? TCPDirectionState()
+            guard !direction.finished else {
+                return false
+            }
+            var output = direction.reassembler.ingest(sequence: sequence, payload: packet.tcpPayloadBytes)
+            var metadata = PacketDecoder.decodeReassembledTCPPayload(
+                output.contiguous,
+                sourcePort: source.port,
+                destinationPort: destination.port
+            )
+
+            // A capture may begin in the middle of an existing byte stream. If
+            // this packet is independently recognizable at its own boundary but
+            // the earlier anchor was opaque, re-anchor here instead of retaining
+            // an undecodable prefix until the bound is exhausted.
+            if metadata == nil, packet.appProtocol != nil,
+               output.contiguous.count != packet.tcpPayloadBytes.count
+            {
+                direction.reassembler.reset()
+                output = direction.reassembler.ingest(sequence: sequence, payload: packet.tcpPayloadBytes)
+                metadata = PacketDecoder.decodeReassembledTCPPayload(
+                    output.contiguous,
+                    sourcePort: source.port,
+                    destinationPort: destination.port
+                )
+            }
+
+            guard let metadata else {
+                tcpDirections[source] = direction
+                return false
+            }
+            packet.appProtocol = metadata.appProtocol
+            packet.sni = metadata.sni ?? packet.sni
+            packet.dnsQuery = metadata.dnsQuery ?? packet.dnsQuery
+            if !metadata.dnsAnswers.isEmpty {
+                packet.dnsAnswers = metadata.dnsAnswers
+            }
+            packet.layers.removeAll { $0.proto == metadata.appProtocol }
+            packet.layers.append(contentsOf: metadata.layers)
+
+            if metadata.isComplete || direction.reassembler.didOverflow {
+                direction.reassembler.reset()
+                direction.finished = true
+            }
+            tcpDirections[source] = direction
+            return true
+        }
+
+        private func applicationRichness(_ packet: DecodedPacket) -> Int {
+            func layerScore(_ layer: DecodedLayer) -> Int {
+                layer.fields.count + layer.children.reduce(0) { $0 + 1 + layerScore($1) }
+            }
+            return packet.layers.reduce(0) { $0 + layerScore($1) }
+                + (packet.sni == nil ? 0 : 100)
+                + (packet.dnsQuery == nil ? 0 : 50)
         }
 
         /// Fold the parts of a packet that accumulate the same way for the first
@@ -229,9 +311,6 @@ private extension SessionAccumulator {
                 }
             }
 
-            if packet.appProtocol != nil {
-                anyAppProtocol = true
-            }
             if !anyTCPRST, Self.hasTCPRST(packet) {
                 anyTCPRST = true
             }
@@ -245,5 +324,10 @@ private extension SessionAccumulator {
             }
             return candidate < stored ? candidate : stored
         }
+    }
+
+    nonisolated struct TCPDirectionState {
+        var reassembler = TCPStreamReassembler()
+        var finished = false
     }
 }

--- a/Tracexy/Core/Session/TCPStreamReassembler.swift
+++ b/Tracexy/Core/Session/TCPStreamReassembler.swift
@@ -1,0 +1,149 @@
+import Foundation
+
+/// A small, bounded TCP byte-stream prefix reassembler for one direction of one
+/// five-tuple. It exists only to recover application metadata split across nearby
+/// segments; it is not a connection table and never retains an unbounded stream.
+nonisolated struct TCPStreamReassembler: Sendable {
+    // MARK: Lifecycle
+
+    init(maxBufferedBytes: Int = 16_384, maxPendingSegments: Int = 32) {
+        self.maxBufferedBytes = max(5, maxBufferedBytes)
+        self.maxPendingSegments = max(1, maxPendingSegments)
+    }
+
+    // MARK: Internal
+
+    enum Disposition: Equatable, Sendable {
+        case advanced
+        case buffered
+        case duplicate
+        case reset
+    }
+
+    struct Output: Equatable, Sendable {
+        let contiguous: [UInt8]
+        let disposition: Disposition
+    }
+
+    private(set) var contiguous: [UInt8] = []
+    private(set) var pendingByteCount = 0
+    private(set) var didOverflow = false
+
+    mutating func ingest(sequence: UInt32, payload: [UInt8]) -> Output {
+        guard !payload.isEmpty else {
+            return Output(contiguous: contiguous, disposition: .duplicate)
+        }
+
+        guard let expected = nextSequence else {
+            return restart(at: sequence, payload: payload, disposition: .advanced)
+        }
+
+        let distance = serialDistance(from: expected, to: sequence)
+        if distance <= 0 {
+            let overlap = Int(-Int64(distance))
+            guard overlap < payload.count else {
+                return Output(contiguous: contiguous, disposition: .duplicate)
+            }
+            let suffix = Array(payload.dropFirst(overlap))
+            guard contiguous.count + suffix.count <= maxBufferedBytes else {
+                return restart(at: sequence, payload: payload, disposition: .reset)
+            }
+            contiguous.append(contentsOf: suffix)
+            nextSequence = expected &+ UInt32(suffix.count)
+            drainPending()
+            return Output(contiguous: contiguous, disposition: .advanced)
+        }
+
+        insertPending(sequence: sequence, payload: payload)
+        if pending.count > maxPendingSegments || pendingByteCount + contiguous.count > maxBufferedBytes {
+            return restart(at: sequence, payload: payload, disposition: .reset)
+        }
+        return Output(contiguous: contiguous, disposition: .buffered)
+    }
+
+    mutating func reset() {
+        nextSequence = nil
+        contiguous.removeAll(keepingCapacity: false)
+        pending.removeAll(keepingCapacity: false)
+        pendingByteCount = 0
+        didOverflow = false
+    }
+
+    // MARK: Private
+
+    private struct Segment: Sendable {
+        let sequence: UInt32
+        let bytes: [UInt8]
+    }
+
+    private let maxBufferedBytes: Int
+    private let maxPendingSegments: Int
+    private var nextSequence: UInt32?
+    private var pending: [Segment] = []
+
+    private mutating func restart(
+        at sequence: UInt32,
+        payload: [UInt8],
+        disposition: Disposition
+    )
+        -> Output
+    {
+        let kept = Array(payload.prefix(maxBufferedBytes))
+        contiguous = kept
+        nextSequence = sequence &+ UInt32(kept.count)
+        pending.removeAll(keepingCapacity: false)
+        pendingByteCount = 0
+        didOverflow = disposition == .reset || payload.count > maxBufferedBytes
+        return Output(contiguous: contiguous, disposition: disposition)
+    }
+
+    private mutating func insertPending(sequence: UInt32, payload: [UInt8]) {
+        if let index = pending.firstIndex(where: { $0.sequence == sequence }) {
+            let existing = pending[index].bytes
+            if payload.count > existing.count, payload.starts(with: existing) {
+                pendingByteCount += payload.count - existing.count
+                pending[index] = Segment(sequence: sequence, bytes: payload)
+            }
+            return
+        }
+        pending.append(Segment(sequence: sequence, bytes: payload))
+        pendingByteCount += payload.count
+    }
+
+    private mutating func drainPending() {
+        while let expected = nextSequence {
+            let candidates = pending.enumerated().filter {
+                serialDistance(from: expected, to: $0.element.sequence) <= 0
+            }
+            guard let candidate = candidates.min(by: {
+                serialDistance(from: expected, to: $0.element.sequence)
+                    < serialDistance(from: expected, to: $1.element.sequence)
+            }) else {
+                return
+            }
+
+            let segment = pending.remove(at: candidate.offset)
+            pendingByteCount -= segment.bytes.count
+            let distance = serialDistance(from: expected, to: segment.sequence)
+            let overlap = Int(-Int64(distance))
+            guard overlap < segment.bytes.count else {
+                continue
+            }
+            let suffix = Array(segment.bytes.dropFirst(overlap))
+            guard contiguous.count + suffix.count <= maxBufferedBytes else {
+                didOverflow = true
+                pending.removeAll(keepingCapacity: false)
+                pendingByteCount = 0
+                return
+            }
+            contiguous.append(contentsOf: suffix)
+            nextSequence = expected &+ UInt32(suffix.count)
+        }
+    }
+
+    /// RFC-style serial-number comparison, valid while observed distances remain
+    /// below 2^31 bytes — far above this metadata window.
+    private func serialDistance(from reference: UInt32, to value: UInt32) -> Int32 {
+        Int32(bitPattern: value &- reference)
+    }
+}

--- a/Tracexy/Models/Session/ProtocolKind.swift
+++ b/Tracexy/Models/Session/ProtocolKind.swift
@@ -15,6 +15,7 @@ nonisolated enum ProtocolKind: String, CaseIterable, Identifiable, Hashable {
     case http2
     case quic
     case websocket
+    case stun
     case other
 
     // MARK: Internal
@@ -40,6 +41,7 @@ nonisolated enum ProtocolKind: String, CaseIterable, Identifiable, Hashable {
         case .http2: "HTTP/2"
         case .quic: "QUIC"
         case .websocket: "WS"
+        case .stun: "STUN"
         case .other: "—"
         }
     }

--- a/Tracexy/Models/Session/SessionSummary.swift
+++ b/Tracexy/Models/Session/SessionSummary.swift
@@ -93,7 +93,7 @@ nonisolated struct SessionSummary: Identifiable, Hashable, Sendable {
     /// exchange worth listing on its own — the condition for offering the
     /// Inspector's Requests facet.
     nonisolated var hasApplicationExchange: Bool {
-        let applicationProtocols: Set<ProtocolKind> = [.http, .http2, .dns, .websocket]
+        let applicationProtocols: Set<ProtocolKind> = [.http, .http2, .dns, .websocket, .stun]
         return protocolStack.contains(where: applicationProtocols.contains)
     }
 }

--- a/Tracexy/Models/UI/AppSettings.swift
+++ b/Tracexy/Models/UI/AppSettings.swift
@@ -168,6 +168,67 @@ enum CaptureFilterMode: String, CaseIterable, Identifiable {
     }
 }
 
+// MARK: - CaptureSettingsResolver
+
+/// Turns persisted Capture-Settings preferences into validated, bounded capture
+/// inputs, read fresh at each capture start. Pure and deterministic so the
+/// mapping (and the clamping of invalid persisted values to a safe default) is
+/// unit-testable without a live capture or `UserDefaults`.
+enum CaptureSettingsResolver {
+    /// The retention-window sizes the UI offers, and the safe fallback used when a
+    /// persisted value is none of them. These make the existing 8k/20k/50k picker
+    /// behavioral: the chosen value becomes the in-memory save/export capacity.
+    static let retainPacketsChoices = [8_000, 20_000, 50_000]
+    static let defaultRetainPackets = 8_000
+
+    /// Clamp a persisted snap length into the supported range (delegating to the
+    /// shared bound), so a corrupt or out-of-range value can never open an
+    /// oversized or too-small capture buffer.
+    static func resolvedSnapLength(_ raw: Int) -> Int {
+        CaptureConfiguration.clampedSnapLength(raw)
+    }
+
+    /// Map a persisted retention choice to an allowed capacity; anything not in the
+    /// offered set clamps to the safe default rather than sizing the window blindly.
+    static func resolvedRetainPackets(_ raw: Int) -> Int {
+        retainPacketsChoices.contains(raw) ? raw : defaultRetainPackets
+    }
+
+    /// Map the persisted filter mode + expression to a BPF string: `.all` → no
+    /// filter (`nil`); `.custom` → the trimmed expression, or `nil` when it is
+    /// blank so an empty custom filter is never sent as a (meaningless) expression.
+    static func resolvedBPF(filterMode: String, expression: String) -> String? {
+        guard filterMode == CaptureFilterMode.custom.rawValue else {
+            return nil
+        }
+        let trimmed = expression.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    /// Assemble a capture configuration from the current preferences. Reads the
+    /// snap length, promiscuous flag, filter mode, and BPF expression fresh, so a
+    /// settings change since the last capture takes effect at the next start.
+    /// `defaults` is injectable so the whole mapping is testable without touching
+    /// the shared store.
+    static func configuration(interface: String, defaults: UserDefaults = .standard) -> CaptureConfiguration {
+        CaptureConfiguration(
+            interface: interface,
+            snapLength: resolvedSnapLength(defaults.integer(forKey: SettingsKeys.snapLength)),
+            promiscuous: defaults.bool(forKey: SettingsKeys.promiscuous),
+            bpf: resolvedBPF(
+                filterMode: defaults.string(forKey: SettingsKeys.captureFilterMode) ?? CaptureFilterMode.all.rawValue,
+                expression: defaults.string(forKey: SettingsKeys.bpfExpression) ?? ""
+            )
+        )
+    }
+
+    /// Resolve the configured retention-window capacity from the current
+    /// preferences, clamping an invalid persisted value to the safe default.
+    static func retainCapacity(defaults: UserDefaults = .standard) -> Int {
+        resolvedRetainPackets(defaults.integer(forKey: SettingsKeys.retainPackets))
+    }
+}
+
 // MARK: - AutoClear
 
 enum AutoClear: String, CaseIterable, Identifiable {

--- a/Tracexy/Models/UI/SessionFilterCategory.swift
+++ b/Tracexy/Models/UI/SessionFilterCategory.swift
@@ -15,6 +15,7 @@ enum SessionFilterCategory: String, CaseIterable, Identifiable, Hashable {
     case http2
     case quic
     case websocket
+    case stun
     case security
     case errors
 
@@ -22,7 +23,7 @@ enum SessionFilterCategory: String, CaseIterable, Identifiable, Hashable {
 
     /// Protocol categories, in display order (the "All" tab clears these).
     static let protocolFilters: [SessionFilterCategory] = [
-        .dns, .tcp, .udp, .tls, .http, .http2, .quic, .websocket,
+        .dns, .tcp, .udp, .tls, .http, .http2, .quic, .websocket, .stun,
     ]
 
     /// Investigation categories, applied independently of the protocol group.
@@ -42,6 +43,7 @@ enum SessionFilterCategory: String, CaseIterable, Identifiable, Hashable {
         case .http2: "HTTP/2"
         case .quic: "QUIC"
         case .websocket: "WebSocket"
+        case .stun: "STUN"
         case .security: "Security"
         case .errors: "Errors"
         }
@@ -62,6 +64,7 @@ enum SessionFilterCategory: String, CaseIterable, Identifiable, Hashable {
         case .http2: .http2
         case .quic: .quic
         case .websocket: .websocket
+        case .stun: .stun
         case .security,
              .errors: nil
         }

--- a/Tracexy/Models/UI/SessionGrouping.swift
+++ b/Tracexy/Models/UI/SessionGrouping.swift
@@ -2,6 +2,10 @@ import Foundation
 
 /// How the session list is grouped.
 ///
+/// `none` — the raw observed sessions — is the default: a real high-volume
+/// capture collapses into a handful of guessed rows under `action`, so the
+/// honest starting point is every session, flat. The grouped modes are opt-in.
+///
 /// Grouping is inference, so it must be switchable off. Correlation can be
 /// wrong — a shared CDN address, a resolver cache older than the causal window —
 /// and a user who suspects it needs the raw sessions back without hunting for a

--- a/Tracexy/Models/UI/SidebarItem.swift
+++ b/Tracexy/Models/UI/SidebarItem.swift
@@ -11,6 +11,7 @@ enum SidebarItem: String, CaseIterable, Identifiable, Hashable {
     case tls
     case http
     case quic
+    case stun
     case saved
 
     // MARK: Internal
@@ -29,6 +30,7 @@ enum SidebarItem: String, CaseIterable, Identifiable, Hashable {
         case .tls: "TLS"
         case .http: "HTTP"
         case .quic: "QUIC"
+        case .stun: "STUN"
         case .saved: "Saved"
         }
     }
@@ -44,6 +46,7 @@ enum SidebarItem: String, CaseIterable, Identifiable, Hashable {
         case .tls: "lock.shield"
         case .http: "globe"
         case .quic: "bolt.horizontal"
+        case .stun: "point.3.connected.trianglepath.dotted"
         case .saved: "folder"
         }
     }
@@ -56,6 +59,7 @@ enum SidebarItem: String, CaseIterable, Identifiable, Hashable {
         case .tls: .tls
         case .http: .http
         case .quic: .quic
+        case .stun: .stun
         default: nil
         }
     }
@@ -94,7 +98,7 @@ enum SidebarSection: String, CaseIterable, Identifiable, Hashable {
     nonisolated var items: [SidebarItem] {
         switch self {
         case .monitor: [.overview, .sessions, .flow]
-        case .protocols: [.dns, .tcp, .tls, .http, .quic]
+        case .protocols: [.dns, .tcp, .tls, .http, .quic, .stun]
         }
     }
 }

--- a/Tracexy/Models/UI/SidebarItem.swift
+++ b/Tracexy/Models/UI/SidebarItem.swift
@@ -93,7 +93,7 @@ enum SidebarSection: String, CaseIterable, Identifiable, Hashable {
 
     nonisolated var items: [SidebarItem] {
         switch self {
-        case .monitor: [.sessions, .overview, .flow]
+        case .monitor: [.overview, .sessions, .flow]
         case .protocols: [.dns, .tcp, .tls, .http, .quic]
         }
     }

--- a/Tracexy/Models/UI/WorkspaceState.swift
+++ b/Tracexy/Models/UI/WorkspaceState.swift
@@ -49,10 +49,12 @@ final class WorkspaceState: Identifiable {
     /// reveal stops for good — a panel the user dismissed must not reappear.
     var allowsAutomaticInspectorReveal: Bool?
 
-    /// How the session list groups rows. Defaults to correlated actions —
-    /// that is the point of the product — with a one-click way back to raw
-    /// sessions when the grouping looks wrong.
-    var sessionGrouping: SessionGrouping = .action
+    /// How the session list groups rows. Defaults to the raw observed sessions
+    /// exactly as decoded. Action grouping is inference layered on top and is
+    /// opt-in — a real high-volume capture collapses into a handful of guessed
+    /// rows, so the honest default is to show every session and let the user
+    /// switch to Action/Host/Process when they want the interpretation.
+    var sessionGrouping: SessionGrouping = .none
 
     /// Selection
     var selectedSessionID: UUID?

--- a/Tracexy/Models/UI/WorkspaceState.swift
+++ b/Tracexy/Models/UI/WorkspaceState.swift
@@ -82,6 +82,13 @@ final class WorkspaceState: Identifiable {
     var isFilterBarVisible: Bool = true
     var autoSelectLatest: Bool = false
 
+    /// Fresh identity issued every time something asks the session search field
+    /// to take focus (⌘F). `SessionFilterBar` observes it via `.task(id:)`, so a
+    /// repeat request re-focuses even when the command has just mounted the bar or
+    /// switched between workspaces. `nil` keeps a fresh workspace from stealing
+    /// focus unprompted.
+    var searchFocusRequest: UUID?
+
     /// The advanced rule rows that are enabled and carry a value (i.e. actually filter).
     var activeFilterRules: [SessionFilterRule] {
         SessionFilterRuleEvaluator.activeRules(in: filterRules)

--- a/Tracexy/Theme/Theme.swift
+++ b/Tracexy/Theme/Theme.swift
@@ -239,6 +239,7 @@ enum Theme {
         case .http2: .mint
         case .quic: .orange
         case .websocket: .pink
+        case .stun: .yellow
         }
     }
 

--- a/Tracexy/TracexyApp.swift
+++ b/Tracexy/TracexyApp.swift
@@ -32,6 +32,17 @@ struct TracexyApp: App {
             // `isSidebarPresented` with the native toolbar toggle.
             SidebarCommands()
 
+            // Edit ▸ Find (⌘F). Reuses the standard Find placement so the shortcut
+            // reads as native, then routes to the Sessions search box the app
+            // already has — no `.searchable`, no new surface. Repeated presses
+            // re-focus the field via the workspace's focus token.
+            CommandGroup(after: .textEditing) {
+                Button("Find") {
+                    coordinator.beginSessionSearch()
+                }
+                .keyboardShortcut("f", modifiers: .command)
+            }
+
             CommandGroup(after: .appInfo) {
                 Button("Check for Updates…") {
                     updater.checkForUpdates()

--- a/Tracexy/ViewModels/MainContentCoordinator+CapturePersistence.swift
+++ b/Tracexy/ViewModels/MainContentCoordinator+CapturePersistence.swift
@@ -3,6 +3,18 @@ import Foundation
 // MARK: - Capture persistence
 
 extension MainContentCoordinator {
+    /// Removes a managed capture from the Library through the recoverable macOS
+    /// Trash. If the file is currently open, its decoded in-memory view is also
+    /// cleared so the workspace cannot keep presenting a capture that no longer
+    /// exists in the Library.
+    func moveSavedCaptureToTrash(_ capture: SavedCapture) throws {
+        try FileManager.default.trashItem(at: capture.url, resultingItemURL: nil)
+        if activeSavedCapture?.url.standardizedFileURL == capture.url.standardizedFileURL {
+            clearSessions()
+        }
+        refreshSavedCaptures()
+    }
+
     /// Saves the complete current capture under Application Support. Live frames
     /// come from the disk-backed pcapng spool, not the bounded UI retention window.
     func saveCurrentCapture() {

--- a/Tracexy/ViewModels/MainContentCoordinator+CapturePersistence.swift
+++ b/Tracexy/ViewModels/MainContentCoordinator+CapturePersistence.swift
@@ -1,0 +1,64 @@
+import Foundation
+
+// MARK: - Capture persistence
+
+extension MainContentCoordinator {
+    /// Saves the complete current capture under Application Support. Live frames
+    /// come from the disk-backed pcapng spool, not the bounded UI retention window.
+    func saveCurrentCapture() {
+        guard !retainedFrames.isEmpty, let directory = Self.capturesDirectory() else {
+            return
+        }
+        let stamp = Self.fileStampFormatter.string(from: Date())
+        let savedSource = activeSavedCapture?.url
+        let fileExtension = savedSource?.pathExtension ?? "pcapng"
+        let url = directory.appendingPathComponent("Capture \(stamp).\(fileExtension)")
+        let pendingIngest = ingestChain
+        Task { @MainActor [weak self] in
+            guard let self else {
+                return
+            }
+            await pendingIngest?.value
+            do {
+                if let savedSource {
+                    try await Task.detached(priority: .userInitiated) {
+                        try FileManager.default.copyItem(at: savedSource, to: url)
+                    }.value
+                } else {
+                    try await self.liveCaptureSpool.copy(to: url)
+                }
+                if let warning = await self.liveCaptureSpool.incompletenessReason() {
+                    self.captureError = "Saved the recoverable capture prefix. Later frames are missing because "
+                        + "the local spool failed — \(warning)"
+                } else {
+                    self.captureError = nil
+                }
+                self.refreshSavedCaptures()
+            } catch {
+                self.captureError = "Couldn’t save capture: \(error.localizedDescription)"
+            }
+        }
+    }
+
+    /// Complete source for session export. A saved file is re-read directly; a
+    /// live capture is read from its spool after queued ingests have completed.
+    func completeCaptureForExport() async throws -> (
+        linkType: UInt32,
+        frames: [CapturedFrame],
+        incompletenessReason: String?
+    ) {
+        await ingestChain?.value
+        if let activeSavedCapture {
+            let capture = try await Task.detached(priority: .userInitiated) {
+                try CaptureFileReader.read(contentsOf: activeSavedCapture.url)
+            }.value
+            return (capture.linkType, capture.frames, nil)
+        }
+        let capture = try await liveCaptureSpool.capture()
+        return await (
+            capture.linkType,
+            capture.frames,
+            liveCaptureSpool.incompletenessReason()
+        )
+    }
+}

--- a/Tracexy/ViewModels/MainContentCoordinator+SessionExport.swift
+++ b/Tracexy/ViewModels/MainContentCoordinator+SessionExport.swift
@@ -12,7 +12,7 @@ extension MainContentCoordinator {
     }
 
     /// Cheap presentation gate for row menus. Packet matching is deliberately
-    /// deferred until activation because decoding the retention window belongs
+    /// deferred until activation because reading and decoding the complete capture belongs
     /// off the main actor.
     func canExport(_: SessionSummary) -> Bool {
         canSaveCapture && !isExportingSession
@@ -33,28 +33,27 @@ extension MainContentCoordinator {
             return
         }
         setSessionExporting(true)
-        let retainedFrameSnapshot = retainedFrameSnapshotForExport
-        let defaultLinkType = currentLinkType
 
         Task { [weak self] in
             defer { self?.setSessionExporting(false) }
             do {
+                guard let self else {
+                    return
+                }
+                let capture = try await self.completeCaptureForExport()
                 let artifact = try await Task.detached(priority: .userInitiated) {
                     let sessionFrames = SessionExporter.frames(
                         matching: session.id,
-                        in: retainedFrameSnapshot,
-                        defaultLinkType: defaultLinkType
+                        in: capture.frames,
+                        defaultLinkType: capture.linkType
                     )
                     return try SessionExporter.artifact(
                         for: session,
                         frames: sessionFrames,
-                        defaultLinkType: defaultLinkType,
+                        defaultLinkType: capture.linkType,
                         format: format
                     )
                 }.value
-                guard let self else {
-                    return
-                }
                 let panel = NSSavePanel()
                 panel.title = format.title
                 // Supply a basename and let the selected UTType append exactly
@@ -73,7 +72,12 @@ extension MainContentCoordinator {
                 try await Task.detached(priority: .userInitiated) {
                     try artifact.data.write(to: url, options: .atomic)
                 }.value
-                self.captureError = nil
+                if let warning = capture.incompletenessReason {
+                    self.captureError = "Exported the recoverable session prefix. Later frames are missing because "
+                        + "the local spool failed — \(warning)"
+                } else {
+                    self.captureError = nil
+                }
             } catch {
                 self?.captureError = "Couldn’t export session: \(error.localizedDescription)"
             }

--- a/Tracexy/ViewModels/MainContentCoordinator+SessionVisibility.swift
+++ b/Tracexy/ViewModels/MainContentCoordinator+SessionVisibility.swift
@@ -1,0 +1,40 @@
+import Foundation
+
+// MARK: - Session visibility
+
+@MainActor
+extension MainContentCoordinator {
+    /// Capture sessions that remain available to presentation surfaces.
+    /// `sessions` is the evidence-backed engine result; this reversible layer is
+    /// the single privacy seam between that raw result and the UI.
+    var presentedSessions: [SessionSummary] {
+        guard !removedSessionIDs.isEmpty else {
+            return sessions
+        }
+        return sessions.filter { !removedSessionIDs.contains($0.id) }
+    }
+
+    var removedSessionCount: Int {
+        removedSessionIDs.intersection(Set(sessions.map(\.id))).count
+    }
+
+    /// Removes decoded sessions from every presentation surface without
+    /// mutating the capture evidence that Save/Export relies on.
+    func removeSessionsFromView(_ ids: Set<UUID>) {
+        let validIDs = ids.intersection(Set(sessions.map(\.id)))
+        guard !validIDs.isEmpty else {
+            return
+        }
+        removedSessionIDs.formUnion(validIDs)
+        if let selectedID = activeWorkspace.selectedSessionID,
+           validIDs.contains(selectedID)
+        {
+            activeWorkspace.selectedSessionID = nil
+        }
+    }
+
+    /// Restores every row removed from the current capture's presentation.
+    func restoreRemovedSessions() {
+        removedSessionIDs.removeAll()
+    }
+}

--- a/Tracexy/ViewModels/MainContentCoordinator+SourceVisibility.swift
+++ b/Tracexy/ViewModels/MainContentCoordinator+SourceVisibility.swift
@@ -1,0 +1,120 @@
+import Foundation
+
+// MARK: - Source visibility
+
+@MainActor
+extension MainContentCoordinator {
+    func isSourceAppHidden(_ app: String) -> Bool {
+        hiddenSourceApps.contains(app)
+    }
+
+    func isSourceDomainHidden(_ domain: String) -> Bool {
+        hiddenSourceDomains.contains(domain)
+    }
+
+    func isSourceIPHidden(_ ip: String) -> Bool {
+        hiddenSourceIPs.contains(ip)
+    }
+
+    func isSourceHostHidden(_ host: String) -> Bool {
+        Self.isDomainName(host) ? isSourceDomainHidden(host) : isSourceIPHidden(host)
+    }
+
+    func hideSourceApp(_ app: String) {
+        guard !app.isEmpty else {
+            return
+        }
+        hiddenSourceApps.insert(app)
+        if activeWorkspace.processFilter == app {
+            selectSidebarItem(.sessions)
+        }
+        persistHiddenSources()
+    }
+
+    func hideSourceDomain(_ domain: String) {
+        guard !domain.isEmpty else {
+            return
+        }
+        hiddenSourceDomains.insert(domain)
+        if activeWorkspace.hostFilter == domain {
+            selectSidebarItem(.sessions)
+        }
+        persistHiddenSources()
+    }
+
+    func hideSourceIP(_ ip: String) {
+        guard !ip.isEmpty else {
+            return
+        }
+        hiddenSourceIPs.insert(ip)
+        if activeWorkspace.ipFilter == ip || activeWorkspace.hostFilter == ip {
+            selectSidebarItem(.sessions)
+        }
+        persistHiddenSources()
+    }
+
+    func hideSourceHost(_ host: String) {
+        if Self.isDomainName(host) {
+            hideSourceDomain(host)
+        } else {
+            hideSourceIP(host)
+        }
+    }
+
+    func restoreHiddenSourceApps() {
+        hiddenSourceApps.removeAll()
+        persistHiddenSources()
+    }
+
+    func restoreHiddenSourceDomains() {
+        hiddenSourceDomains.removeAll()
+        persistHiddenSources()
+    }
+
+    func restoreHiddenSourceIPs() {
+        hiddenSourceIPs.removeAll()
+        persistHiddenSources()
+    }
+
+    private func persistHiddenSources() {
+        SourceVisibilityPreferences.persist(
+            apps: hiddenSourceApps,
+            domains: hiddenSourceDomains,
+            ips: hiddenSourceIPs
+        )
+    }
+}
+
+// MARK: - SourceVisibilityPreferences
+
+enum SourceVisibilityPreferences {
+    // MARK: Internal
+
+    static func loadApps() -> Set<String> {
+        load(key: appsKey)
+    }
+
+    static func loadDomains() -> Set<String> {
+        load(key: domainsKey)
+    }
+
+    static func loadIPs() -> Set<String> {
+        load(key: ipsKey)
+    }
+
+    static func persist(apps: Set<String>, domains: Set<String>, ips: Set<String>) {
+        UserDefaults.standard.set(apps.sorted(), forKey: appsKey)
+        UserDefaults.standard.set(domains.sorted(), forKey: domainsKey)
+        UserDefaults.standard.set(ips.sorted(), forKey: ipsKey)
+    }
+
+    // MARK: Private
+
+    private static let appsKey = TracexyIdentity.current.defaultsKey("sources.hiddenApps")
+    private static let domainsKey = TracexyIdentity.current.defaultsKey("sources.hiddenDomains")
+    private static let ipsKey = TracexyIdentity.current.defaultsKey("sources.hiddenIPs")
+
+    private static func load(key: String) -> Set<String> {
+        Set(UserDefaults.standard.stringArray(forKey: key) ?? [])
+    }
+}

--- a/Tracexy/ViewModels/MainContentCoordinator.swift
+++ b/Tracexy/ViewModels/MainContentCoordinator.swift
@@ -198,6 +198,15 @@ final class MainContentCoordinator {
     /// Protocols muted from the session list.
     private(set) var mutedProtocols: Set<ProtocolKind> = MainContentCoordinator.loadMutedProtocols()
 
+    // MARK: Source visibility
+
+    /// Source rows the user removed from the Browse sidebar. This is presentation
+    /// state only: captured sessions and packet evidence remain untouched and can
+    /// still be found from Sessions. Each category can restore its hidden rows.
+    var hiddenSourceApps = SourceVisibilityPreferences.loadApps()
+    var hiddenSourceDomains = SourceVisibilityPreferences.loadDomains()
+    var hiddenSourceIPs = SourceVisibilityPreferences.loadIPs()
+
     /// Complete local raw-frame retention for save/export. The in-memory frame
     /// window remains bounded independently for responsive UI.
     let liveCaptureSpool = LiveCaptureSpool(
@@ -599,6 +608,18 @@ final class MainContentCoordinator {
         return directory
     }
 
+    /// A host is a domain name (not a bare IPv4/IPv6 literal).
+    static func isDomainName(_ host: String) -> Bool {
+        if host.contains(":") {
+            return false // IPv6 literal
+        }
+        let parts = host.split(separator: ".")
+        if parts.count == 4, parts.allSatisfy({ UInt8($0) != nil }) {
+            return false // IPv4 literal
+        }
+        return host.contains(".") && host.contains { $0.isLetter }
+    }
+
     func setSessionExporting(_ isExporting: Bool) {
         isExportingSession = isExporting
     }
@@ -771,11 +792,6 @@ final class MainContentCoordinator {
         if let imported = savedCaptures.first(where: { $0.url == destination }) {
             openSavedCapture(imported)
         }
-    }
-
-    func deleteSavedCapture(_ capture: SavedCapture) {
-        try? FileManager.default.removeItem(at: capture.url)
-        refreshSavedCaptures()
     }
 
     /// Rescans the captures folder and rebuilds `savedCaptures`, newest first.
@@ -1150,18 +1166,6 @@ final class MainContentCoordinator {
     private static func loadMutedProtocols() -> Set<ProtocolKind> {
         let raw = UserDefaults.standard.stringArray(forKey: mutedProtocolsKey) ?? []
         return Set(raw.compactMap(ProtocolKind.init(rawValue:)))
-    }
-
-    /// A host is a domain name (not a bare IPv4/IPv6 literal).
-    private static func isDomainName(_ host: String) -> Bool {
-        if host.contains(":") {
-            return false // IPv6 literal
-        }
-        let parts = host.split(separator: ".")
-        if parts.count == 4, parts.allSatisfy({ UInt8($0) != nil }) {
-            return false // IPv4 literal
-        }
-        return host.contains(".") && host.contains { $0.isLetter }
     }
 
     /// The IP portion of an "ip:port" endpoint (handles IPv6's inner colons).

--- a/Tracexy/ViewModels/MainContentCoordinator.swift
+++ b/Tracexy/ViewModels/MainContentCoordinator.swift
@@ -207,6 +207,13 @@ final class MainContentCoordinator {
     var hiddenSourceDomains = SourceVisibilityPreferences.loadDomains()
     var hiddenSourceIPs = SourceVisibilityPreferences.loadIPs()
 
+    /// Session rows removed from the current capture's presentation. This is
+    /// deliberately capture-scoped and reversible: packet evidence and the
+    /// save/export source stay intact, while every UI-derived surface reads
+    /// ``presentedSessions`` so a removed sensitive row cannot reappear in an
+    /// Overview rollup, Flow Map, Sources, finding, or related-session card.
+    var removedSessionIDs: Set<UUID> = []
+
     /// Complete local raw-frame retention for save/export. The in-memory frame
     /// window remains bounded independently for responsive UI.
     let liveCaptureSpool = LiveCaptureSpool(
@@ -272,7 +279,7 @@ final class MainContentCoordinator {
         // not once per session.
         let preparedRules = SessionFilterRuleEvaluator.prepared(advancedRules)
 
-        return sessions.filter { session in
+        return presentedSessions.filter { session in
             // Noise Control (sidebar Focus) hides muted hosts/protocols everywhere.
             if mutedHosts.contains(session.host) {
                 return false
@@ -313,17 +320,17 @@ final class MainContentCoordinator {
         guard let id = activeWorkspace.selectedSessionID else {
             return nil
         }
-        return sessions.first { $0.id == id }
+        return presentedSessions.first { $0.id == id }
     }
 
     // MARK: Dashboard rollups
 
     var errorCount: Int {
-        sessions.filter { $0.status == .error }.count
+        presentedSessions.filter { $0.status == .error }.count
     }
 
     var warningCount: Int {
-        sessions.filter { $0.status == .warning }.count
+        presentedSessions.filter { $0.status == .warning }.count
     }
 
     /// Severity-ranked findings across the whole capture, derived only from real
@@ -332,7 +339,7 @@ final class MainContentCoordinator {
     /// display, so a filtered list and its findings summary never disagree.
     var findings: [Finding] {
         var result: [Finding] = []
-        for session in sessions {
+        for session in presentedSessions {
             if result.count >= Self.maxFindings {
                 break
             }
@@ -402,7 +409,7 @@ final class MainContentCoordinator {
     /// to (the "sub-IPs"), for the sidebar "Domains" tree — sibling-app-style.
     var domainGroups: [DomainGroup] {
         var byDomain: [String: (ips: Set<String>, count: Int)] = [:]
-        for session in sessions where Self.isDomainName(session.host) {
+        for session in presentedSessions where Self.isDomainName(session.host) {
             var entry = byDomain[session.host] ?? (ips: [], count: 0)
             entry.count += 1
             for answer in session.dnsAnswers where !answer.hasPrefix("CNAME") {
@@ -427,7 +434,7 @@ final class MainContentCoordinator {
     /// (the "sub-links"), for an expandable sidebar "Apps" tree — sibling-app-style.
     var appGroups: [AppGroup] {
         var byApp: [String: (hosts: Set<String>, count: Int)] = [:]
-        for session in sessions {
+        for session in presentedSessions {
             let app = session.processName ?? "—"
             var entry = byApp[app] ?? (hosts: [], count: 0)
             entry.count += 1
@@ -458,26 +465,26 @@ final class MainContentCoordinator {
             return "capture error — \(captureError)"
         }
         if isCapturing {
-            return "\(captureInterface) · live · \(sessions.count.formatted()) sessions"
+            return "\(captureInterface) · live · \(presentedSessions.count.formatted()) sessions"
         }
         if sessions.isEmpty {
             return "idle — press Start to capture"
         }
-        return "\(sessions.count.formatted()) sessions"
+        return "\(presentedSessions.count.formatted()) sessions"
     }
 
     // MARK: Aggregate rollups (status bar)
 
     var totalBytes: Int {
-        sessions.reduce(0) { $0 + $1.totalBytes }
+        presentedSessions.reduce(0) { $0 + $1.totalBytes }
     }
 
     var totalBytesUp: Int {
-        sessions.reduce(0) { $0 + $1.bytesUp }
+        presentedSessions.reduce(0) { $0 + $1.bytesUp }
     }
 
     var totalBytesDown: Int {
-        sessions.reduce(0) { $0 + $1.bytesDown }
+        presentedSessions.reduce(0) { $0 + $1.bytesDown }
     }
 
     // MARK: Saved captures
@@ -499,7 +506,7 @@ final class MainContentCoordinator {
     var presentProtocols: [ProtocolKind] {
         var seen = Set<ProtocolKind>()
         var ordered: [ProtocolKind] = []
-        for session in sessions {
+        for session in presentedSessions {
             let proto = session.primaryProtocol
             if seen.insert(proto).inserted {
                 ordered.append(proto)
@@ -636,7 +643,7 @@ final class MainContentCoordinator {
     /// this slice anyway, so the narrower input costs no accuracy.
     func activity(containing session: SessionSummary) -> Activity? {
         let window = ActivityBuilder.dnsCausalWindow
-        let slice = sessions.filter {
+        let slice = presentedSessions.filter {
             abs($0.startTime.timeIntervalSince(session.startTime)) <= window
         }
         guard slice.count > 1 else {
@@ -755,6 +762,7 @@ final class MainContentCoordinator {
             captureStatistics = nil
             helperBufferDropCount = 0
             retainedFrames.replace(with: parsed.frames)
+            removedSessionIDs.removeAll()
             sessions = SessionBuilder.build(from: parsed.frames, linkType: parsed.linkType)
             isViewingSavedCapture = true
             // Remember which file this is and aggregate its activity once, here at
@@ -885,6 +893,7 @@ final class MainContentCoordinator {
         captureStatistics = nil
         helperBufferDropCount = 0
         retainedFrames.reset()
+        removedSessionIDs.removeAll()
         sessions = []
         throughputSamples = []
         pendingChartBytes = 0
@@ -1021,6 +1030,7 @@ final class MainContentCoordinator {
         // bounds memory only — sessions accumulate independently (see
         // ``retainedFrameLimit``).
         retainedFrames = RetainedFrameBuffer(capacity: CaptureSettingsResolver.retainCapacity())
+        removedSessionIDs.removeAll()
         sessions = []
         throughputSamples = []
         pendingChartBytes = 0
@@ -1623,7 +1633,7 @@ private extension MainContentCoordinator {
             if self.activeWorkspace.autoSelectLatest,
                // Newest by timestamp, tie-broken by id so the choice never depends
                // on the array's (first-seen) order.
-               let latest = applied.max(by: {
+               let latest = applied.lazy.filter({ !self.removedSessionIDs.contains($0.id) }).max(by: {
                    ($0.startTime, $0.id.uuidString) < ($1.startTime, $1.id.uuidString)
                }),
                self.activeWorkspace.selectedSessionID != latest.id
@@ -1666,7 +1676,7 @@ private extension MainContentCoordinator {
 
     private func groupCounts(_ key: (SessionSummary) -> String) -> [(name: String, count: Int)] {
         var totals: [String: Int] = [:]
-        for session in sessions {
+        for session in presentedSessions {
             totals[key(session), default: 0] += 1
         }
         return totals.sorted { $0.value > $1.value }.map { (name: $0.key, count: $0.value) }

--- a/Tracexy/ViewModels/MainContentCoordinator.swift
+++ b/Tracexy/ViewModels/MainContentCoordinator.swift
@@ -606,6 +606,24 @@ final class MainContentCoordinator {
         revealPanelsForSelection()
     }
 
+    // MARK: Search
+
+    /// ⌘F: bring the user to the session search box and put the cursor in it.
+    ///
+    /// Routes to the Sessions surface if they are elsewhere, reveals the filter
+    /// bar, and switches the search on — the three states the box needs to be
+    /// usable — then bumps a focus token the existing field observes. It does
+    /// *not* touch the query text or any active filter (host/process/IP drill-down,
+    /// category chips, advanced rules), so an in-progress investigation is
+    /// preserved; ⌘F only reveals and focuses the box that is already there.
+    func beginSessionSearch() {
+        let ws = activeWorkspace
+        ws.sidebarSelection = .sessions
+        ws.isFilterBarVisible = true
+        ws.isSearchEnabled = true
+        ws.searchFocusRequest = UUID()
+    }
+
     // MARK: Sidebar selection
 
     /// Selects a top-level sidebar item, clearing any host/process/IP drill-down.

--- a/Tracexy/ViewModels/MainContentCoordinator.swift
+++ b/Tracexy/ViewModels/MainContentCoordinator.swift
@@ -156,6 +156,20 @@ final class MainContentCoordinator {
     /// live one (so the UI can label it and Start replaces it).
     var isViewingSavedCapture = false
 
+    /// The saved file currently open in this workspace, or `nil` during a live
+    /// capture or an idle session. Held so the Overview can label the file
+    /// truthfully (name, format, size, provenance) instead of guessing. Cleared at
+    /// every live/new/clear boundary so a stale file identity can never outlive the
+    /// capture it described.
+    private(set) var activeSavedCapture: SavedCapture?
+
+    /// Bounded, deterministic frames-over-time aggregation for the open saved
+    /// capture, computed once at open/import and cached here. `nil` for live and
+    /// idle captures. Derived from real frame timestamps/lengths behind this seam,
+    /// so the Overview chart draws from per-bucket totals and never re-scans frames
+    /// or receives packet bytes.
+    private(set) var savedCaptureActivity: CaptureActivity?
+
     /// Link type of the current capture, needed to write a faithful `.pcap`.
     var currentLinkType: UInt32 = LinkType.ethernet
 
@@ -184,6 +198,26 @@ final class MainContentCoordinator {
     /// buffer so there is a single source of truth for the count.
     var retainedFrameEvictionCount: UInt64 {
         retainedFrames.evictionCount
+    }
+
+    /// Raw frames currently held for save/export. Distinct from the session count:
+    /// this is only the recent tail kept in memory, bounded by
+    /// ``retainedFrameLimit``. Surfaced as retention state, never as capture loss.
+    var retainedFrameCount: Int {
+        retainedFrames.count
+    }
+
+    /// The retention window's capacity — the denominator in the Overview's
+    /// "N / capacity frames" retention readout.
+    var retainedFrameCapacity: Int {
+        Self.retainedFrameLimit
+    }
+
+    /// Sum of the captured lengths of the retained frames — the payload bytes a
+    /// `.pcap` save would write. Used only to estimate a save size; it is neither
+    /// capture fidelity nor total captured traffic.
+    var retainedCapturedByteCount: Int {
+        retainedFrames.capturedByteCount
     }
 
     /// All sessions decoded from the current capture's real frames.
@@ -264,29 +298,10 @@ final class MainContentCoordinator {
         sessions.filter { $0.status == .warning }.count
     }
 
-    /// Rollups below describe **what the user is currently looking at**, so they
-    /// are computed over `visibleSessions` rather than every decoded session.
-    /// Reporting capture-wide totals beside a filtered list is a contradiction
-    /// the user cannot resolve: the list says 40 rows, the summary says 1,284,
-    /// and nothing on screen explains the gap.
-    var medianLatencyMilliseconds: Double? {
-        let values = visibleSessions.compactMap(\.latencyMilliseconds).sorted()
-        guard !values.isEmpty else {
-            return nil
-        }
-        return values[values.count / 2]
-    }
-
-    /// 95th-percentile latency — the slow tail Overview reports next to the median.
-    var p95LatencyMilliseconds: Double? {
-        let values = visibleSessions.compactMap(\.latencyMilliseconds).sorted()
-        guard !values.isEmpty else {
-            return nil
-        }
-        let index = min(values.count - 1, Int((Double(values.count) * 0.95).rounded(.down)))
-        return values[index]
-    }
-
+    /// Severity-ranked findings across the whole capture, derived only from real
+    /// decoded signals (status, plaintext HTTP, empty DNS answers, high DNS
+    /// response time). The Overview scopes these to the active filter before
+    /// display, so a filtered list and its findings summary never disagree.
     var findings: [Finding] {
         var result: [Finding] = []
         for session in sessions {
@@ -323,10 +338,14 @@ final class MainContentCoordinator {
                 ))
             }
             if let latency = session.latencyMilliseconds, latency > 400 {
+                // `latencyMilliseconds` is the DNS query→response time only (see
+                // `SessionAccumulator`), so the finding names that specifically
+                // rather than claiming a general network-latency figure we do not
+                // measure.
                 result.append(Finding(
                     severity: .note,
-                    title: "High latency (\(Int(latency)) ms)",
-                    subtitle: session.host,
+                    title: "High DNS response time",
+                    subtitle: "\(Int(latency)) ms to resolve \(session.host)",
                     sessionID: session.id
                 ))
             }
@@ -693,6 +712,12 @@ final class MainContentCoordinator {
             retainedFrames.replace(with: parsed.frames)
             sessions = SessionBuilder.build(from: parsed.frames, linkType: parsed.linkType)
             isViewingSavedCapture = true
+            // Remember which file this is and aggregate its activity once, here at
+            // the open boundary, so the Overview can label the file truthfully and
+            // draw its frames-over-time chart without re-scanning frames on every
+            // body update.
+            activeSavedCapture = capture
+            savedCaptureActivity = CaptureActivityBuilder.build(frames: parsed.frames)
             captureError = nil
             activeWorkspace.selectedSessionID = nil
             selectSidebarItem(.sessions)
@@ -821,6 +846,8 @@ final class MainContentCoordinator {
         throughputSamples = []
         pendingChartBytes = 0
         isViewingSavedCapture = false
+        activeSavedCapture = nil
+        savedCaptureActivity = nil
         activeWorkspace.selectedSessionID = nil
     }
 
@@ -929,6 +956,8 @@ final class MainContentCoordinator {
         isStarting = true
         startGeneration &+= 1
         isViewingSavedCapture = false
+        activeSavedCapture = nil
+        savedCaptureActivity = nil
         retainedFrames.reset()
         sessions = []
         throughputSamples = []

--- a/Tracexy/ViewModels/MainContentCoordinator.swift
+++ b/Tracexy/ViewModels/MainContentCoordinator.swift
@@ -75,15 +75,22 @@ final class MainContentCoordinator {
     /// bounded on a long-running capture.
     static let maxCorrelatedSessions = 5_000
 
-    /// How many raw frames are retained for save/export.
+    /// How many recent raw frames are retained for immediate UI inspection.
     ///
     /// This is a bound on *memory*, not on capture fidelity. Sessions accumulate
     /// incrementally in `LiveSessionEngine` and do not depend on this window, so
-    /// evicting an old raw frame here never drops a session or forces a re-decode
-    /// of history — it leaves only the recent tail available to a `.pcap` save. Every
-    /// eviction is counted in `retainedFrameEvictionCount`, and that count is a
-    /// UI-side figure that must never be presented as kernel/interface loss.
+    /// evicting an old raw frame here never drops a session, truncates a saved
+    /// capture, or forces a re-decode of history. Complete live capture bytes are
+    /// written independently to ``LiveCaptureSpool``. Every memory-window eviction
+    /// is counted in `retainedFrameEvictionCount`, and that count is a UI-side
+    /// figure that must never be presented as kernel/interface loss.
     static let retainedFrameLimit = 8_000
+
+    static let fileStampFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd HH.mm.ss"
+        return formatter
+    }()
 
     /// The capacity limits this build runs under. Held so the views that need
     /// to *show* a limit can read it; nothing reads it to decide behaviour —
@@ -170,7 +177,7 @@ final class MainContentCoordinator {
     /// or receives packet bytes.
     private(set) var savedCaptureActivity: CaptureActivity?
 
-    /// Link type of the current capture, needed to write a faithful `.pcap`.
+    /// Link type of the current capture, needed for faithful decode and capture-file export.
     var currentLinkType: UInt32 = LinkType.ethernet
 
     /// Shared privileged-helper manager (install/version/update/uninstall).
@@ -191,16 +198,27 @@ final class MainContentCoordinator {
     /// Protocols muted from the session list.
     private(set) var mutedProtocols: Set<ProtocolKind> = MainContentCoordinator.loadMutedProtocols()
 
-    /// Cumulative frames dropped from the *local* raw-retention window (kept only
-    /// for save/export; see ``retainedFrameLimit``). This is a UI-side memory
-    /// bound, never kernel/interface loss, and must never be surfaced as capture
-    /// fidelity. Sessions are unaffected by it. Read straight off the retention
-    /// buffer so there is a single source of truth for the count.
+    /// Complete local raw-frame retention for save/export. The in-memory frame
+    /// window remains bounded independently for responsive UI.
+    let liveCaptureSpool = LiveCaptureSpool(
+        directoryName: TracexyIdentity.current.appSupportDirectoryName
+    )
+    /// Serializes engine access so batches fold in arrival order even though each
+    /// call hops onto the engine actor, and so a boundary reset is ordered ahead
+    /// of the ingests that follow it.
+    var ingestChain: Task<Void, Never>?
+    /// Bounded FIFO window of raw frames kept for immediate UI state. Complete
+    /// save/export reads the disk-backed spool instead.
+    var retainedFrames = RetainedFrameBuffer(capacity: MainContentCoordinator.retainedFrameLimit)
+
+    /// Cumulative frames evicted from the local in-memory inspection window. This
+    /// is a UI memory bound, never kernel/interface loss; sessions and the complete
+    /// disk-backed save/export spool are unaffected.
     var retainedFrameEvictionCount: UInt64 {
         retainedFrames.evictionCount
     }
 
-    /// Raw frames currently held for save/export. Distinct from the session count:
+    /// Raw frames currently held for immediate UI inspection. Distinct from the session count:
     /// this is only the recent tail kept in memory, bounded by
     /// ``retainedFrameLimit``. Surfaced as retention state, never as capture loss.
     var retainedFrameCount: Int {
@@ -208,13 +226,14 @@ final class MainContentCoordinator {
     }
 
     /// The retention window's capacity — the denominator in the Overview's
-    /// "N / capacity frames" retention readout.
+    /// "N / capacity frames" retention readout. Reads the live buffer so it
+    /// reflects the configured "Retain up to" size a running capture adopted.
     var retainedFrameCapacity: Int {
-        Self.retainedFrameLimit
+        retainedFrames.capacity
     }
 
-    /// Sum of the captured lengths of the retained frames — the payload bytes a
-    /// `.pcap` save would write. Used only to estimate a save size; it is neither
+    /// Sum of the captured lengths in the in-memory window. Used only as a bounded
+    /// live-buffer estimate; it is neither
     /// capture fidelity nor total captured traffic.
     var retainedCapturedByteCount: Int {
         retainedFrames.capturedByteCount
@@ -568,10 +587,16 @@ final class MainContentCoordinator {
         focusGate.canInsertFocusSet(into: focusSets)
     }
 
-    /// Read-only copy used by the session-export extension before it leaves the
-    /// main actor to scope and serialize packet data.
-    var retainedFrameSnapshotForExport: [CapturedFrame] {
-        retainedFrames.frames
+    /// `~/Library/Application Support/<bundle id>/Captures`, created on demand.
+    static func capturesDirectory() -> URL? {
+        guard let base = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first else {
+            return nil
+        }
+        let directory = base
+            .appendingPathComponent(TracexyIdentity.current.appBundleIdentifier, isDirectory: true)
+            .appendingPathComponent("Captures", isDirectory: true)
+        try? FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        return directory
     }
 
     func setSessionExporting(_ isExporting: Bool) {
@@ -688,25 +713,6 @@ final class MainContentCoordinator {
         UserDefaults.standard.set(pinnedHosts, forKey: Self.pinnedHostsKey)
     }
 
-    /// Writes the retained frames to a timestamped `.pcap` under Application Support,
-    /// then refreshes the saved list. Returns the new file (nil if nothing to save).
-    @discardableResult
-    func saveCurrentCapture() -> SavedCapture? {
-        guard !retainedFrames.isEmpty, let directory = Self.capturesDirectory() else {
-            return nil
-        }
-        let stamp = Self.fileStampFormatter.string(from: Date())
-        let url = directory.appendingPathComponent("Capture \(stamp).pcap")
-        do {
-            try PcapWriter.write(linkType: currentLinkType, frames: retainedFrames.frames, to: url)
-        } catch {
-            captureError = "Couldn’t save capture: \(error.localizedDescription)"
-            return nil
-        }
-        refreshSavedCaptures()
-        return savedCaptures.first { $0.url == url }
-    }
-
     /// Loads a saved `.pcap`/`.pcapng` into the session list (read-only) and stops live.
     func openSavedCapture(_ capture: SavedCapture) {
         do {
@@ -744,23 +750,26 @@ final class MainContentCoordinator {
         }
     }
 
-    /// Imports an external `.pcap` file: copies it into the captures folder and opens it.
+    /// Imports an external `.pcap` file into the captures folder and opens it.
+    ///
+    /// Lossless and idempotent: a source that is already the managed file is
+    /// refreshed and reopened in place, and a name collision with a different
+    /// external file replaces the old copy only after the new one is fully
+    /// staged, so a failed import never destroys existing capture data.
     func importCapture(from source: URL) {
         guard let directory = Self.capturesDirectory() else {
             return
         }
-        let destination = directory.appendingPathComponent(source.lastPathComponent)
+        let destination: URL
         do {
-            if FileManager.default.fileExists(atPath: destination.path) {
-                try FileManager.default.removeItem(at: destination)
-            }
-            try FileManager.default.copyItem(at: source, to: destination)
-            refreshSavedCaptures()
-            if let imported = savedCaptures.first(where: { $0.url == destination }) {
-                openSavedCapture(imported)
-            }
+            destination = try CaptureImporter.importCapture(from: source, intoDirectory: directory)
         } catch {
             captureError = "Couldn’t import “\(source.lastPathComponent)”: \(error.localizedDescription)"
+            return
+        }
+        refreshSavedCaptures()
+        if let imported = savedCaptures.first(where: { $0.url == destination }) {
+            openSavedCapture(imported)
         }
     }
 
@@ -970,13 +979,32 @@ final class MainContentCoordinator {
         guard !isStarting else {
             return
         }
+        // Read the current Capture-Settings preferences fresh at each start and map
+        // them to a validated, bounded configuration (interface, snap length,
+        // promiscuous mode, optional BPF). An invalid custom filter — or any
+        // out-of-bounds value — surfaces here, before any capture backend is asked
+        // to start, rather than failing silently mid-capture.
+        let resolvedConfiguration = CaptureSettingsResolver.configuration(interface: captureInterface)
+        let configuration: CaptureConfiguration
+        switch resolvedConfiguration.validated() {
+        case let .success(valid):
+            configuration = valid
+        case let .failure(error):
+            captureError = "Capture couldn’t start — \(error.message)"
+            return
+        }
+        activeCaptureConfiguration = configuration
         captureError = nil
         isStarting = true
         startGeneration &+= 1
         isViewingSavedCapture = false
         activeSavedCapture = nil
         savedCaptureActivity = nil
-        retainedFrames.reset()
+        // Size the in-memory inspection window from the configured
+        // "Retain up to" preference, resetting it to a clean, zeroed window. This
+        // bounds memory only — sessions accumulate independently (see
+        // ``retainedFrameLimit``).
+        retainedFrames = RetainedFrameBuffer(capacity: CaptureSettingsResolver.retainCapacity())
         sessions = []
         throughputSamples = []
         pendingChartBytes = 0
@@ -991,11 +1019,11 @@ final class MainContentCoordinator {
         if [.overview, .saved].contains(activeWorkspace.sidebarSelection) {
             selectSidebarItem(.sessions)
         }
-        // Dev fast path: bypass the signed helper and capture straight through
-        // libpcap. The helper needs one-time Login-Items approval; a dev build
-        // launched by `scripts/run.sh` (which passes `--direct-capture`) instead
-        // opens /dev/bpf directly — which works whenever the user can access BPF
-        // (e.g. a member of the ChmodBPF / access_bpf group). No sudo, no approval.
+        // Explicit development fast path: bypass the signed helper and capture
+        // straight through libpcap. `scripts/run.sh -d` opts into this mode; the
+        // default script path remains production-shaped and exercises the helper.
+        // Direct mode works whenever the user can access a free BPF device (for
+        // example through ChmodBPF / access_bpf). No sudo or helper approval.
         if Self.forceDirectCapture {
             startDirect()
             return
@@ -1066,12 +1094,6 @@ final class MainContentCoordinator {
 
     private static let pinnedHostsKey = TracexyIdentity.current.defaultsKey("pinnedHosts")
 
-    private static let fileStampFormatter: DateFormatter = {
-        let formatter = DateFormatter()
-        formatter.dateFormat = "yyyy-MM-dd HH.mm.ss"
-        return formatter
-    }()
-
     // MARK: Focus / Noise persistence
 
     private static let focusSetsKey = TracexyIdentity.current.defaultsKey("focusSets")
@@ -1085,16 +1107,13 @@ final class MainContentCoordinator {
     /// Off-main incremental session engine: decodes and groups each captured frame
     /// exactly once, so the main actor never re-decodes retained history.
     private let sessionEngine = LiveSessionEngine()
-    /// Serializes engine access so batches fold in arrival order even though each
-    /// call hops onto the engine actor, and so a boundary reset is ordered ahead
-    /// of the ingests that follow it.
-    private var ingestChain: Task<Void, Never>?
     private var lastSessionsUpdate = Date.distantPast
     private var pendingChartBytes = 0
-    /// Bounded FIFO window of raw frames kept only for save/export. Independent of
-    /// session accumulation — evicting here never drops a session — and its
-    /// cumulative eviction count is surfaced only as retention truncation.
-    private var retainedFrames = RetainedFrameBuffer(capacity: MainContentCoordinator.retainedFrameLimit)
+
+    /// The validated configuration for the capture currently starting/running,
+    /// built from the live Capture-Settings preferences at ``startCapture()`` and
+    /// consumed by both the direct and helper backends so neither re-reads defaults.
+    private var activeCaptureConfiguration: CaptureConfiguration?
 
     private var pollTimer: Timer?
     /// Bumped every time a start attempt begins or ends. A late helper reply or a
@@ -1131,18 +1150,6 @@ final class MainContentCoordinator {
     private static func loadMutedProtocols() -> Set<ProtocolKind> {
         let raw = UserDefaults.standard.stringArray(forKey: mutedProtocolsKey) ?? []
         return Set(raw.compactMap(ProtocolKind.init(rawValue:)))
-    }
-
-    /// `~/Library/Application Support/<bundle id>/Captures`, created on demand.
-    private static func capturesDirectory() -> URL? {
-        guard let base = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first else {
-            return nil
-        }
-        let directory = base
-            .appendingPathComponent(TracexyIdentity.current.appBundleIdentifier, isDirectory: true)
-            .appendingPathComponent("Captures", isDirectory: true)
-        try? FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
-        return directory
     }
 
     /// A host is a domain name (not a bare IPv4/IPv6 literal).
@@ -1297,9 +1304,13 @@ final class MainContentCoordinator {
 
 private extension MainContentCoordinator {
     func startViaHelper(token: Int) {
+        guard let configuration = activeCaptureConfiguration else {
+            handleCaptureError("Capture configuration was unavailable.")
+            return
+        }
         do {
             let proxy = try helper.proxy()
-            proxy.startCapture(interface: captureInterface) { [weak self] started, message in
+            proxy.startCapture(configuration: configuration) { [weak self] started, message in
                 Task { @MainActor in
                     guard let self, self.startGeneration == token else {
                         return
@@ -1446,31 +1457,36 @@ private extension MainContentCoordinator {
             isStarting = false
             return
         }
+        guard let configuration = activeCaptureConfiguration else {
+            handleCaptureError("Capture configuration was unavailable.")
+            return
+        }
+        // Open + compile the filter synchronously so a bad snap length or BPF fails
+        // before the capture is reported started, rather than after.
+        do {
+            try live.start(
+                configuration: configuration,
+                onBatch: { [weak self] frames, linkType in
+                    guard let coordinator = self else {
+                        return
+                    }
+                    Task { @MainActor in coordinator.ingest(frames, linkType: linkType) }
+                },
+                onStatistics: { [weak self] sample in
+                    guard let coordinator = self else {
+                        return
+                    }
+                    Task { @MainActor in coordinator.captureStatistics = sample }
+                }
+            )
+        } catch {
+            handleCaptureError((error as? LiveCapture.Failure)?.message ?? error.localizedDescription)
+            return
+        }
         isCapturing = true
         isStarting = false
         captureStartedAt = Date()
         captureStatistics = nil
-        live.start(
-            interface: captureInterface,
-            onBatch: { [weak self] frames, linkType in
-                guard let coordinator = self else {
-                    return
-                }
-                Task { @MainActor in coordinator.ingest(frames, linkType: linkType) }
-            },
-            onError: { [weak self] message in
-                guard let coordinator = self else {
-                    return
-                }
-                Task { @MainActor in coordinator.handleCaptureError(message) }
-            },
-            onStatistics: { [weak self] sample in
-                guard let coordinator = self else {
-                    return
-                }
-                Task { @MainActor in coordinator.captureStatistics = sample }
-            }
-        )
     }
 
     private func ingest(_ frames: [CapturedFrame], linkType: UInt32) {
@@ -1501,6 +1517,15 @@ private extension MainContentCoordinator {
         let previous = ingestChain
         ingestChain = Task { @MainActor in
             await previous?.value
+            do {
+                try await self.liveCaptureSpool.append(frames, defaultLinkType: linkType, epoch: token)
+            } catch {
+                self.captureError = "Capture stopped: the local spool failed — \(error.localizedDescription). "
+                    + "Frames written before the failure remain available to save."
+                if self.isCapturing {
+                    self.stopCapture()
+                }
+            }
             await self.sessionEngine.ingest(frames, linkType: linkType, epoch: token)
             guard shouldSnapshot,
                   self.startGeneration == token,
@@ -1528,6 +1553,16 @@ private extension MainContentCoordinator {
         let previous = ingestChain
         ingestChain = Task { @MainActor in
             await previous?.value
+            do {
+                try await self.liveCaptureSpool.append(
+                    frames,
+                    defaultLinkType: linkType,
+                    epoch: captureToken
+                )
+            } catch {
+                self.captureError = "Capture stopped: the local spool failed — \(error.localizedDescription). "
+                    + "Frames written before the failure remain available to save."
+            }
             await self.sessionEngine.ingest(frames, linkType: linkType, epoch: captureToken)
             guard self.startGeneration == stoppedToken,
                   !self.isCapturing,
@@ -1543,7 +1578,7 @@ private extension MainContentCoordinator {
         }
     }
 
-    /// Stage raw frames for save/export within a bounded window. The window and
+    /// Stage recent raw frames for UI inspection within a bounded window. The window and
     /// its saturating eviction count live in ``RetainedFrameBuffer``; this is a
     /// thin hop so the ingest path reads clearly. Independent of session
     /// accumulation — see ``retainedFrameLimit``.
@@ -1599,8 +1634,16 @@ private extension MainContentCoordinator {
     /// work carries the previous token and is dropped by the engine's epoch guard.
     private func resetSessionEngine(token: Int) {
         let engine = sessionEngine
+        let spool = liveCaptureSpool
+        let previous = ingestChain
         ingestChain = Task { @MainActor in
+            await previous?.value
             await engine.reset(epoch: token)
+            do {
+                try await spool.reset(epoch: token)
+            } catch {
+                self.captureError = "Capture spool unavailable — \(error.localizedDescription)"
+            }
         }
     }
 
@@ -1649,7 +1692,7 @@ enum CaptureDisplayState {
 
 // MARK: - SavedCapture
 
-/// One saved `.pcap` file on disk, listed under the sidebar's "Saved Captures".
+/// One saved `.pcap` or `.pcapng` file on disk, listed under the sidebar's "Saved Captures".
 struct SavedCapture: Identifiable, Hashable {
     let url: URL
     let name: String

--- a/Tracexy/Views/Inspector/ContextDockView.swift
+++ b/Tracexy/Views/Inspector/ContextDockView.swift
@@ -611,7 +611,7 @@ struct ContextDockView: View {
     /// selected session marked so the sparkline can call it out.
     private func baselineHistory(for session: SessionSummary) -> [BaselinePoint] {
         let cutoff = session.startTime.addingTimeInterval(-3_600)
-        return coordinator.sessions
+        return coordinator.presentedSessions
             .filter { $0.host == session.host && $0.startTime >= cutoff }
             .sorted { $0.startTime < $1.startTime }
             .compactMap { peer in
@@ -649,8 +649,8 @@ struct ContextDockView: View {
     /// Peers worth offering: the same host first, then the same process. Capped —
     /// this is a navigation aid, not a second session list.
     private func relatedSessions(for session: SessionSummary) -> [SessionSummary] {
-        let sameHost = coordinator.sessions.filter { $0.id != session.id && $0.host == session.host }
-        let sameProcess = coordinator.sessions.filter {
+        let sameHost = coordinator.presentedSessions.filter { $0.id != session.id && $0.host == session.host }
+        let sameProcess = coordinator.presentedSessions.filter {
             $0.id != session.id
                 && $0.host != session.host
                 && $0.processName != nil
@@ -664,7 +664,7 @@ struct ContextDockView: View {
     }
 
     private func peerLatencies(for session: SessionSummary) -> [Double] {
-        coordinator.sessions
+        coordinator.presentedSessions
             .filter { $0.host == session.host }
             .compactMap(\.latencyMilliseconds)
     }

--- a/Tracexy/Views/Inspector/DecodedClipboardText.swift
+++ b/Tracexy/Views/Inspector/DecodedClipboardText.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+// MARK: - DecodedClipboardText
+
+/// Pure, side-effect-free clipboard formatting for the decode tree's contextual
+/// copy actions. Kept out of the view so the exact text each menu item produces
+/// is unit-testable, and so the view is left with only the pasteboard call.
+///
+/// Every string here is derived solely from values already present on the
+/// decoded `DecodedField`/`DecodedLayer` — nothing is inferred, fetched, or
+/// fabricated. Names and values are emitted verbatim.
+enum DecodedClipboardText {
+    /// A field's value alone (the "Copy Value" action).
+    static func value(_ field: DecodedField) -> String {
+        field.value
+    }
+
+    /// A field's name alone (the "Copy Field Name" action).
+    static func name(_ field: DecodedField) -> String {
+        field.name
+    }
+
+    /// A field as `Name: Value`, the form most useful to paste into notes or a
+    /// bug report (the `Copy "Name: Value"` action).
+    static func nameValue(_ field: DecodedField) -> String {
+        "\(field.name): \(field.value)"
+    }
+
+    /// The layer header exactly as shown in the tree: its title, plus the summary
+    /// when one is present. Field values keep their own deliberate copy actions.
+    static func layerSummary(_ layer: DecodedLayer) -> String {
+        layer.summary.isEmpty ? layer.title : "\(layer.title): \(layer.summary)"
+    }
+}

--- a/Tracexy/Views/Inspector/InspectorView.swift
+++ b/Tracexy/Views/Inspector/InspectorView.swift
@@ -1,3 +1,4 @@
+import AppKit
 import SwiftUI
 
 // MARK: - InspectorView
@@ -738,7 +739,14 @@ private struct DecodedLayerTree: View {
         .padding(.vertical, 1).padding(.horizontal, 4)
         .background(rowBackground(layer.byteRange), in: RoundedRectangle(cornerRadius: 4))
         .contentShape(Rectangle())
+        // Tap still selects the byte range for the hex pane; the context menu is
+        // an additive right-click affordance and leaves that behavior untouched.
         .onTapGesture { onSelect(layer.byteRange) }
+        .contextMenu {
+            Button("Copy Layer Summary", systemImage: "doc.on.doc") {
+                copy(DecodedClipboardText.layerSummary(layer))
+            }
+        }
     }
 
     private func fieldRow(_ field: DecodedField) -> some View {
@@ -752,6 +760,17 @@ private struct DecodedLayerTree: View {
         .background(rowBackground(field.byteRange), in: RoundedRectangle(cornerRadius: 4))
         .contentShape(Rectangle())
         .onTapGesture { onSelect(field.byteRange) }
+        .contextMenu {
+            Button("Copy Value", systemImage: "doc.on.doc") {
+                copy(DecodedClipboardText.value(field))
+            }
+            Button("Copy Field Name", systemImage: "textformat") {
+                copy(DecodedClipboardText.name(field))
+            }
+            Button("Copy \u{201C}Name: Value\u{201D}", systemImage: "text.append") {
+                copy(DecodedClipboardText.nameValue(field))
+            }
+        }
     }
 
     private func rowBackground(_ range: Range<Int>?) -> Color {
@@ -759,6 +778,13 @@ private struct DecodedLayerTree: View {
             return .clear
         }
         return Color.accentColor.opacity(0.18)
+    }
+
+    /// The only side effect of the copy actions: the text formatting itself lives
+    /// in the pure ``DecodedClipboardText`` so it stays independently testable.
+    private func copy(_ text: String) {
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(text, forType: .string)
     }
 }
 

--- a/Tracexy/Views/Inspector/InspectorView.swift
+++ b/Tracexy/Views/Inspector/InspectorView.swift
@@ -388,7 +388,7 @@ struct InspectorView: View {
     private func applicationLayers(_ layers: [DecodedLayer]) -> [DecodedLayer] {
         var found: [DecodedLayer] = []
         for layer in layers {
-            let isApplication: Set<ProtocolKind> = [.http, .http2, .dns, .websocket, .quic]
+            let isApplication: Set<ProtocolKind> = [.http, .http2, .dns, .websocket, .quic, .stun]
             if isApplication.contains(layer.proto) {
                 found.append(layer)
             }

--- a/Tracexy/Views/Main/RootView.swift
+++ b/Tracexy/Views/Main/RootView.swift
@@ -254,7 +254,7 @@ struct MainDetailView: View {
             : nil
         let summary = SessionStatusBarModel.statusText(
             surface: surface,
-            totalSessions: coordinator.sessions.count,
+            totalSessions: coordinator.presentedSessions.count,
             visibleCount: coordinator.visibleSessions.count,
             hasSelection: workspace.selectedSessionID != nil
         )
@@ -293,6 +293,7 @@ struct MainDetailView: View {
             canAddFocusSet: coordinator.canAddFocusSet,
             isNoiseControlActive: coordinator.isNoiseControlActive,
             hasSessions: !coordinator.sessions.isEmpty,
+            removedSessionCount: coordinator.removedSessionCount,
             activeFilterRuleCount: workspace.activeFilterRules.count,
             isAdvancedFilterVisible: workspace.isAdvancedFilterVisible,
             autoSelectLatest: workspace.autoSelectLatest
@@ -312,6 +313,8 @@ struct MainDetailView: View {
             openWindow(id: TracexyApp.noiseControlWindowID)
         case .clearSessions:
             showsClearConfirmation = true
+        case .restoreRemovedSessions:
+            coordinator.restoreRemovedSessions()
         case .advancedFilters:
             // Keep the category tabs visible and reveal/hide the advanced rule
             // builder directly beneath them.

--- a/Tracexy/Views/Overview/OverviewView.swift
+++ b/Tracexy/Views/Overview/OverviewView.swift
@@ -132,7 +132,7 @@ struct OverviewView: View {
 
     /// The span of the currently accumulated live sessions, for a stopped capture.
     private var sessionsSpanLabel: String {
-        let sessions = coordinator.sessions
+        let sessions = coordinator.presentedSessions
         guard let earliest = sessions.map(\.startTime).min() else {
             return "—"
         }
@@ -220,7 +220,7 @@ struct OverviewView: View {
         if coordinator.activeWorkspace.hasActiveFilters {
             Label(
                 "Showing \(coordinator.visibleSessions.count.formatted()) of "
-                    + "\(coordinator.sessions.count.formatted()) sessions — a filter is active.",
+                    + "\(coordinator.presentedSessions.count.formatted()) sessions — a filter is active.",
                 systemImage: "line.3.horizontal.decrease.circle"
             )
             .font(Theme.Typography.caption)
@@ -274,7 +274,7 @@ struct OverviewView: View {
     private var kpiRow: some View {
         HStack(alignment: .top, spacing: Theme.Metrics.spacingL) {
             kpi("Frames", value: frameCount.formatted())
-            kpi("Sessions", value: coordinator.sessions.count.formatted())
+            kpi("Sessions", value: coordinator.presentedSessions.count.formatted())
             kpi("Traffic", value: byteString(coordinator.totalBytes))
             TimelineView(.periodic(from: .now, by: 1)) { context in
                 kpi("Duration", value: durationValue(at: context.date))
@@ -294,7 +294,11 @@ struct OverviewView: View {
             HStack(spacing: Theme.Metrics.spacingM) {
                 sectionLabel("Capture Activity", systemImage: "waveform.path.ecg")
                 Spacer()
-                Button(isSaved ? "Open all \(coordinator.sessions.count.formatted()) sessions" : "Open live sessions") {
+                Button(
+                    isSaved
+                        ? "Open all \(coordinator.presentedSessions.count.formatted()) sessions"
+                        : "Open live sessions"
+                ) {
                     coordinator.selectSidebarItem(.sessions)
                 }
                 .buttonStyle(.link)

--- a/Tracexy/Views/Overview/OverviewView.swift
+++ b/Tracexy/Views/Overview/OverviewView.swift
@@ -169,11 +169,11 @@ struct OverviewView: View {
         return (stats.isLossy || coordinator.helperBufferDropCount > 0) ? .orange : .green
     }
 
-    /// Estimated bytes a `.pcap` save of the retained frames would write: the
-    /// 24-byte global header, a 16-byte record header per frame, and each frame's
-    /// captured payload.
-    private var estimatedSaveBytes: Int {
-        24 + coordinator.retainedFrameCount * 16 + coordinator.retainedCapturedByteCount
+    /// Captured payload currently available for immediate packet inspection.
+    /// This is deliberately not labelled as a save estimate: the complete live
+    /// capture is stored independently in the disk-backed pcapng spool.
+    private var inspectionWindowBytes: Int {
+        coordinator.retainedCapturedByteCount
     }
 
     // MARK: Layout
@@ -361,8 +361,8 @@ struct OverviewView: View {
 
     // MARK: Storage
 
-    /// Where the capture lives: a live capture's local save buffer (retention and
-    /// estimated size), or a saved file's on-disk provenance. Fidelity and drops
+    /// Where the capture lives: a live capture's bounded inspection buffer plus
+    /// complete disk-backed spool, or a saved file's on-disk provenance. Fidelity and drops
     /// are reported here so a green figure never implies a complete capture and an
     /// absent one never reads as clean.
     private var storageCard: some View {
@@ -391,7 +391,7 @@ struct OverviewView: View {
                 .buttonStyle(.link)
                 .font(Theme.Typography.captionMedium)
                 .disabled(!coordinator.canSaveCapture)
-                .help("Write the retained frames to a .pcap under Application Support")
+                .help("Write the complete disk-backed capture to a .pcapng under Application Support")
             }
         }
     }
@@ -417,8 +417,8 @@ struct OverviewView: View {
             "Retention",
             "\(coordinator.retainedFrameCount.formatted()) / \(coordinator.retainedFrameCapacity.formatted()) frames"
         )
-        storageRow("Estimated size", byteString(estimatedSaveBytes))
-        storageRow("Save format", "PCAP")
+        storageRow("Window bytes", byteString(inspectionWindowBytes))
+        storageRow("Save format", "PCAPNG")
         if let fidelity = stats?.fidelity {
             let incomplete = (stats?.isLossy ?? false) || helperDrops > 0
             storageRow(
@@ -438,7 +438,7 @@ struct OverviewView: View {
         }
         if coordinator.retainedFrameEvictionCount > 0 {
             Text(
-                "\(coordinator.retainedFrameEvictionCount.formatted()) frames trimmed from the save buffer — a local memory bound, not capture loss; sessions are unaffected."
+                "\(coordinator.retainedFrameEvictionCount.formatted()) older frames left the inspection window — the complete disk-backed capture and sessions are unaffected."
             )
             .font(Theme.Typography.micro)
             .foregroundStyle(.secondary)
@@ -474,7 +474,7 @@ struct OverviewView: View {
     // MARK: Protocol mix
 
     private var protocolMixCard: some View {
-        let kinds: [ProtocolKind] = [.dns, .tcp, .udp, .tls, .http, .http2, .quic]
+        let kinds: [ProtocolKind] = [.dns, .tcp, .udp, .tls, .http, .http2, .quic, .stun]
         let entries = kinds
             .map { (kind: $0, hits: coordinator.count(for: $0)) }
             .filter { $0.hits > 0 }
@@ -706,6 +706,7 @@ struct OverviewView: View {
         case .tls: .tls
         case .http: .http
         case .quic: .quic
+        case .stun: .stun
         default: nil
         }
     }

--- a/Tracexy/Views/Overview/OverviewView.swift
+++ b/Tracexy/Views/Overview/OverviewView.swift
@@ -1,33 +1,47 @@
 import Charts
 import SwiftUI
 
-/// The earned intelligence surface: a bounded dashboard that only becomes
-/// valuable once sessions exist. Capture health and traffic charts stay visible
-/// near the top; findings are a severity summary plus a short actionable preview,
-/// never an unbounded list that pushes every chart below the fold.
+/// The capture-centric Overview: a bounded, truthful summary of the capture the
+/// user is looking at, answering *what am I looking at, what happened, who is
+/// involved, what needs attention, and where is it stored* — for both a live
+/// capture and an opened saved file.
 ///
-/// Live capture state — interface, running/stopped, current throughput — is
-/// deliberately absent: the toolbar and status bar already carry it on every
-/// surface, and repeating it here made this surface open with something both
-/// redundant and instantaneous while its unique content sat below the fold.
-///
-/// Every number is derived from real decoded data via the coordinator; nothing
-/// here is fabricated.
+/// Every number is derived from real decoded/captured data via the coordinator.
+/// Live and saved are deliberately distinguished: a live capture reports running
+/// state, live throughput, kernel/helper fidelity, and local save-buffer
+/// retention; a saved file reports its provenance, an activity-over-time chart
+/// built from real frame timestamps, and an explicitly *unknown* fidelity — never
+/// a fabricated clean figure, and never the live "waiting for traffic" state.
 struct OverviewView: View {
     // MARK: Internal
 
     var coordinator: MainContentCoordinator
 
     var body: some View {
-        ScrollView {
-            VStack(alignment: .leading, spacing: Theme.Metrics.spacingL) {
-                scopeNotice
-                ViewThatFits(in: .horizontal) {
-                    wideDashboard
-                    compactDashboard
+        GeometryReader { proxy in
+            ScrollView {
+                VStack(alignment: .leading, spacing: Theme.Metrics.spacingL) {
+                    scopeNotice
+                    summaryStrip
+                    if proxy.size.width >= Self.wideDashboardMinimumWidth {
+                        wideBody
+                    } else {
+                        compactBody
+                    }
                 }
+                // A vertical ScrollView otherwise accepts the dashboard's ideal
+                // width. When that ideal width is wider than the workspace left
+                // after the native sidebar opens, SwiftUI centers the overflow and
+                // its leading edge disappears underneath the sidebar. Constrain the
+                // proposal to the actual workspace viewport so the explicit
+                // breakpoint can choose the compact layout and every card remains
+                // inside the split.
+                .frame(
+                    width: max(0, proxy.size.width - Theme.Metrics.spacingL * 2),
+                    alignment: .leading
+                )
+                .padding(Theme.Metrics.spacingL)
             }
-            .padding(Theme.Metrics.spacingL)
         }
     }
 
@@ -40,13 +54,22 @@ struct OverviewView: View {
         return formatter
     }()
 
-    private static let findingPreviewLimit = 5
+    private static let summaryHorizontalMinimumWidth: CGFloat = 760
+    /// The three-column dashboard needs enough *workspace* width to preserve its
+    /// readable card columns. Below this point it reflows instead of relying on
+    /// intrinsic measurement that can extend beneath the native sidebar.
+    private static let wideDashboardMinimumWidth: CGFloat = 1_280
 
     private let compactColumns = [
         GridItem(.adaptive(minimum: 260), spacing: Theme.Metrics.spacingL),
     ]
 
-    /// Scoped like every other rollup here. This preview describes the same
+    /// True while an opened saved capture is on screen (versus a live/idle one).
+    private var isSaved: Bool {
+        coordinator.isViewingSavedCapture
+    }
+
+    /// Scoped like every other rollup here. This summary describes the same
     /// filtered session set as the surrounding charts.
     private var scopedFindings: [Finding] {
         let visibleIDs = Set(coordinator.visibleSessions.map(\.id))
@@ -58,32 +81,136 @@ struct OverviewView: View {
         }
     }
 
-    private var wideDashboard: some View {
-        HStack(alignment: .top, spacing: Theme.Metrics.spacingL) {
-            VStack(alignment: .leading, spacing: Theme.Metrics.spacingL) {
-                captureHealthCard
-                throughputCard
-                HStack(alignment: .top, spacing: Theme.Metrics.spacingL) {
-                    topTalkersCard
-                    protocolMixCard
-                }
-            }
-            .frame(minWidth: 520)
+    // MARK: Presentation values
 
-            findingsCard
-                .frame(width: 340)
+    private var identityTitle: String {
+        if isSaved {
+            return coordinator.activeSavedCapture?.name ?? "Saved capture"
+        }
+        return coordinator.captureInterface
+    }
+
+    private var identitySubtitle: String {
+        if isSaved {
+            return "Saved capture · \(savedFormat) · \(linkTypeName)"
+        }
+        let state = switch coordinator.captureDisplayState {
+        case .capturing: "Live capture"
+        case .starting: "Starting"
+        case .error: "Capture error"
+        case .stopped: coordinator.sessions.isEmpty ? "Idle" : "Stopped capture"
+        }
+        return "\(state) · \(linkTypeName)"
+    }
+
+    private var savedFormat: String {
+        let ext = coordinator.activeSavedCapture?.url.pathExtension ?? "pcap"
+        return ext.isEmpty ? "PCAP" : ext.uppercased()
+    }
+
+    private var linkTypeName: String {
+        switch coordinator.currentLinkType {
+        case LinkType.ethernet: "Ethernet"
+        case LinkType.raw: "Raw IP"
+        case LinkType.null: "Loopback"
+        default: "Link type \(coordinator.currentLinkType)"
         }
     }
 
-    private var compactDashboard: some View {
+    /// Frames shown in the KPI strip: exact for a saved file; the kernel-received
+    /// count for a live capture when available, otherwise the frames currently
+    /// held. Never a fabricated total.
+    private var frameCount: Int {
+        if isSaved {
+            return coordinator.savedCaptureActivity?.totalFrames ?? coordinator.retainedFrameCount
+        }
+        if let received = coordinator.captureStatistics?.received {
+            return Int(received)
+        }
+        return coordinator.retainedFrameCount
+    }
+
+    /// The span of the currently accumulated live sessions, for a stopped capture.
+    private var sessionsSpanLabel: String {
+        let sessions = coordinator.sessions
+        guard let earliest = sessions.map(\.startTime).min() else {
+            return "—"
+        }
+        let latest = sessions
+            .map { $0.startTime.addingTimeInterval($0.duration) }
+            .max() ?? earliest
+        return secondsLabel(max(0, latest.timeIntervalSince(earliest)))
+    }
+
+    private var activitySubtitle: String {
+        if isSaved {
+            return "Frames over capture time"
+        }
+        return "Throughput · live bytes per second"
+    }
+
+    private var fidelityValue: String {
+        if isSaved {
+            return "Unknown"
+        }
+        guard let fidelity = coordinator.captureStatistics?.fidelity else {
+            return "Unknown"
+        }
+        return Self.percent.string(from: fidelity as NSNumber) ?? "—"
+    }
+
+    private var fidelityTint: Color {
+        if isSaved {
+            return .orange
+        }
+        guard let stats = coordinator.captureStatistics, stats.fidelity != nil else {
+            return .orange
+        }
+        return (stats.isLossy || coordinator.helperBufferDropCount > 0) ? .orange : .green
+    }
+
+    /// Estimated bytes a `.pcap` save of the retained frames would write: the
+    /// 24-byte global header, a 16-byte record header per frame, and each frame's
+    /// captured payload.
+    private var estimatedSaveBytes: Int {
+        24 + coordinator.retainedFrameCount * 16 + coordinator.retainedCapturedByteCount
+    }
+
+    // MARK: Layout
+
+    private var wideBody: some View {
+        Grid(
+            alignment: .topLeading,
+            horizontalSpacing: Theme.Metrics.spacingL,
+            verticalSpacing: Theme.Metrics.spacingL
+        ) {
+            GridRow(alignment: .top) {
+                activityCard
+                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+                    .gridCellColumns(2)
+                storageCard
+                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+            }
+            GridRow(alignment: .top) {
+                topTalkersCard
+                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+                protocolMixCard
+                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+                sourceSummaryCard
+                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+            }
+        }
+    }
+
+    private var compactBody: some View {
         VStack(alignment: .leading, spacing: Theme.Metrics.spacingL) {
-            captureHealthCard
-            throughputCard
+            activityCard
+            storageCard
             LazyVGrid(columns: compactColumns, alignment: .leading, spacing: Theme.Metrics.spacingL) {
                 topTalkersCard
                 protocolMixCard
+                sourceSummaryCard
             }
-            findingsCard
         }
     }
 
@@ -101,182 +228,247 @@ struct OverviewView: View {
         }
     }
 
-    // MARK: Capture health
+    // MARK: Summary strip (identity + KPIs + fidelity)
 
-    /// Capture fidelity and decoded latency share one compact health card. Both
-    /// qualify the charts below, and neither needs a full-width card of its own.
-    private var captureHealthCard: some View {
+    private var summaryStrip: some View {
         card {
-            sectionLabel("Capture Health", systemImage: "checkmark.seal")
             ViewThatFits(in: .horizontal) {
-                HStack(alignment: .center, spacing: Theme.Metrics.spacingL) {
-                    fidelitySummary
+                HStack(alignment: .top, spacing: Theme.Metrics.spacingL) {
+                    identityBlock
                         .frame(maxWidth: .infinity, alignment: .leading)
-                    Divider()
-                        .frame(height: 68)
-                    latencySummary
+                    kpiRow
                 }
-                VStack(alignment: .leading, spacing: Theme.Metrics.spacingM) {
-                    fidelitySummary
-                    Divider()
-                    latencySummary
+                .frame(minWidth: Self.summaryHorizontalMinimumWidth, alignment: .topLeading)
+                VStack(alignment: .leading, spacing: Theme.Metrics.spacingL) {
+                    identityBlock
+                    kpiRow
                 }
             }
+            Divider()
+            findingSummaryBar
         }
     }
 
-    @ViewBuilder private var fidelitySummary: some View {
-        let stats = coordinator.captureStatistics
-        // Helper-stage loss is a separate figure from the kernel `pcap_stats`
-        // fidelity below. It can be non-zero even when the kernel reports a
-        // perfect capture, so it must pull the presentation off green and warn
-        // rather than being folded into (or hidden behind) the percent.
-        let helperDrops = coordinator.helperBufferDropCount
-        VStack(alignment: .leading, spacing: Theme.Metrics.spacingS) {
-            Text("Fidelity")
-                .font(Theme.Typography.captionMedium)
+    private var identityBlock: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            SectionHeader("Overview")
+            Text(identityTitle)
+                .font(Theme.Typography.title)
+                .lineLimit(1)
+            Text(identitySubtitle)
+                .font(Theme.Typography.caption)
                 .foregroundStyle(.secondary)
-            if let stats, let fidelity = stats.fidelity {
-                let incomplete = stats.isLossy || helperDrops > 0
-                HStack(alignment: .firstTextBaseline, spacing: Theme.Metrics.spacingM) {
-                    Text(Self.percent.string(from: fidelity as NSNumber) ?? "—")
-                        .font(Theme.Typography.metric)
-                        .foregroundStyle(incomplete ? Color.orange : Color.green)
-                        .monospacedDigit()
-                    Text("captured")
-                        .font(Theme.Typography.body)
-                        .foregroundStyle(.secondary)
-                    Spacer()
+                .lineLimit(1)
+            if isSaved {
+                Button("View in Library") {
+                    coordinator.activeWorkspace.navigatorMode = .library
                 }
-                Text(Self.lossDetail(stats))
-                    .font(Theme.Typography.caption)
-                    .foregroundStyle(.secondary)
-                if stats.isLossy {
-                    Text("Packets were dropped, so the figures below understate the traffic.")
-                        .font(Theme.Typography.caption)
-                        .foregroundStyle(.orange)
-                }
-                helperDropNotice(helperDrops)
-            } else {
-                Text("Not measured")
-                    .font(Theme.Typography.surfaceTitle)
-                    .foregroundStyle(.secondary)
-                Text(coordinator.isViewingSavedCapture
-                    ? "A saved capture carries no kernel accounting — any loss during the original capture is not recoverable from the file."
-                    : "Capture loss is reported once a live capture is running.")
-                    .font(Theme.Typography.caption)
-                    .foregroundStyle(.secondary)
-                    .fixedSize(horizontal: false, vertical: true)
-                // Even with no kernel figure, known helper-stage loss is reported
-                // truthfully rather than left implied by "Not measured".
-                helperDropNotice(helperDrops)
-            }
-        }
-    }
-
-    private var latencySummary: some View {
-        VStack(alignment: .leading, spacing: Theme.Metrics.spacingS) {
-            Text("Latency")
+                .buttonStyle(.link)
                 .font(Theme.Typography.captionMedium)
-                .foregroundStyle(.secondary)
-            HStack(alignment: .firstTextBaseline, spacing: Theme.Metrics.spacingL) {
-                latencyStat("Median", coordinator.medianLatencyMilliseconds)
-                latencyStat("p95", coordinator.p95LatencyMilliseconds)
+                .help("Reveal this file in the Library navigator")
+                .padding(.top, 2)
             }
         }
     }
 
-    // MARK: Findings
+    private var kpiRow: some View {
+        HStack(alignment: .top, spacing: Theme.Metrics.spacingL) {
+            kpi("Frames", value: frameCount.formatted())
+            kpi("Sessions", value: coordinator.sessions.count.formatted())
+            kpi("Traffic", value: byteString(coordinator.totalBytes))
+            TimelineView(.periodic(from: .now, by: 1)) { context in
+                kpi("Duration", value: durationValue(at: context.date))
+            }
+            kpi("Fidelity", value: fidelityValue, tint: fidelityTint)
+        }
+        .fixedSize(horizontal: false, vertical: true)
+    }
 
-    private var findingsCard: some View {
-        let all = scopedFindings
-        let shown = Array(all.prefix(Self.findingPreviewLimit))
-        return card {
+    // MARK: Capture activity
+
+    /// Live shows the live throughput plot; a saved file shows a bounded
+    /// frames-over-time chart built from real captured timestamps — never the
+    /// live "waiting for traffic" empty state.
+    private var activityCard: some View {
+        card {
             HStack(spacing: Theme.Metrics.spacingM) {
-                sectionLabel("Findings", systemImage: "sparkle.magnifyingglass")
+                sectionLabel("Capture Activity", systemImage: "waveform.path.ecg")
                 Spacer()
-                Text(all.count.formatted())
-                    .font(Theme.Typography.monoSmall)
-                    .foregroundStyle(.secondary)
-                if !all.isEmpty {
-                    Button("Filter Security") {
-                        coordinator.showSecuritySessions()
-                    }
-                    .buttonStyle(.link)
-                    .font(Theme.Typography.captionMedium)
-                    .help("Show sessions with security findings in the full session table")
+                Button(isSaved ? "Open all \(coordinator.sessions.count.formatted()) sessions" : "Open live sessions") {
+                    coordinator.selectSidebarItem(.sessions)
                 }
+                .buttonStyle(.link)
+                .font(Theme.Typography.captionMedium)
+                .help("Open the session list")
             }
-            if all.isEmpty {
-                emptyFindings
+            Text(activitySubtitle)
+                .font(Theme.Typography.caption)
+                .foregroundStyle(.secondary)
+            if isSaved {
+                savedActivityChart
             } else {
-                findingSeveritySummary(all)
-                Divider()
-                ForEach(shown) { finding in
-                    findingRow(finding)
-                }
-                if all.count > shown.count {
-                    Text("Showing \(shown.count.formatted()) of \(all.count.formatted())")
-                        .font(Theme.Typography.caption)
-                        .foregroundStyle(.tertiary)
-                }
+                ThroughputChart(samples: coordinator.throughputSamples)
+                    .frame(height: 168)
+                    .overlay(alignment: .center) {
+                        if coordinator.throughputSamples.isEmpty {
+                            Text("Waiting for traffic…")
+                                .font(Theme.Typography.caption)
+                                .foregroundStyle(.tertiary)
+                        }
+                    }
             }
         }
     }
 
-    private var emptyFindings: some View {
-        HStack(spacing: Theme.Metrics.spacingM) {
-            Image(systemName: "checkmark.seal").foregroundStyle(.green)
-            Text("No findings — traffic looks healthy")
+    @ViewBuilder private var savedActivityChart: some View {
+        if let activity = coordinator.savedCaptureActivity, !activity.isEmpty {
+            VStack(alignment: .leading, spacing: Theme.Metrics.spacingS) {
+                Chart(activity.buckets) { bucket in
+                    BarMark(
+                        x: .value("Bucket", bucket.index),
+                        y: .value("Frames", bucket.frameCount)
+                    )
+                    .foregroundStyle(Color.accentColor.gradient)
+                    .cornerRadius(2)
+                }
+                .chartXAxis(.hidden)
+                .chartYAxis {
+                    AxisMarks(position: .leading, values: .automatic(desiredCount: 3)) { value in
+                        AxisGridLine().foregroundStyle(.quaternary)
+                        AxisValueLabel {
+                            if let frames = value.as(Int.self) {
+                                Text(frames.formatted()).font(Theme.Typography.micro)
+                            }
+                        }
+                    }
+                }
+                .frame(height: 168)
+                HStack {
+                    Text("0 s").font(Theme.Typography.micro).foregroundStyle(.tertiary)
+                    Spacer()
+                    Text(secondsLabel(activity.duration))
+                        .font(Theme.Typography.micro).foregroundStyle(.tertiary)
+                }
+            }
+        } else {
+            Text("No frames in this capture")
                 .font(Theme.Typography.body)
                 .foregroundStyle(.secondary)
+                .frame(height: 168, alignment: .center)
+                .frame(maxWidth: .infinity)
         }
-        .padding(.vertical, 2)
+    }
+
+    // MARK: Storage
+
+    /// Where the capture lives: a live capture's local save buffer (retention and
+    /// estimated size), or a saved file's on-disk provenance. Fidelity and drops
+    /// are reported here so a green figure never implies a complete capture and an
+    /// absent one never reads as clean.
+    private var storageCard: some View {
+        card {
+            sectionLabel(isSaved ? "Local Storage" : "Live Buffer", systemImage: "internaldrive")
+            Text(isSaved ? "Saved file" : "Unsaved capture")
+                .font(Theme.Typography.bodyMedium)
+            VStack(alignment: .leading, spacing: Theme.Metrics.spacingS) {
+                if isSaved {
+                    savedStorageRows
+                } else {
+                    liveStorageRows
+                }
+            }
+            Divider()
+            if isSaved {
+                Button("Open in Saved Captures") {
+                    coordinator.activeWorkspace.navigatorMode = .library
+                }
+                .buttonStyle(.link)
+                .font(Theme.Typography.captionMedium)
+            } else {
+                Button("Save Capture…", systemImage: "square.and.arrow.down") {
+                    coordinator.saveCurrentCapture()
+                }
+                .buttonStyle(.link)
+                .font(Theme.Typography.captionMedium)
+                .disabled(!coordinator.canSaveCapture)
+                .help("Write the retained frames to a .pcap under Application Support")
+            }
+        }
+    }
+
+    @ViewBuilder private var savedStorageRows: some View {
+        storageRow("Format", savedFormat)
+        storageRow("File size", byteString(coordinator.activeSavedCapture?.byteCount ?? 0))
+        storageRow("Frames", frameCount.formatted())
+        storageRow("Fidelity", "Unknown", tint: .orange)
+        storageRow("Drop counters", "Unavailable in file")
+        Text(
+            "A saved file carries no kernel accounting; any loss during the original capture is not recoverable from it."
+        )
+        .font(Theme.Typography.micro)
+        .foregroundStyle(.secondary)
+        .fixedSize(horizontal: false, vertical: true)
+    }
+
+    @ViewBuilder private var liveStorageRows: some View {
+        let stats = coordinator.captureStatistics
+        let helperDrops = coordinator.helperBufferDropCount
+        storageRow(
+            "Retention",
+            "\(coordinator.retainedFrameCount.formatted()) / \(coordinator.retainedFrameCapacity.formatted()) frames"
+        )
+        storageRow("Estimated size", byteString(estimatedSaveBytes))
+        storageRow("Save format", "PCAP")
+        if let fidelity = stats?.fidelity {
+            let incomplete = (stats?.isLossy ?? false) || helperDrops > 0
+            storageRow(
+                "Capture health",
+                Self.percent.string(from: fidelity as NSNumber) ?? "—",
+                tint: incomplete ? .orange : .green
+            )
+        } else {
+            storageRow("Capture health", "Unknown", tint: .orange)
+        }
+        storageRow("Drop counters", dropCountersText(stats, helperDrops: helperDrops))
+        if stats?.isLossy == true {
+            Text("Packets were dropped by the capture source, so the figures above understate the traffic.")
+                .font(Theme.Typography.micro)
+                .foregroundStyle(.orange)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        if coordinator.retainedFrameEvictionCount > 0 {
+            Text(
+                "\(coordinator.retainedFrameEvictionCount.formatted()) frames trimmed from the save buffer — a local memory bound, not capture loss; sessions are unaffected."
+            )
+            .font(Theme.Typography.micro)
+            .foregroundStyle(.secondary)
+            .fixedSize(horizontal: false, vertical: true)
+        }
     }
 
     // MARK: Top talkers
 
     private var topTalkersCard: some View {
         let talkers = coordinator.topHosts()
+        let maxBytes = talkers.map(\.bytes).max() ?? 0
         return card {
-            sectionLabel("Top Talkers", systemImage: "chart.bar.xaxis")
+            HStack(spacing: Theme.Metrics.spacingM) {
+                sectionLabel("Top Talkers", systemImage: "chart.bar.xaxis")
+                Spacer()
+                if !talkers.isEmpty {
+                    Button("Open Sessions") { coordinator.selectSidebarItem(.sessions) }
+                        .buttonStyle(.link)
+                        .font(Theme.Typography.captionMedium)
+                }
+            }
             if talkers.isEmpty {
                 Text("No traffic yet").font(Theme.Typography.body).foregroundStyle(.secondary)
             } else {
-                Chart(talkers, id: \.host) { entry in
-                    BarMark(
-                        x: .value("Bytes", entry.bytes),
-                        y: .value("Host", entry.host)
-                    )
-                    .foregroundStyle(Color.accentColor.gradient)
-                    .cornerRadius(3)
-                    .annotation(position: .trailing, alignment: .leading, spacing: 4) {
-                        Text(ByteCountFormatter.string(fromByteCount: Int64(entry.bytes), countStyle: .binary))
-                            .font(Theme.Typography.monoSmall)
-                            .foregroundStyle(.secondary)
-                    }
+                ForEach(talkers, id: \.host) { entry in
+                    talkerRow(host: entry.host, bytes: entry.bytes, maxBytes: maxBytes)
                 }
-                .chartXAxis(.hidden)
-                .chartYAxis {
-                    AxisMarks(preset: .aligned, position: .leading) { value in
-                        AxisValueLabel {
-                            if let host = value.as(String.self) {
-                                Text(host).font(Theme.Typography.micro).lineLimit(1)
-                            }
-                        }
-                    }
-                }
-                .frame(height: CGFloat(talkers.count) * 24 + 8)
-                .animation(.smooth, value: talkers.map(\.bytes))
             }
         }
-    }
-
-    // MARK: Throughput
-
-    private var throughputCard: some View {
-        RealtimeChart(samples: coordinator.throughputSamples)
-            .frame(height: 184)
     }
 
     // MARK: Protocol mix
@@ -286,50 +478,159 @@ struct OverviewView: View {
         let entries = kinds
             .map { (kind: $0, hits: coordinator.count(for: $0)) }
             .filter { $0.hits > 0 }
+        let maxHits = entries.map(\.hits).max() ?? 0
         return card {
             sectionLabel("Protocol Mix", systemImage: "chart.bar")
             if entries.isEmpty {
                 Text("No protocols decoded yet").font(Theme.Typography.body).foregroundStyle(.secondary)
             } else {
-                Chart(entries, id: \.kind) { entry in
-                    BarMark(
-                        x: .value("Sessions", entry.hits),
-                        y: .value("Protocol", entry.kind.label)
-                    )
-                    .foregroundStyle(Theme.color(for: entry.kind))
-                    .cornerRadius(3)
-                    .annotation(position: .trailing, alignment: .leading, spacing: 4) {
-                        Text(entry.hits.formatted())
-                            .font(Theme.Typography.monoSmall)
-                            .foregroundStyle(.secondary)
-                    }
+                ForEach(entries, id: \.kind) { entry in
+                    protocolRow(kind: entry.kind, hits: entry.hits, maxHits: maxHits)
                 }
-                .chartXAxis(.hidden)
-                .chartYAxis {
-                    AxisMarks(preset: .aligned, position: .leading) { value in
-                        AxisValueLabel {
-                            if let label = value.as(String.self) {
-                                Text(label).font(Theme.Typography.micro)
-                            }
-                        }
-                    }
-                }
-                .frame(height: CGFloat(entries.count) * 26 + 8)
-                .animation(.smooth, value: entries.map(\.hits))
             }
         }
     }
 
-    /// A compact warning that the capture helper dropped frames before they
-    /// reached the app — shown whenever the count is non-zero, so a green kernel
-    /// fidelity never implies a complete capture when the helper stage lost data.
-    @ViewBuilder
-    private func helperDropNotice(_ helperDrops: UInt64) -> some View {
-        if helperDrops > 0 {
-            Text("\(helperDrops.formatted()) frames were dropped by the capture helper before reaching the app.")
+    // MARK: Source summary
+
+    /// Who is involved, from the same observed data the sidebar's Sources groups
+    /// build on — no fabricated apps, domains, or IPs.
+    private var sourceSummaryCard: some View {
+        let attributedApps = coordinator.appGroups.filter { $0.app != "—" }.count
+        return card {
+            sectionLabel("Source Summary", systemImage: "person.2")
+            sourceRow(
+                "Apps",
+                attributedApps > 0 ? "\(attributedApps.formatted()) observed" : "No attribution",
+                tint: attributedApps > 0 ? .primary : .orange
+            )
+            sourceRow("Domains", "\(coordinator.domainGroups.count.formatted()) observed")
+            sourceRow("IP Addresses", "\(coordinator.ipHosts.count.formatted()) observed")
+            Divider()
+            Button("Open Flow Map") { coordinator.selectSidebarItem(.flow) }
+                .buttonStyle(.link)
+                .font(Theme.Typography.captionMedium)
+                .help("See where this traffic is going")
+        }
+    }
+
+    // MARK: Findings summary
+
+    /// Overview reports security posture without duplicating the evidence list.
+    /// Individual sessions belong in the scalable Sessions/Security workflow.
+    private var findingSummaryBar: some View {
+        let all = scopedFindings
+        return HStack(spacing: Theme.Metrics.spacingM) {
+            sectionLabel("Findings", systemImage: "sparkle.magnifyingglass")
+            if all.isEmpty {
+                emptyFindings
+            } else {
+                findingSeveritySummary(all)
+                Spacer(minLength: Theme.Metrics.spacingM)
+                Button("Review \(all.count.formatted()) in Sessions") {
+                    coordinator.showSecuritySessions()
+                }
+                .buttonStyle(.link)
+                .font(Theme.Typography.captionMedium)
+                .help("Show sessions with security findings in the full session table")
+            }
+        }
+    }
+
+    private var emptyFindings: some View {
+        HStack(spacing: Theme.Metrics.spacingM) {
+            Image(systemName: "checkmark.seal").foregroundStyle(.green)
+            Text("No findings in the current scope")
+                .font(Theme.Typography.body)
+                .foregroundStyle(.secondary)
+        }
+        .padding(.vertical, 2)
+    }
+
+    private func kpi(_ label: String, value: String, tint: Color = .primary) -> some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text(label.uppercased())
+                .font(Theme.Typography.micro)
+                .tracking(0.5)
+                .foregroundStyle(.secondary)
+            Text(value)
+                .font(Theme.Typography.title)
+                .foregroundStyle(tint)
+                .monospacedDigit()
+                .lineLimit(1)
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(label): \(value)")
+    }
+
+    private func storageRow(_ label: String, _ value: String, tint: Color = .primary) -> some View {
+        HStack(alignment: .firstTextBaseline) {
+            Text(label)
                 .font(Theme.Typography.caption)
-                .foregroundStyle(.orange)
-                .fixedSize(horizontal: false, vertical: true)
+                .foregroundStyle(.secondary)
+            Spacer(minLength: Theme.Metrics.spacingM)
+            Text(value)
+                .font(Theme.Typography.caption)
+                .foregroundStyle(tint)
+                .monospacedDigit()
+                .multilineTextAlignment(.trailing)
+        }
+    }
+
+    private func talkerRow(host: String, bytes: Int, maxBytes: Int) -> some View {
+        Button {
+            coordinator.selectHost(host)
+        } label: {
+            HStack(spacing: Theme.Metrics.spacingM) {
+                Text(host)
+                    .font(Theme.Typography.caption)
+                    .lineLimit(1)
+                    .frame(width: 118, alignment: .leading)
+                proportionBar(fraction: maxBytes > 0 ? Double(bytes) / Double(maxBytes) : 0, tint: .accentColor)
+                Text(byteString(bytes))
+                    .font(Theme.Typography.monoMicro)
+                    .foregroundStyle(.secondary)
+                    .frame(width: 62, alignment: .trailing)
+            }
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .help("Show sessions for \(host)")
+    }
+
+    @ViewBuilder
+    private func protocolRow(kind: ProtocolKind, hits: Int, maxHits: Int) -> some View {
+        let destination = protocolDestination(kind)
+        Button {
+            if let destination {
+                coordinator.selectSidebarItem(destination)
+            }
+        } label: {
+            HStack(spacing: Theme.Metrics.spacingM) {
+                Text(kind.label)
+                    .font(Theme.Typography.caption)
+                    .lineLimit(1)
+                    .frame(width: 60, alignment: .leading)
+                proportionBar(fraction: maxHits > 0 ? Double(hits) / Double(maxHits) : 0, tint: Theme.color(for: kind))
+                Text(hits.formatted())
+                    .font(Theme.Typography.monoMicro)
+                    .foregroundStyle(.secondary)
+                    .frame(width: 40, alignment: .trailing)
+            }
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .disabled(destination == nil)
+        .help(destination == nil
+            ? "\(kind.label): \(hits.formatted()) sessions"
+            : "Filter the session list to \(kind.label)")
+    }
+
+    private func sourceRow(_ label: String, _ value: String, tint: Color = .primary) -> some View {
+        HStack(alignment: .firstTextBaseline) {
+            Text(label).font(Theme.Typography.caption).foregroundStyle(.secondary)
+            Spacer(minLength: Theme.Metrics.spacingM)
+            Text(value).font(Theme.Typography.caption).foregroundStyle(tint).monospacedDigit()
         }
     }
 
@@ -350,66 +651,80 @@ struct OverviewView: View {
         }
     }
 
-    private func latencyStat(_ label: String, _ milliseconds: Double?) -> some View {
-        VStack(alignment: .leading, spacing: 2) {
-            Text(milliseconds.map { "\(Int($0)) ms" } ?? "—")
-                .font(Theme.Typography.metricRounded)
-                .foregroundStyle(Theme.latencyColor(milliseconds: milliseconds))
-            Text(label).font(Theme.Typography.micro).foregroundStyle(.secondary)
-        }
-    }
-
     // MARK: Building blocks
 
     private func card(@ViewBuilder _ content: () -> some View) -> some View {
         VStack(alignment: .leading, spacing: Theme.Metrics.spacingM) {
             content()
         }
-        .frame(maxWidth: .infinity, alignment: .leading)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         .padding(Theme.Metrics.spacingL)
         .background(.background.secondary, in: RoundedRectangle(cornerRadius: Theme.Metrics.cornerRadius))
     }
 
     private func sectionLabel(_ title: String, systemImage: String) -> some View {
-        // Centralize casing, tracking, font and colour in `SectionHeader` so every
-        // Overview card titles the same way; the glyph keeps its secondary tint.
         SectionHeader(title, systemImage: systemImage)
     }
 
-    private func findingRow(_ finding: Finding) -> some View {
-        Button {
-            guard let id = finding.sessionID,
-                  let session = coordinator.sessions.first(where: { $0.id == id }) else
-            {
-                return
+    /// A thin proportional fill over a track — the row-level bar used by Top
+    /// Talkers and Protocol Mix. Bounded to `0...1`; a zero fraction shows the bare
+    /// track rather than trapping.
+    private func proportionBar(fraction: Double, tint: Color) -> some View {
+        let clamped = min(max(fraction, 0), 1)
+        return GeometryReader { proxy in
+            ZStack(alignment: .leading) {
+                Capsule().fill(.quaternary.opacity(0.5))
+                Capsule().fill(tint.gradient)
+                    .frame(width: max(0, proxy.size.width * clamped))
             }
-            coordinator.showSecuritySessions()
-            coordinator.select(session)
-        } label: {
-            HStack(spacing: Theme.Metrics.spacingM) {
-                Image(systemName: finding.severity.systemImage)
-                    .foregroundStyle(finding.severity.tint)
-                    .frame(width: 18)
-                VStack(alignment: .leading, spacing: 1) {
-                    Text(finding.title).font(Theme.Typography.bodyMedium).lineLimit(1)
-                    Text(finding.subtitle).font(Theme.Typography.caption).foregroundStyle(.secondary).lineLimit(1)
-                }
-                Spacer()
-                Image(systemName: "chevron.right").font(.system(size: Theme.Icon.small)).foregroundStyle(.tertiary)
-            }
-            .contentShape(Rectangle())
         }
-        .buttonStyle(.plain)
+        .frame(height: 6)
+        .frame(maxWidth: .infinity)
     }
 
-    private static func lossDetail(_ stats: CaptureStatistics) -> String {
-        let dropped = stats.totalDropped
-        guard dropped > 0 else {
-            return "\(stats.received.formatted()) packets · none dropped by the kernel buffer or the interface"
+    private func durationValue(at now: Date) -> String {
+        if isSaved {
+            return secondsLabel(coordinator.savedCaptureActivity?.duration ?? 0)
         }
-        return "\(stats.received.formatted()) captured · "
-            + "\(stats.droppedByKernel.formatted()) dropped by the kernel buffer · "
-            + "\(stats.droppedByInterface.formatted()) dropped by the interface"
+        if coordinator.captureDisplayState == .capturing,
+           let startedAt = coordinator.captureStartedAt
+        {
+            return secondsLabel(now.timeIntervalSince(startedAt))
+        }
+        return sessionsSpanLabel
+    }
+
+    private func dropCountersText(_ stats: CaptureStatistics?, helperDrops: UInt64) -> String {
+        let kernel = stats.map { $0.totalDropped.formatted() } ?? "—"
+        return "Kernel \(kernel) · helper \(helperDrops.formatted())"
+    }
+
+    private func protocolDestination(_ kind: ProtocolKind) -> SidebarItem? {
+        switch kind {
+        case .dns: .dns
+        case .tcp: .tcp
+        case .tls: .tls
+        case .http: .http
+        case .quic: .quic
+        default: nil
+        }
+    }
+
+    private func byteString(_ bytes: Int) -> String {
+        ByteCountFormatter.string(fromByteCount: Int64(bytes), countStyle: .binary)
+    }
+
+    /// A human duration for the KPI strip and activity axis: milliseconds under a
+    /// second, seconds otherwise, always non-negative.
+    private func secondsLabel(_ seconds: TimeInterval) -> String {
+        let value = max(0, seconds)
+        if value == 0 {
+            return "0 s"
+        }
+        if value < 1 {
+            return "\(Int((value * 1_000).rounded())) ms"
+        }
+        return String(format: "%.2f s", value)
     }
 
     private func severityTitle(_ severity: Finding.Severity) -> String {

--- a/Tracexy/Views/Sessions/SessionCenterView.swift
+++ b/Tracexy/Views/Sessions/SessionCenterView.swift
@@ -68,6 +68,16 @@ struct SessionCenterView: View {
             } description: {
                 Text(error)
             }
+        } else if coordinator.presentedSessions.isEmpty, coordinator.removedSessionCount > 0 {
+            ContentUnavailableView {
+                Label("All Sessions Removed from View", systemImage: "eye.slash")
+            } description: {
+                Text("The capture evidence is still intact and can be restored.")
+            } actions: {
+                Button("Restore Removed Sessions") {
+                    coordinator.restoreRemovedSessions()
+                }
+            }
         } else if coordinator.isCapturing {
             ContentUnavailableView {
                 Label("Capturing on \(coordinator.captureInterface)", systemImage: "dot.radiowaves.left.and.right")
@@ -355,6 +365,16 @@ struct SessionCenterView: View {
                 Button("Copy Summary", systemImage: "doc.on.doc") {
                     copyToPasteboard(row.summary)
                 }
+
+                Divider()
+
+                Button(
+                    "Remove \(activity.sessions.count) Sessions from View",
+                    systemImage: "trash",
+                    role: .destructive
+                ) {
+                    coordinator.removeSessionsFromView(Set(activity.sessions.map(\.id)))
+                }
             case let .group(group):
                 groupMenu(group)
             }
@@ -427,6 +447,12 @@ struct SessionCenterView: View {
             coordinator.isProtocolMuted(proto) ? "Unmute \(proto.label)" : "Mute \(proto.label)",
             systemImage: coordinator.isProtocolMuted(proto) ? "speaker.wave.2" : "speaker.slash"
         ) { coordinator.toggleMuteProtocol(proto) }
+
+        Divider()
+
+        Button("Remove from View", systemImage: "trash", role: .destructive) {
+            coordinator.removeSessionsFromView(Set([session.id]))
+        }
     }
 
     /// The menu for an observed group. Scopes by the group's real attribute — a
@@ -466,6 +492,16 @@ struct SessionCenterView: View {
             Button("Show Sessions for \(group.key)", systemImage: "app.badge") {
                 coordinator.selectProcess(group.key)
             }
+        }
+
+        Divider()
+
+        Button(
+            "Remove \(group.sessions.count) Sessions from View",
+            systemImage: "trash",
+            role: .destructive
+        ) {
+            coordinator.removeSessionsFromView(Set(group.sessions.map(\.id)))
         }
     }
 

--- a/Tracexy/Views/Sessions/SessionFilterBar.swift
+++ b/Tracexy/Views/Sessions/SessionFilterBar.swift
@@ -33,9 +33,24 @@ struct SessionFilterBar: View {
         .background(Color(nsColor: .windowBackgroundColor))
         .overlay(alignment: .bottom) { Divider() }
         .fixedSize(horizontal: false, vertical: true)
+        // ⌘F focus. `.task(id:)` fires both on first appear and on every token
+        // change, so a press that *mounts* this bar (coming from Overview/Flow)
+        // and a press while it is already visible both land the cursor in the
+        // field. The nil guard keeps a freshly-created workspace from stealing
+        // focus before the user has ever asked for it.
+        .task(id: workspace.searchFocusRequest) {
+            guard workspace.searchFocusRequest != nil else {
+                return
+            }
+            isSearchFieldFocused = true
+        }
     }
 
     // MARK: Private
+
+    /// Drives the native cursor for the existing search field; set by the ⌘F
+    /// focus token above. No layout or styling changes hang off this.
+    @FocusState private var isSearchFieldFocused: Bool
 
     private var maxRules: Int {
         coordinator.policy.maxSessionFilterRules
@@ -175,6 +190,7 @@ struct SessionFilterBar: View {
             )
             .textFieldStyle(.roundedBorder)
             .font(Theme.Typography.body)
+            .focused($isSearchFieldFocused)
             .accessibilityLabel("Search sessions")
             if !workspace.filterText.isEmpty {
                 Button {

--- a/Tracexy/Views/Sessions/SessionStatusBar.swift
+++ b/Tracexy/Views/Sessions/SessionStatusBar.swift
@@ -131,8 +131,8 @@ nonisolated struct FooterSnapshot: Equatable {
 ///   from `pcap_stats`; unknown when no statistics are available;
 /// - `helperDropCount`, frames the privileged helper evicted before the app drained
 ///   them — capture-source loss that is *not* part of the kernel figure;
-/// - `retentionEvictionCount`, frames trimmed from the local save/export window —
-///   a memory bound, never captured-packet loss.
+/// - `retentionEvictionCount`, frames trimmed from the local inspection window —
+///   a memory bound, never captured-packet or savefile loss.
 nonisolated struct CaptureLoss: Equatable {
     let hasStatistics: Bool
     let totalDropped: UInt64
@@ -171,7 +171,7 @@ nonisolated enum SessionStatusBarModel {
             FooterActionDescriptor(
                 kind: .saveCapture,
                 title: "Save Capture",
-                help: "Save the current capture to a .pcap file.",
+                help: "Save the complete current capture to a .pcapng file.",
                 systemImage: "square.and.arrow.down",
                 placement: .primary,
                 priority: 0,
@@ -367,17 +367,17 @@ nonisolated enum SessionStatusBarModel {
             ))
         }
 
-        // Retention truncation — the local save/export window trimmed its oldest
-        // frames to stay bounded. This is emphatically *not* capture loss: every
-        // session is still accounted for, only the tail of raw frames a `.pcap`
-        // save could write was shortened. Neutral and last, so it never reads as
-        // an alarm about missed traffic.
+        // Memory-window eviction — the immediate inspection window trimmed its
+        // oldest frames to stay bounded. This is emphatically *not* capture loss:
+        // sessions remain accounted for and the complete raw stream continues to
+        // the disk-backed spool used by save/export. Neutral and last, so it never
+        // reads as an alarm about missed traffic.
         if loss.retentionEvictionCount > 0 {
             items.append(FooterTelemetry(
                 kind: .retentionTruncation,
-                text: "\(loss.retentionEvictionCount.formatted()) not retained",
-                help: "Older raw frames were dropped from the save/export window to bound memory — "
-                    + "sessions are unaffected; a saved .pcap contains only the retained recent tail.",
+                text: "\(loss.retentionEvictionCount.formatted()) outside memory window",
+                help: "Older raw frames left the bounded inspection window — sessions and the complete "
+                    + "disk-backed save remain unaffected.",
                 systemImage: "tray.full",
                 role: .neutral
             ))

--- a/Tracexy/Views/Sessions/SessionStatusBar.swift
+++ b/Tracexy/Views/Sessions/SessionStatusBar.swift
@@ -39,6 +39,7 @@ nonisolated struct FooterActionDescriptor: Identifiable, Equatable {
         case newFocusSet
         case noiseControl
         case clearSessions
+        case restoreRemovedSessions
         case advancedFilters
         case autoSelectLatest
     }
@@ -160,6 +161,7 @@ nonisolated enum SessionStatusBarModel {
         canAddFocusSet: Bool,
         isNoiseControlActive: Bool,
         hasSessions: Bool,
+        removedSessionCount: Int,
         activeFilterRuleCount: Int,
         isAdvancedFilterVisible: Bool,
         autoSelectLatest: Bool
@@ -218,12 +220,23 @@ nonisolated enum SessionStatusBarModel {
                 isDestructive: true
             ),
             FooterActionDescriptor(
+                kind: .restoreRemovedSessions,
+                title: "Restore Removed Sessions (\(removedSessionCount))",
+                help: "Restore every session removed from the current capture's views.",
+                systemImage: "arrow.uturn.backward",
+                placement: .listOptions,
+                priority: 4,
+                isEnabled: removedSessionCount > 0,
+                isActive: false,
+                isDestructive: false
+            ),
+            FooterActionDescriptor(
                 kind: .advancedFilters,
                 title: activeFilterRuleCount > 0 ? "Advanced Filters (on)" : "Advanced Filters",
                 help: "Show the advanced filter rule builder.",
                 systemImage: "line.3.horizontal.decrease.circle",
                 placement: .listOptions,
-                priority: 4,
+                priority: 5,
                 isEnabled: true,
                 isActive: isAdvancedFilterVisible || activeFilterRuleCount > 0,
                 isDestructive: false
@@ -234,7 +247,7 @@ nonisolated enum SessionStatusBarModel {
                 help: "Automatically select the newest session as it arrives.",
                 systemImage: "arrow.down.circle",
                 placement: .listOptions,
-                priority: 5,
+                priority: 6,
                 isEnabled: true,
                 isActive: autoSelectLatest,
                 isDestructive: false

--- a/Tracexy/Views/Settings/CaptureSettingsView.swift
+++ b/Tracexy/Views/Settings/CaptureSettingsView.swift
@@ -2,10 +2,11 @@ import SwiftUI
 
 // MARK: - CaptureSettingsView
 
-/// Capture defaults. `Default interface` is honored by the coordinator on launch;
-/// the filter/buffer options persist and will drive the capture engine as those
-/// paths land (BPF, snaplen, promiscuous, and retention are not yet wired to
-/// `LiveCapture`).
+/// Capture defaults, all behavioral: the coordinator reads these preferences fresh
+/// at each capture start and maps them to a validated `CaptureConfiguration`
+/// (interface, snap length, promiscuous mode, optional BPF) honored by both the
+/// direct and privileged-helper backends, and sizes the in-memory save/export
+/// retention window from "Retain up to".
 struct CaptureSettingsView: View {
     // MARK: Internal
 
@@ -26,6 +27,12 @@ struct CaptureSettingsView: View {
                     .labelsHidden()
                     .frame(width: metrics.menuWidth(240))
                     .frame(minHeight: metrics.controlHeight)
+                }
+
+                if let note = CaptureSourceGuidance.tunnelNote(for: defaultInterface, in: allInterfaces) {
+                    SettingsIndented {
+                        SettingsFootnote(note)
+                    }
                 }
 
                 SettingsDivider()
@@ -109,6 +116,38 @@ struct CaptureSettingsView: View {
     @State private var interfaceGroups: [InterfaceGroup] = []
 
     private let metrics = SettingsDisplayMetrics.standard
+
+    /// The discovered interfaces, flattened out of their display groups, for the
+    /// tunnel-guidance lookup.
+    private var allInterfaces: [NetworkInterface] {
+        interfaceGroups.flatMap(\.interfaces)
+    }
+}
+
+// MARK: - CaptureSourceGuidance
+
+/// Derives the compact, evidence-based note shown when the selected default
+/// interface is a tunnel (VPN) source. Pure and deterministic so its visibility
+/// and text are unit-testable without rendering the view.
+///
+/// A tunnel interface carries the inner, already-decapsulated IP packets, so a
+/// capture there sees pre-encryption IP traffic the physical link never exposes —
+/// but a tunnel has no Ethernet framing, so link-layer/MAC detail is absent. The
+/// note states exactly that tradeoff and nothing more. It is shown only for a
+/// tunnel-category interface; "Automatic" (no explicit selection) and every
+/// non-tunnel interface get no note.
+enum CaptureSourceGuidance {
+    static func tunnelNote(for interfaceID: String, in interfaces: [NetworkInterface]) -> String? {
+        guard !interfaceID.isEmpty,
+              let interface = interfaces.first(where: { $0.id == interfaceID }),
+              interface.category == .tunnels else
+        {
+            return nil
+        }
+        return "This is a tunnel (VPN) interface. You’ll capture the inner, pre-encryption IP traffic it "
+            + "carries — which the physical link never exposes — but not link-layer or MAC details, because "
+            + "a tunnel has no Ethernet framing."
+    }
 }
 
 #Preview {

--- a/Tracexy/Views/Sidebar/NoiseControlWindow.swift
+++ b/Tracexy/Views/Sidebar/NoiseControlWindow.swift
@@ -70,7 +70,7 @@ struct NoiseControlWindow: View {
     /// can be un-muted even after its traffic scrolled off.
     private var topHosts: [(host: String, hits: Int)] {
         var counts: [String: Int] = [:]
-        for session in coordinator.sessions {
+        for session in coordinator.presentedSessions {
             counts[session.host, default: 0] += 1
         }
         for host in coordinator.mutedHosts where counts[host] == nil {

--- a/Tracexy/Views/Sidebar/SidebarView.swift
+++ b/Tracexy/Views/Sidebar/SidebarView.swift
@@ -8,7 +8,7 @@ import UniformTypeIdentifiers
 /// swaps the whole body so each kind of work stands alone, instead of stacking
 /// Monitor + Protocols + Sources + Favorites into one crowded list.
 ///
-/// - Browse  — Monitor destinations (Sessions/Overview/Flow Map), the Protocols
+/// - Browse  — Monitor destinations (Overview/Sessions/Flow Map), the Protocols
 ///             lens group, and Sources (Apps/Domains/IPs). Protocols is a single
 ///             disclosure group, collapsed by default: those rows filter the same
 ///             list rather than navigating anywhere, so they stay secondary to the

--- a/Tracexy/Views/Sidebar/SidebarView.swift
+++ b/Tracexy/Views/Sidebar/SidebarView.swift
@@ -53,6 +53,25 @@ struct SidebarView: View {
                 Button("Import Capture…", systemImage: "tray.and.arrow.down") { importCapture() }
             }
         }
+        .confirmationDialog(
+            capturePendingRemoval.map { "Move “\($0.name)” to Trash?" } ?? "Move Capture to Trash?",
+            isPresented: captureRemovalConfirmation,
+            titleVisibility: .visible
+        ) {
+            if let capture = capturePendingRemoval {
+                Button("Move to Trash", role: .destructive) {
+                    moveCaptureToTrash(capture)
+                }
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("The capture will disappear from Saved and can be recovered from the Trash.")
+        }
+        .alert("Couldn’t Remove Capture", isPresented: captureRemovalErrorPresentation) {
+            Button("OK", role: .cancel) { captureRemovalError = nil }
+        } message: {
+            Text(captureRemovalError ?? "The capture could not be moved to the Trash.")
+        }
     }
 
     // MARK: Private
@@ -63,6 +82,13 @@ struct SidebarView: View {
     /// the navigator's own rows and never touches `WorkspaceState.filterText` or
     /// the session list, which have their own filter controls.
     @State private var sidebarSearch = ""
+
+    /// Context-menu removal is staged through a confirmation because a saved
+    /// capture is user data, not merely sidebar presentation state. The actual
+    /// operation is recoverable (move to Trash), matching native macOS library
+    /// behavior while still removing the row immediately after success.
+    @State private var capturePendingRemoval: SavedCapture?
+    @State private var captureRemovalError: String?
 
     @State private var protocolsExpanded = false
     @State private var savedExpanded = false
@@ -101,14 +127,24 @@ struct SidebarView: View {
 
     /// Apps whose name matches, or that contacted a matching host. A name match
     /// keeps every child; otherwise only the matching hosts are shown.
+    private var visibleAppGroups: [AppGroup] {
+        coordinator.appGroups.compactMap { group in
+            guard !coordinator.isSourceAppHidden(group.app) else {
+                return nil
+            }
+            let hosts = group.hosts.filter { !coordinator.isSourceHostHidden($0) }
+            return AppGroup(app: group.app, hosts: hosts, count: group.count)
+        }
+    }
+
     private var filteredAppGroups: [AppGroup] {
         guard isSearching else {
-            return coordinator.appGroups
+            return visibleAppGroups
         }
         if matches("Apps") || matches("Sources") {
-            return coordinator.appGroups
+            return visibleAppGroups
         }
-        return coordinator.appGroups.compactMap { group in
+        return visibleAppGroups.compactMap { group in
             if matches(group.app) {
                 return group
             }
@@ -117,14 +153,24 @@ struct SidebarView: View {
         }
     }
 
+    private var visibleDomainGroups: [DomainGroup] {
+        coordinator.domainGroups.compactMap { group in
+            guard !coordinator.isSourceDomainHidden(group.domain) else {
+                return nil
+            }
+            let ips = group.ips.filter { !coordinator.isSourceIPHidden($0) }
+            return DomainGroup(domain: group.domain, ips: ips, count: group.count)
+        }
+    }
+
     private var filteredDomainGroups: [DomainGroup] {
         guard isSearching else {
-            return coordinator.domainGroups
+            return visibleDomainGroups
         }
         if matches("Domains") || matches("Sources") {
-            return coordinator.domainGroups
+            return visibleDomainGroups
         }
-        return coordinator.domainGroups.compactMap { group in
+        return visibleDomainGroups.compactMap { group in
             if matches(group.domain) {
                 return group
             }
@@ -133,14 +179,30 @@ struct SidebarView: View {
         }
     }
 
+    private var visibleIPHosts: [(name: String, count: Int)] {
+        coordinator.ipHosts.filter { !coordinator.isSourceIPHidden($0.name) }
+    }
+
     private var filteredIPHosts: [(name: String, count: Int)] {
         guard isSearching else {
-            return coordinator.ipHosts
+            return visibleIPHosts
         }
         if matches("IP Addresses") || matches("Sources") {
-            return coordinator.ipHosts
+            return visibleIPHosts
         }
-        return coordinator.ipHosts.filter { matches($0.name) }
+        return visibleIPHosts.filter { matches($0.name) }
+    }
+
+    private var showsAppsCategory: Bool {
+        !filteredAppGroups.isEmpty || (!isSearching && !coordinator.hiddenSourceApps.isEmpty)
+    }
+
+    private var showsDomainsCategory: Bool {
+        !filteredDomainGroups.isEmpty || (!isSearching && !coordinator.hiddenSourceDomains.isEmpty)
+    }
+
+    private var showsIPAddressesCategory: Bool {
+        !filteredIPHosts.isEmpty || (!isSearching && !coordinator.hiddenSourceIPs.isEmpty)
     }
 
     private var filteredPinnedHosts: [String] {
@@ -195,6 +257,28 @@ struct SidebarView: View {
     /// browsing but bows out of a search unless the query is about muting.
     private var showsNoiseControl: Bool {
         !isSearching || matches("noise control") || matches("muted") || matches("mute")
+    }
+
+    private var captureRemovalConfirmation: Binding<Bool> {
+        Binding(
+            get: { capturePendingRemoval != nil },
+            set: {
+                if !$0 {
+                    capturePendingRemoval = nil
+                }
+            }
+        )
+    }
+
+    private var captureRemovalErrorPresentation: Binding<Bool> {
+        Binding(
+            get: { captureRemovalError != nil },
+            set: {
+                if !$0 {
+                    captureRemovalError = nil
+                }
+            }
+        )
     }
 
     /// Honest empty state — shown only while searching, so an idle capture with
@@ -298,9 +382,13 @@ struct SidebarView: View {
                         .accessibilityAddTraits(isActiveHost(host) ? .isSelected : [])
                         .accessibilityAction { coordinator.selectHost(host) }
                         .contextMenu {
-                            Button("Unpin", systemImage: "pin.slash") {
-                                coordinator.togglePinHost(host)
-                            }
+                            SidebarSourceContextMenu(
+                                value: host,
+                                copyLabel: "Copy Address",
+                                pinnedHost: host,
+                                coordinator: coordinator,
+                                onShowSessions: { coordinator.selectHost(host) }
+                            )
                         }
                 }
             }
@@ -327,9 +415,12 @@ struct SidebarView: View {
                             Button("Reveal in Finder", systemImage: "folder") {
                                 NSWorkspace.shared.activateFileViewerSelecting([capture.url])
                             }
+                            Button("Copy Path", systemImage: "doc.on.doc") {
+                                copyToPasteboard(capture.url.path)
+                            }
                             Divider()
-                            Button("Delete", systemImage: "trash", role: .destructive) {
-                                coordinator.deleteSavedCapture(capture)
+                            Button("Move to Trash…", systemImage: "trash", role: .destructive) {
+                                capturePendingRemoval = capture
                             }
                         }
                 }
@@ -357,22 +448,52 @@ struct SidebarView: View {
     /// hosts/IPs that app contacted.
     private var appsDisclosure: some View {
         DisclosureGroup(isExpanded: searchExpansion($appsExpanded)) {
-            ForEach(filteredAppGroups) { group in
-                AppRow(group: group, coordinator: coordinator, forceExpanded: isSearching)
+            if filteredAppGroups.isEmpty {
+                Text("No visible apps")
+                    .font(Theme.Typography.caption).foregroundStyle(.tertiary)
+            } else {
+                ForEach(filteredAppGroups) { group in
+                    AppRow(group: group, coordinator: coordinator, forceExpanded: isSearching)
+                }
             }
         } label: {
-            Label("Apps", systemImage: "app.badge").badge(coordinator.appGroups.count)
+            sourceCategoryLabel(
+                title: "Apps",
+                systemImage: "app.badge",
+                count: visibleAppGroups.count,
+                expanded: $appsExpanded,
+                copyLabel: "Copy App Names",
+                values: filteredAppGroups.map(\.app).filter { $0 != "—" },
+                hiddenCount: coordinator.hiddenSourceApps.count,
+                restoreLabel: "Restore Hidden Apps",
+                onRestore: coordinator.restoreHiddenSourceApps
+            )
         }
     }
 
     /// Domains, each expandable to the server IPs it resolved to (sub-IPs).
     private var domainsDisclosure: some View {
         DisclosureGroup(isExpanded: searchExpansion($domainsExpanded)) {
-            ForEach(filteredDomainGroups) { group in
-                DomainRow(group: group, coordinator: coordinator, forceExpanded: isSearching)
+            if filteredDomainGroups.isEmpty {
+                Text("No visible domains")
+                    .font(Theme.Typography.caption).foregroundStyle(.tertiary)
+            } else {
+                ForEach(filteredDomainGroups) { group in
+                    DomainRow(group: group, coordinator: coordinator, forceExpanded: isSearching)
+                }
             }
         } label: {
-            Label("Domains", systemImage: "globe").badge(coordinator.domainGroups.count)
+            sourceCategoryLabel(
+                title: "Domains",
+                systemImage: "globe",
+                count: visibleDomainGroups.count,
+                expanded: $domainsExpanded,
+                copyLabel: "Copy Domains",
+                values: filteredDomainGroups.map(\.domain),
+                hiddenCount: coordinator.hiddenSourceDomains.count,
+                restoreLabel: "Restore Hidden Domains",
+                onRestore: coordinator.restoreHiddenSourceDomains
+            )
         }
     }
 
@@ -381,21 +502,95 @@ struct SidebarView: View {
     private var ipAddressesDisclosure: some View {
         let hosts = isSearching ? filteredIPHosts : Array(filteredIPHosts.prefix(20))
         return DisclosureGroup(isExpanded: searchExpansion($ipsExpanded)) {
-            ForEach(hosts, id: \.name) { host in
-                Label(host.name, systemImage: "number")
-                    .foregroundStyle(isActiveIP(host.name) ? Color.accentColor : .secondary)
-                    .font(isActiveIP(host.name) ? Theme.Typography.navigationMedium : Theme.Typography.navigation)
-                    .lineLimit(1).badge(host.count)
-                    .contentShape(Rectangle())
-                    .onTapGesture { coordinator.selectIP(host.name) }
-                    .accessibilityAddTraits(.isButton)
-                    .accessibilityAddTraits(isActiveIP(host.name) ? .isSelected : [])
-                    .accessibilityAction { coordinator.selectIP(host.name) }
-                    .help("Show sessions for \(host.name)")
-                    .contextMenu { PinHostButton(host: host.name, coordinator: coordinator) }
+            if hosts.isEmpty {
+                Text("No visible IP addresses")
+                    .font(Theme.Typography.caption).foregroundStyle(.tertiary)
+            } else {
+                ForEach(hosts, id: \.name) { host in
+                    Label(host.name, systemImage: "number")
+                        .foregroundStyle(isActiveIP(host.name) ? Color.accentColor : .secondary)
+                        .font(isActiveIP(host.name) ? Theme.Typography.navigationMedium : Theme.Typography.navigation)
+                        .lineLimit(1)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .badge(host.count)
+                        .contentShape(Rectangle())
+                        .onTapGesture { coordinator.selectIP(host.name) }
+                        .accessibilityAddTraits(.isButton)
+                        .accessibilityAddTraits(isActiveIP(host.name) ? .isSelected : [])
+                        .accessibilityAction { coordinator.selectIP(host.name) }
+                        .help("Show sessions for \(host.name)")
+                        .contextMenu {
+                            SidebarSourceContextMenu(
+                                value: host.name,
+                                copyLabel: "Copy IP Address",
+                                pinnedHost: host.name,
+                                coordinator: coordinator,
+                                onShowSessions: { coordinator.selectIP(host.name) },
+                                onRemove: { coordinator.hideSourceIP(host.name) }
+                            )
+                        }
+                }
             }
         } label: {
-            Label("IP Addresses", systemImage: "number").badge(coordinator.ipHosts.count)
+            sourceCategoryLabel(
+                title: "IP Addresses",
+                systemImage: "number",
+                count: visibleIPHosts.count,
+                expanded: $ipsExpanded,
+                copyLabel: "Copy IP Addresses",
+                values: hosts.map(\.name),
+                hiddenCount: coordinator.hiddenSourceIPs.count,
+                restoreLabel: "Restore Hidden IP Addresses",
+                onRestore: coordinator.restoreHiddenSourceIPs
+            )
+        }
+    }
+
+    /// A Sources category is itself an actionable sidebar item, not only a
+    /// disclosure triangle. The full-width label makes secondary-clicking the
+    /// row reliable, while the menu exposes category-level actions that remain
+    /// meaningful even before the user expands it.
+    private func sourceCategoryLabel(
+        title: String,
+        systemImage: String,
+        count: Int,
+        expanded: Binding<Bool>,
+        copyLabel: String,
+        values: [String],
+        hiddenCount: Int,
+        restoreLabel: String,
+        onRestore: @escaping () -> Void
+    )
+        -> some View
+    {
+        let appearsExpanded = isSearching || expanded.wrappedValue
+        return HStack {
+            Label(title, systemImage: systemImage)
+            Spacer(minLength: 0)
+        }
+        .badge(count)
+        .contentShape(Rectangle())
+        .contextMenu {
+            Button("Show All Sessions", systemImage: "rectangle.stack") {
+                coordinator.selectSidebarItem(.sessions)
+            }
+            Button(copyLabel, systemImage: "doc.on.doc") {
+                copyToPasteboard(values.joined(separator: "\n"))
+            }
+            .disabled(values.isEmpty)
+            if hiddenCount > 0 {
+                Button("\(restoreLabel) (\(hiddenCount))", systemImage: "arrow.uturn.backward") {
+                    onRestore()
+                }
+            }
+            Divider()
+            Button(
+                appearsExpanded ? "Collapse \(title)" : "Expand \(title)",
+                systemImage: appearsExpanded ? "chevron.up" : "chevron.down"
+            ) {
+                expanded.wrappedValue.toggle()
+            }
+            .disabled(isSearching)
         }
     }
 
@@ -440,15 +635,15 @@ struct SidebarView: View {
                 }
             }
 
-            if !filteredAppGroups.isEmpty || !filteredDomainGroups.isEmpty || !filteredIPHosts.isEmpty {
+            if showsAppsCategory || showsDomainsCategory || showsIPAddressesCategory {
                 Section("Sources") {
-                    if !filteredAppGroups.isEmpty {
+                    if showsAppsCategory {
                         appsDisclosure
                     }
-                    if !filteredDomainGroups.isEmpty {
+                    if showsDomainsCategory {
                         domainsDisclosure
                     }
-                    if !filteredIPHosts.isEmpty {
+                    if showsIPAddressesCategory {
                         ipAddressesDisclosure
                     }
                 }
@@ -532,6 +727,20 @@ struct SidebarView: View {
         if panel.runModal() == .OK, let url = panel.url {
             coordinator.importCapture(from: url)
         }
+    }
+
+    private func moveCaptureToTrash(_ capture: SavedCapture) {
+        capturePendingRemoval = nil
+        do {
+            try coordinator.moveSavedCaptureToTrash(capture)
+        } catch {
+            captureRemovalError = error.localizedDescription
+        }
+    }
+
+    private func copyToPasteboard(_ value: String) {
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(value, forType: .string)
     }
 
     private func selectionBinding(_ workspace: WorkspaceState) -> Binding<SidebarItem?> {
@@ -618,25 +827,47 @@ private struct DomainRow: View {
                     .foregroundStyle(isActiveIP(ip) ? Color.accentColor : .secondary)
                     .font(isActiveIP(ip) ? Theme.Typography.navigationMedium : Theme.Typography.navigation)
                     .lineLimit(1)
+                    .frame(maxWidth: .infinity, alignment: .leading)
                     .contentShape(Rectangle())
                     .onTapGesture { coordinator.selectIP(ip) }
                     .accessibilityAddTraits(.isButton)
                     .accessibilityAddTraits(isActiveIP(ip) ? .isSelected : [])
                     .accessibilityAction { coordinator.selectIP(ip) }
                     .help("Show sessions for \(ip)")
+                    .contextMenu {
+                        SidebarSourceContextMenu(
+                            value: ip,
+                            copyLabel: "Copy IP Address",
+                            pinnedHost: ip,
+                            coordinator: coordinator,
+                            onShowSessions: { coordinator.selectIP(ip) },
+                            onRemove: { coordinator.hideSourceIP(ip) }
+                        )
+                    }
             }
         } label: {
             Label(group.domain, systemImage: "globe")
                 .foregroundStyle(isActiveHost ? Color.accentColor : .secondary)
                 .font(isActiveHost ? Theme.Typography.navigationMedium : Theme.Typography.navigation)
-                .lineLimit(1).badge(group.count)
+                .lineLimit(1)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .badge(group.count)
                 .contentShape(Rectangle())
                 .onTapGesture { coordinator.selectHost(group.domain) }
                 .accessibilityAddTraits(.isButton)
                 .accessibilityAddTraits(isActiveHost ? .isSelected : [])
                 .accessibilityAction { coordinator.selectHost(group.domain) }
                 .help("Show sessions for \(group.domain)")
-                .contextMenu { PinHostButton(host: group.domain, coordinator: coordinator) }
+                .contextMenu {
+                    SidebarSourceContextMenu(
+                        value: group.domain,
+                        copyLabel: "Copy Domain",
+                        pinnedHost: group.domain,
+                        coordinator: coordinator,
+                        onShowSessions: { coordinator.selectHost(group.domain) },
+                        onRemove: { coordinator.hideSourceDomain(group.domain) }
+                    )
+                }
         }
     }
 
@@ -656,6 +887,40 @@ private struct DomainRow: View {
     private func isActiveIP(_ ip: String) -> Bool {
         coordinator.activeWorkspace.sidebarSelection == .sessions
             && coordinator.activeWorkspace.ipFilter == ip
+    }
+}
+
+// MARK: - SidebarSourceContextMenu
+
+/// Shared native actions for dynamic source rows. Static navigation groups stay
+/// intentionally quiet (as in Rockxy); rows representing actual apps, hosts,
+/// domains, and IPs expose the actions that help an investigation continue.
+private struct SidebarSourceContextMenu: View {
+    let value: String
+    let copyLabel: String
+    var pinnedHost: String?
+    let coordinator: MainContentCoordinator
+    let onShowSessions: () -> Void
+    var onRemove: (() -> Void)?
+
+    var body: some View {
+        Button("Show Sessions", systemImage: "rectangle.stack") {
+            onShowSessions()
+        }
+        Button(copyLabel, systemImage: "doc.on.doc") {
+            NSPasteboard.general.clearContents()
+            NSPasteboard.general.setString(value, forType: .string)
+        }
+        if let pinnedHost {
+            Divider()
+            PinHostButton(host: pinnedHost, coordinator: coordinator)
+        }
+        if let onRemove {
+            Divider()
+            Button("Remove from Sources", systemImage: "trash", role: .destructive) {
+                onRemove()
+            }
+        }
     }
 }
 
@@ -693,12 +958,23 @@ private struct AppRow: View {
                     .foregroundStyle(isActiveHost(host) ? Color.accentColor : .secondary)
                     .font(isActiveHost(host) ? Theme.Typography.navigationMedium : Theme.Typography.navigation)
                     .lineLimit(1)
+                    .frame(maxWidth: .infinity, alignment: .leading)
                     .contentShape(Rectangle())
                     .onTapGesture { coordinator.selectHost(host) }
                     .accessibilityAddTraits(.isButton)
                     .accessibilityAddTraits(isActiveHost(host) ? .isSelected : [])
                     .accessibilityAction { coordinator.selectHost(host) }
                     .help("Show sessions for \(host)")
+                    .contextMenu {
+                        SidebarSourceContextMenu(
+                            value: host,
+                            copyLabel: "Copy Address",
+                            pinnedHost: host,
+                            coordinator: coordinator,
+                            onShowSessions: { coordinator.selectHost(host) },
+                            onRemove: { coordinator.hideSourceHost(host) }
+                        )
+                    }
             }
         } label: {
             HStack(spacing: 6) {
@@ -706,6 +982,7 @@ private struct AppRow: View {
                 Text(group.app).lineLimit(1)
                     .font(isActiveApp ? Theme.Typography.navigationMedium : Theme.Typography.navigation)
                     .foregroundStyle(isActiveApp ? Color.accentColor : .primary)
+                Spacer(minLength: 0)
             }
             .badge(group.count)
             .contentShape(Rectangle())
@@ -714,6 +991,16 @@ private struct AppRow: View {
             .accessibilityAddTraits(isActiveApp ? .isSelected : [])
             .accessibilityAction { coordinator.selectProcess(group.app) }
             .help("Show sessions from \(group.app)")
+            .contextMenu {
+                SidebarSourceContextMenu(
+                    value: group.app,
+                    copyLabel: "Copy App Name",
+                    pinnedHost: nil,
+                    coordinator: coordinator,
+                    onShowSessions: { coordinator.selectProcess(group.app) },
+                    onRemove: { coordinator.hideSourceApp(group.app) }
+                )
+            }
         }
     }
 

--- a/TracexyCaptureHelper/CaptureService.swift
+++ b/TracexyCaptureHelper/CaptureService.swift
@@ -26,7 +26,7 @@ final class CaptureService: NSObject, TracexyHelperProtocol {
         reply(version, build, HelperProtocolVersion.current)
     }
 
-    func startCapture(interface: String, withReply reply: @escaping (Bool, String) -> Void) {
+    func startCapture(configuration: CaptureConfiguration, withReply reply: @escaping (Bool, String) -> Void) {
         // Serialize the whole start/stop lifecycle on a *separate* operation lock,
         // so a start can't interleave with a stop (e.g. assigning `capture` after
         // a concurrent stop cleared it). This lock is only ever held by lifecycle
@@ -57,11 +57,13 @@ final class CaptureService: NSObject, TracexyHelperProtocol {
             statsAvailable = false
             lock.unlock()
 
-            // `start` opens the handle synchronously: it throws if the interface
-            // can't be opened (so we never report a started capture that isn't
-            // running) and otherwise returns the real link type before the first
-            // frame — reported immediately so a savefile is faithful from frame 0.
-            let linkType = try session.start(interface: interface, onBatch: { [weak self] frames in
+            // `start` validates the configuration, opens the handle, and compiles
+            // any BPF synchronously: it throws on an out-of-bounds value, an
+            // interface that can't be opened, or a bad filter (so we never report a
+            // started capture that isn't running or silently ignored its filter),
+            // and otherwise returns the real link type before the first frame —
+            // reported immediately so a savefile is faithful from frame 0.
+            let linkType = try session.start(configuration: configuration, onBatch: { [weak self] frames in
                 guard let self else {
                     return
                 }
@@ -85,10 +87,12 @@ final class CaptureService: NSObject, TracexyHelperProtocol {
             capture = session
             captureLinkType = linkType
             lock.unlock()
-            Self.logger.info("started capture on \(interface, privacy: .public)")
+            Self.logger.info("started capture on \(configuration.interface, privacy: .public)")
             reply(true, "")
+        } catch let error as PcapCapture.Failure {
+            reply(false, error.message)
         } catch {
-            reply(false, "\(error)")
+            reply(false, error.localizedDescription)
         }
     }
 

--- a/TracexyCaptureHelper/PcapCapture.swift
+++ b/TracexyCaptureHelper/PcapCapture.swift
@@ -23,6 +23,13 @@ final class PcapCapture: @unchecked Sendable {
         // symbol must not fail the capture — the app is then told accounting is
         // unavailable rather than shown a fabricated clean figure.
         stats = try? PcapCapture.symbol(library, "pcap_stats", as: StatsFn.self)
+        // Optional: only needed when a BPF filter is configured. Resolved lazily so
+        // a plain (no-filter) capture never fails on a missing symbol; a requested
+        // filter with these unavailable fails the start with a clear message.
+        compileFilter = try? PcapCapture.symbol(library, "pcap_compile", as: CompileFn.self)
+        setFilter = try? PcapCapture.symbol(library, "pcap_setfilter", as: SetFilterFn.self)
+        freeCode = try? PcapCapture.symbol(library, "pcap_freecode", as: FreeCodeFn.self)
+        getError = try? PcapCapture.symbol(library, "pcap_geterr", as: GetErrFn.self)
     }
 
     // MARK: Internal
@@ -50,17 +57,39 @@ final class PcapCapture: @unchecked Sendable {
     /// frame arrives.
     @discardableResult
     func start(
-        interface: String,
+        configuration: CaptureConfiguration,
         onBatch: @escaping @Sendable ([CapturedFrameMessage]) -> Void,
         onStatistics: @escaping @Sendable (HelperCaptureStats?) -> Void
     )
         throws -> UInt32
     {
         lifecycle.stop()
+        // Re-validate on the privileged side even though the app validated too:
+        // bounds must hold regardless of what crossed the wire (defense in depth).
+        let config: CaptureConfiguration
+        switch configuration.validated() {
+        case let .success(normalized):
+            config = normalized
+        case let .failure(error):
+            throw Failure(message: error.message)
+        }
         var errbuf = [CChar](repeating: 0, count: 256)
-        let handle = interface.withCString { name in openLive(name, 65_536, 1, 100, &errbuf) }
+        let snaplen = Int32(config.snapLength)
+        let promisc: Int32 = config.promiscuous ? 1 : 0
+        let handle = config.interface.withCString { name in openLive(name, snaplen, promisc, 100, &errbuf) }
         guard let handle else {
             throw Failure(message: String(cString: errbuf))
+        }
+        // Compile + install any BPF filter before reporting the capture started.
+        // A bad expression fails closed here (handle closed, program freed) so the
+        // caller never reports a running capture that silently ignored the filter.
+        if let expression = config.bpf {
+            do {
+                try applyFilter(expression, handle: handle)
+            } catch {
+                closeHandle(handle)
+                throw error
+            }
         }
         let linkType = UInt32(bitPattern: dataLink(handle))
         // The raw C handle and close fn are not `Sendable`; carry them across the
@@ -114,6 +143,17 @@ final class PcapCapture: @unchecked Sendable {
     private typealias CloseFn = @convention(c) (OpaquePointer?) -> Void
     private typealias DataLinkFn = @convention(c) (OpaquePointer?) -> Int32
     private typealias StatsFn = @convention(c) (OpaquePointer?, UnsafeMutableRawPointer?) -> Int32
+    /// `int pcap_compile(pcap_t*, struct bpf_program*, const char*, int optimize, bpf_u_int32 netmask)`.
+    private typealias CompileFn = @convention(c) (
+        OpaquePointer?, UnsafeMutableRawPointer?, UnsafePointer<CChar>?, Int32, UInt32
+    )
+        -> Int32
+    /// `int pcap_setfilter(pcap_t*, struct bpf_program*)`.
+    private typealias SetFilterFn = @convention(c) (OpaquePointer?, UnsafeMutableRawPointer?) -> Int32
+    /// `void pcap_freecode(struct bpf_program*)`.
+    private typealias FreeCodeFn = @convention(c) (UnsafeMutableRawPointer?) -> Void
+    /// `char *pcap_geterr(pcap_t*)`.
+    private typealias GetErrFn = @convention(c) (OpaquePointer?) -> UnsafePointer<CChar>?
 
     private let library: UnsafeMutableRawPointer
     private let openLive: OpenLiveFn
@@ -121,6 +161,10 @@ final class PcapCapture: @unchecked Sendable {
     private let closeHandle: CloseFn
     private let dataLink: DataLinkFn
     private let stats: StatsFn?
+    private let compileFilter: CompileFn?
+    private let setFilter: SetFilterFn?
+    private let freeCode: FreeCodeFn?
+    private let getError: GetErrFn?
 
     private let lifecycle = CaptureWorkerLifecycle()
 
@@ -129,6 +173,44 @@ final class PcapCapture: @unchecked Sendable {
             throw Failure(message: "missing symbol \(name)")
         }
         return unsafeBitCast(pointer, to: T.self)
+    }
+
+    /// Compile and install a BPF filter on an open handle, freeing the compiled
+    /// program on every path. Throws with libpcap's own error text (via
+    /// `pcap_geterr`) so a bad expression surfaces the real reason.
+    private func applyFilter(_ expression: String, handle: OpaquePointer) throws {
+        guard let compileFilter, let setFilter, let freeCode else {
+            throw Failure(message: "BPF filtering is unavailable on this system.")
+        }
+        // `struct bpf_program { u_int bf_len; struct bpf_insn *bf_insns; }` is 16
+        // bytes on LP64. Zero it so a failed compile leaves nothing to free.
+        let programSize = 16
+        let program = UnsafeMutableRawPointer.allocate(byteCount: programSize, alignment: 8)
+        program.initializeMemory(as: UInt8.self, repeating: 0, count: programSize)
+        defer { program.deallocate() }
+        let netmaskUnknown: UInt32 = 0xFFFFFFFF
+        let compiled = expression.withCString { cstr in
+            compileFilter(handle, program, cstr, 1, netmaskUnknown)
+        }
+        guard compiled == 0 else {
+            throw Failure(message: filterErrorMessage(handle: handle, fallback: "invalid BPF filter expression."))
+        }
+        // Once compiled, free the program regardless of how setfilter goes — the
+        // kernel/handle keeps its own copy after a successful install.
+        defer { freeCode(program) }
+        guard setFilter(handle, program) == 0 else {
+            throw Failure(message: filterErrorMessage(handle: handle, fallback: "could not apply the BPF filter."))
+        }
+    }
+
+    private func filterErrorMessage(handle: OpaquePointer, fallback: String) -> String {
+        if let getError, let cstr = getError(handle) {
+            let message = String(cString: cstr)
+            if !message.isEmpty {
+                return message
+            }
+        }
+        return fallback
     }
 
     /// Sampled by the worker thread itself. `pcap_stats` needs the same handle the

--- a/TracexyTests/Core/Capture/CaptureActivityTests.swift
+++ b/TracexyTests/Core/Capture/CaptureActivityTests.swift
@@ -1,0 +1,109 @@
+import Foundation
+import Testing
+@testable import Tracexy
+
+// MARK: - CaptureActivityTests
+
+@Suite("Capture activity aggregation")
+struct CaptureActivityTests {
+    // MARK: Internal
+
+    @Test("An empty capture aggregates to nothing without trapping")
+    func emptyCapture() {
+        let activity = CaptureActivityBuilder.build(frames: [])
+        #expect(activity.buckets.isEmpty)
+        #expect(activity.isEmpty)
+        #expect(activity.duration == 0)
+        #expect(activity.totalFrames == 0)
+        #expect(activity.totalBytes == 0)
+        #expect(activity.bucketWidth == 0)
+        #expect(activity.peakFrameCount == 0)
+    }
+
+    @Test("A single instant collapses into one truthful bucket, never dividing by zero")
+    func singleInstant() {
+        // Several frames sharing one timestamp: no span to bucket over.
+        let frames = (0 ..< 4).map { _ in frame(atOffset: 0, bytes: 100) }
+        let activity = CaptureActivityBuilder.build(frames: frames)
+
+        #expect(activity.buckets.count == 1)
+        #expect(activity.duration == 0)
+        #expect(activity.bucketWidth == 0)
+        #expect(activity.totalFrames == 4)
+        #expect(activity.totalBytes == 400)
+        #expect(activity.buckets.first?.frameCount == 4)
+        #expect(activity.buckets.first?.byteCount == 400)
+    }
+
+    @Test("A single frame is one bucket carrying it")
+    func singleFrame() {
+        let activity = CaptureActivityBuilder.build(frames: [frame(atOffset: 5, bytes: 42)])
+        #expect(activity.buckets.count == 1)
+        #expect(activity.totalFrames == 1)
+        #expect(activity.totalBytes == 42)
+        #expect(activity.duration == 0)
+    }
+
+    @Test("A normal multi-frame span buckets to min(cap, frameCount) and conserves totals")
+    func multiBucketConservesTotals() {
+        // Ten frames one second apart, span = 9 s. cap 5 → exactly five buckets.
+        let frames = (0 ..< 10).map { index in
+            frame(atOffset: Double(index), bytes: 10 * (index + 1))
+        }
+        let activity = CaptureActivityBuilder.build(frames: frames, maxBuckets: 5)
+
+        #expect(activity.buckets.count == 5)
+        #expect(activity.duration == 9)
+        #expect(activity.bucketWidth == 9.0 / 5.0)
+        // Every frame lands in exactly one bucket, so per-bucket totals sum to the
+        // capture totals — no frame or byte is lost or double-counted.
+        #expect(activity.buckets.reduce(0) { $0 + $1.frameCount } == activity.totalFrames)
+        #expect(activity.buckets.reduce(0) { $0 + $1.byteCount } == activity.totalBytes)
+        #expect(activity.totalFrames == 10)
+        #expect(activity.totalBytes == frames.reduce(0) { $0 + $1.originalLength })
+        // Bucket offsets are the ordered left edges.
+        #expect(activity.buckets.map(\.index) == [0, 1, 2, 3, 4])
+        #expect(activity.buckets.first?.startOffset == 0)
+    }
+
+    @Test("The bucket count stays bounded by the cap on a large capture")
+    func boundedByCap() {
+        let frames = (0 ..< 5_000).map { index in
+            frame(atOffset: Double(index) * 0.01, bytes: 1)
+        }
+        let activity = CaptureActivityBuilder.build(frames: frames, maxBuckets: 24)
+        #expect(activity.buckets.count == 24)
+        #expect(activity.totalFrames == 5_000)
+        #expect(activity.buckets.reduce(0) { $0 + $1.frameCount } == 5_000)
+    }
+
+    @Test("Aggregation is deterministic for identical input")
+    func deterministic() {
+        let frames = (0 ..< 30).map { index in frame(atOffset: Double(index) * 0.5, bytes: index) }
+        let first = CaptureActivityBuilder.build(frames: frames)
+        let second = CaptureActivityBuilder.build(frames: frames)
+        #expect(first == second)
+    }
+
+    @Test("The trailing frame is clamped into the final bucket, not spilled past it")
+    func trailingEdgeClamped() {
+        // The last frame sits exactly on the span's trailing edge, which would map
+        // to index == bucketCount without clamping.
+        let frames = (0 ..< 8).map { index in frame(atOffset: Double(index), bytes: 1) }
+        let activity = CaptureActivityBuilder.build(frames: frames, maxBuckets: 4)
+        #expect(activity.buckets.count == 4)
+        #expect(activity.buckets.reduce(0) { $0 + $1.frameCount } == 8)
+    }
+
+    // MARK: Private
+
+    private static let base = Date(timeIntervalSince1970: 1_700_000_000)
+
+    private func frame(atOffset offset: TimeInterval, bytes: Int) -> CapturedFrame {
+        CapturedFrame(
+            bytes: [UInt8](repeating: 0, count: max(0, bytes)),
+            timestamp: Self.base.addingTimeInterval(offset),
+            originalLength: bytes
+        )
+    }
+}

--- a/TracexyTests/Core/Capture/CaptureImporterTests.swift
+++ b/TracexyTests/Core/Capture/CaptureImporterTests.swift
@@ -1,0 +1,143 @@
+import Foundation
+import Testing
+@testable import Tracexy
+
+/// Deterministic filesystem coverage for lossless, idempotent capture import.
+/// Each test runs in its own throwaway temporary directory so no state leaks
+/// into the real managed Captures folder.
+@Suite("Capture import is lossless and idempotent")
+struct CaptureImporterTests {
+    // MARK: Internal
+
+    @Test("A source that is already the managed file is reopened in place, never removed or copied")
+    func sameManagedURLIsPreserved() throws {
+        try withTemporaryDirectory { directory in
+            let managed = directory.appendingPathComponent("existing.pcap")
+            let payload = Data("managed-capture".utf8)
+            try payload.write(to: managed)
+
+            let result = try CaptureImporter.importCapture(from: managed, intoDirectory: directory)
+
+            #expect(result == directory.appendingPathComponent("existing.pcap"))
+            // The file survives untouched...
+            #expect(FileManager.default.fileExists(atPath: managed.path))
+            #expect(try Data(contentsOf: managed) == payload)
+            // ...and no duplicate or temporary artifact is left behind.
+            #expect(try directoryEntryCount(directory) == 1)
+        }
+    }
+
+    @Test("A same-named symlink resolving into the managed directory is treated as the same file")
+    func symlinkedSourceIsSameFile() throws {
+        try withTemporaryDirectory { directory in
+            try withTemporaryDirectory { externalDirectory in
+                let managed = directory.appendingPathComponent("existing.pcap")
+                let payload = Data("managed-capture".utf8)
+                try payload.write(to: managed)
+
+                // A symlink (e.g. handed back by a file picker) that carries the
+                // same name but resolves back to the managed file. Resolution,
+                // not the name, must recognise it as the managed file so nothing
+                // is copied or removed.
+                let link = externalDirectory.appendingPathComponent("existing.pcap")
+                try FileManager.default.createSymbolicLink(at: link, withDestinationURL: managed)
+
+                let result = try CaptureImporter.importCapture(from: link, intoDirectory: directory)
+
+                #expect(result == managed)
+                #expect(FileManager.default.fileExists(atPath: managed.path))
+                #expect(try Data(contentsOf: managed) == payload)
+                // No copy landed in the managed directory.
+                #expect(try directoryEntryCount(directory) == 1)
+            }
+        }
+    }
+
+    @Test("An external file with no name collision is copied in and the source is left intact")
+    func externalFileIsCopied() throws {
+        try withTemporaryDirectory { directory in
+            try withTemporaryDirectory { externalDirectory in
+                let source = externalDirectory.appendingPathComponent("fresh.pcap")
+                let payload = Data("brand-new-capture".utf8)
+                try payload.write(to: source)
+
+                let result = try CaptureImporter.importCapture(from: source, intoDirectory: directory)
+
+                let destination = directory.appendingPathComponent("fresh.pcap")
+                #expect(result == destination)
+                #expect(try Data(contentsOf: destination) == payload)
+                // Source untouched.
+                #expect(try Data(contentsOf: source) == payload)
+                #expect(try directoryEntryCount(directory) == 1)
+            }
+        }
+    }
+
+    @Test("A colliding external file replaces the managed copy only after the new copy fully succeeds")
+    func collisionReplacesAfterSuccessfulCopy() throws {
+        try withTemporaryDirectory { directory in
+            try withTemporaryDirectory { externalDirectory in
+                let managed = directory.appendingPathComponent("capture.pcap")
+                try Data("old-managed".utf8).write(to: managed)
+
+                let source = externalDirectory.appendingPathComponent("capture.pcap")
+                let incoming = Data("new-external".utf8)
+                try incoming.write(to: source)
+
+                let result = try CaptureImporter.importCapture(from: source, intoDirectory: directory)
+
+                #expect(result == managed)
+                // Destination now holds the incoming payload.
+                #expect(try Data(contentsOf: managed) == incoming)
+                // Source is not consumed.
+                #expect(try Data(contentsOf: source) == incoming)
+                // The staged temporary sibling was consumed by the replace.
+                #expect(try directoryEntryCount(directory) == 1)
+            }
+        }
+    }
+
+    @Test("A copy failure on collision preserves both the source and the pre-existing managed file")
+    func failedCollisionPreservesBothFiles() throws {
+        try withTemporaryDirectory { directory in
+            let managed = directory.appendingPathComponent("capture.pcap")
+            let existing = Data("old-managed".utf8)
+            try existing.write(to: managed)
+
+            // A source that does not exist forces the staging copy to fail with
+            // ENOENT — the same failure that previously destroyed the managed
+            // file when it was removed up front. The managed file must survive.
+            let missingSource = directory
+                .appendingPathComponent("elsewhere", isDirectory: true)
+                .appendingPathComponent("capture.pcap")
+
+            #expect(throws: (any Error).self) {
+                try CaptureImporter.importCapture(from: missingSource, intoDirectory: directory)
+            }
+
+            // Pre-existing managed file is intact, unchanged, and no temporary
+            // artifact leaked into the directory.
+            #expect(FileManager.default.fileExists(atPath: managed.path))
+            #expect(try Data(contentsOf: managed) == existing)
+            #expect(try directoryEntryCount(directory) == 1)
+        }
+    }
+
+    // MARK: Private
+
+    /// Number of non-hidden entries directly in `directory`. Also asserts that
+    /// no leftover `.import-*.tmp` staging artifacts remain.
+    private func directoryEntryCount(_ directory: URL) throws -> Int {
+        let all = try FileManager.default.contentsOfDirectory(atPath: directory.path)
+        #expect(!all.contains { $0.contains(".import-") })
+        return all.filter { !$0.hasPrefix(".") }.count
+    }
+
+    private func withTemporaryDirectory(_ body: (URL) throws -> Void) throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tracexy-import-tests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        try body(directory)
+    }
+}

--- a/TracexyTests/Core/Capture/LiveCaptureSpoolTests.swift
+++ b/TracexyTests/Core/Capture/LiveCaptureSpoolTests.swift
@@ -1,0 +1,47 @@
+import Foundation
+import Testing
+@testable import Tracexy
+
+@Suite("Disk-backed live capture spool")
+struct LiveCaptureSpoolTests {
+    // MARK: Internal
+
+    @Test("Spool round-trips every appended frame across batches")
+    func roundTrip() async throws {
+        let spool = LiveCaptureSpool(directoryName: "LiveCaptureSpoolTests")
+        try await spool.reset(epoch: 7)
+        let first = frame(byte: 1, timestamp: 1, linkType: LinkType.ethernet)
+        let second = frame(byte: 2, timestamp: 2, linkType: LinkType.raw)
+
+        try await spool.append([first], defaultLinkType: LinkType.ethernet, epoch: 7)
+        try await spool.append([second], defaultLinkType: LinkType.ethernet, epoch: 7)
+        let capture = try await spool.capture()
+
+        #expect(capture.frames.count == 2)
+        #expect(capture.frames.map(\.bytes) == [first.bytes, second.bytes])
+        #expect(capture.frames.map(\.originalLength) == [first.originalLength, second.originalLength])
+        #expect(capture.frames.map(\.linkType) == [LinkType.ethernet, LinkType.raw])
+    }
+
+    @Test("Stale capture generations cannot append into a new spool")
+    func staleEpochIgnored() async throws {
+        let spool = LiveCaptureSpool(directoryName: "LiveCaptureSpoolTests")
+        try await spool.reset(epoch: 2)
+        try await spool.append([frame(byte: 1, timestamp: 1)], defaultLinkType: LinkType.ethernet, epoch: 1)
+        try await spool.append([frame(byte: 2, timestamp: 2)], defaultLinkType: LinkType.ethernet, epoch: 2)
+
+        let capture = try await spool.capture()
+        #expect(capture.frames.map(\.bytes) == [[2, 2, 2]])
+    }
+
+    // MARK: Private
+
+    private func frame(byte: UInt8, timestamp: TimeInterval, linkType: UInt32? = nil) -> CapturedFrame {
+        CapturedFrame(
+            bytes: [byte, byte, byte],
+            timestamp: Date(timeIntervalSince1970: timestamp),
+            originalLength: 7,
+            linkType: linkType
+        )
+    }
+}

--- a/TracexyTests/Core/Capture/RetainedFrameBufferTests.swift
+++ b/TracexyTests/Core/Capture/RetainedFrameBufferTests.swift
@@ -33,6 +33,26 @@ struct RetainedFrameBufferTests {
         #expect(buffer.isEmpty)
         #expect(buffer.isEmpty)
         #expect(buffer.evictionCount == 0)
+        #expect(buffer.capturedByteCount == 0)
+    }
+
+    @Test("Captured-byte total tracks only the frames still retained, across evict/replace/reset")
+    func capturedByteTotalTracksRetainedFrames() {
+        // Each helper frame carries exactly one captured byte, so the running total
+        // equals the retained count and stays a memory/save-size figure — never a
+        // capture-loss figure, which the eviction counter reports separately.
+        var buffer = RetainedFrameBuffer(capacity: 3)
+        buffer.append(contentsOf: frames(0 ..< 5))
+        #expect(buffer.count == 3)
+        #expect(buffer.capturedByteCount == 3) // three retained × 1 captured byte
+        #expect(buffer.evictionCount == 2) // loss/truncation is a distinct figure
+
+        buffer.replace(with: frames(0 ..< 10))
+        #expect(buffer.capturedByteCount == 10)
+        #expect(buffer.evictionCount == 0)
+
+        buffer.reset()
+        #expect(buffer.capturedByteCount == 0)
     }
 
     @Test("Replace bypasses the capacity bound and zeroes the count for an opened file")

--- a/TracexyTests/Core/Protocol/QUICDecodeTests.swift
+++ b/TracexyTests/Core/Protocol/QUICDecodeTests.swift
@@ -1,0 +1,214 @@
+import Foundation
+import Testing
+@testable import Tracexy
+
+// MARK: - Helpers
+
+private func decodeFrame(_ frame: [UInt8], linkType: UInt32 = LinkType.ethernet) -> DecodedPacket {
+    PacketDecoder.decode(
+        PacketBuffer(frame),
+        linkType: linkType,
+        timestamp: Date(timeIntervalSince1970: 1_700_000_000),
+        originalLength: frame.count
+    )
+}
+
+/// Builds a QUIC long-header prefix (RFC 9000 §17.2): first byte, 32-bit version,
+/// destination CID (length-prefixed), source CID (length-prefixed), then opaque
+/// (encrypted) bytes the decoder never interprets. CID lengths are written from
+/// the supplied arrays so a caller can model both well-formed and over-cap CIDs.
+private func quicLongHeader(
+    firstByte: UInt8,
+    version: UInt32,
+    dcid: [UInt8],
+    scid: [UInt8],
+    dcidLen: UInt8? = nil,
+    scidLen: UInt8? = nil,
+    payload: [UInt8] = [0xAA, 0xBB, 0xCC, 0xDD]
+)
+    -> [UInt8]
+{
+    var bytes: [UInt8] = [firstByte]
+    bytes += [
+        UInt8((version >> 24) & 0xFF),
+        UInt8((version >> 16) & 0xFF),
+        UInt8((version >> 8) & 0xFF),
+        UInt8(version & 0xFF),
+    ]
+    bytes.append(dcidLen ?? UInt8(dcid.count))
+    bytes += dcid
+    bytes.append(scidLen ?? UInt8(scid.count))
+    bytes += scid
+    bytes += payload
+    return bytes
+}
+
+/// Wraps a QUIC payload in Ethernet + IPv4 + UDP. Detection is the long-header
+/// bit on UDP/443, so the destination port defaults to 443.
+private func quicFrame(
+    _ payload: [UInt8],
+    src: String = "192.168.1.30",
+    dst: String = "142.250.72.196",
+    srcPort: UInt16 = 55_000,
+    dstPort: UInt16 = 443
+)
+    -> [UInt8]
+{
+    PacketBuilder.ethernetIPv4(
+        proto: 17,
+        src: src,
+        dst: dst,
+        payload: PacketBuilder.udp(srcPort: srcPort, dstPort: dstPort, payload: payload)
+    )
+}
+
+private extension DecodedPacket {
+    func layer(_ kind: ProtocolKind) -> DecodedLayer? {
+        layers.first { $0.proto == kind }
+    }
+}
+
+// MARK: - QUICDecodeTests
+
+/// Clear-text QUIC long-header metadata (RFC 9000 §17.2) on UDP/443 — packet
+/// type, version, and the destination/source connection IDs only. The decoder
+/// never decrypts or guesses any protected field; short headers and truncated
+/// headers stay honest (identification only, or UDP per the existing gate).
+@Suite("QUIC decode")
+struct QUICDecodeTests {
+    @Test("An Initial long header surfaces type, version, and both connection IDs over UDP/443")
+    func initialLongHeader() {
+        let dcid: [UInt8] = [0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08]
+        let scid: [UInt8] = [0xAA, 0xBB, 0xCC, 0xDD]
+        let frame = quicFrame(quicLongHeader(firstByte: 0xC0, version: 1, dcid: dcid, scid: scid))
+        let packet = decodeFrame(frame)
+
+        #expect(packet.appProtocol == .quic)
+        #expect(packet.transport == .udp)
+        #expect(packet.protocolStack == [.ipv4, .udp, .quic])
+        // The UDP five-tuple is untouched by app-layer enrichment.
+        #expect(packet.sourceEndpoint == IPEndpoint(ip: "192.168.1.30", port: 55_000))
+        #expect(packet.destinationEndpoint == IPEndpoint(ip: "142.250.72.196", port: 443))
+        #expect(packet.fiveTuple?.proto == .udp)
+
+        let quic = packet.layer(.quic)
+        #expect(quic?.fields.contains(DecodedField(name: "Packet Type", value: "Initial")) == true)
+        #expect(quic?.fields.contains(DecodedField(name: "Version", value: "0x00000001")) == true)
+        #expect(quic?.fields.contains(DecodedField(name: "Destination CID", value: "0102030405060708")) == true)
+        #expect(quic?.fields.contains(DecodedField(name: "Source CID", value: "aabbccdd")) == true)
+    }
+
+    @Test("The v1 packet-type bits name 0-RTT, Handshake, and Retry")
+    func packetTypeNames() {
+        let cases: [(UInt8, String)] = [(0xC0, "Initial"), (0xD0, "0-RTT"), (0xE0, "Handshake"), (0xF0, "Retry")]
+        for (firstByte, name) in cases {
+            let frame = quicFrame(quicLongHeader(firstByte: firstByte, version: 1, dcid: [0x01, 0x02], scid: [0x03]))
+            let packet = decodeFrame(frame)
+            #expect(packet.layer(.quic)?.fields.contains(DecodedField(name: "Packet Type", value: name)) == true)
+        }
+    }
+
+    @Test("A zero-length source connection ID is labelled honestly")
+    func zeroLengthSourceCID() {
+        let frame = quicFrame(quicLongHeader(firstByte: 0xC0, version: 1, dcid: [0x01, 0x02, 0x03, 0x04], scid: []))
+        let packet = decodeFrame(frame)
+        #expect(packet.layer(.quic)?.fields.contains(
+            DecodedField(name: "Source CID", value: "(zero-length)")
+        ) == true)
+    }
+
+    @Test("Version 0 is labelled Version Negotiation")
+    func versionNegotiation() {
+        let frame = quicFrame(quicLongHeader(firstByte: 0x80, version: 0, dcid: [0x01, 0x02], scid: [0x03, 0x04]))
+        let packet = decodeFrame(frame)
+
+        let quic = packet.layer(.quic)
+        #expect(quic?.summary == "Version Negotiation")
+        #expect(quic?.fields.contains(DecodedField(name: "Packet Type", value: "Version Negotiation")) == true)
+        #expect(quic?.fields.contains(
+            DecodedField(name: "Version", value: "Version Negotiation (0x00000000)")
+        ) == true)
+    }
+
+    @Test("A non-v1 version renders the raw type rather than assuming the v1 mapping")
+    func nonV1VersionRawType() {
+        // QUIC v2 (RFC 9369) is 0x6b3343cf and remaps the type codepoints, so the
+        // v1 names must not be applied to it.
+        let frame = quicFrame(quicLongHeader(firstByte: 0xC0, version: 0x6B3343CF, dcid: [0x01], scid: [0x02]))
+        let packet = decodeFrame(frame)
+
+        let quic = packet.layer(.quic)
+        #expect(quic?.fields.contains(DecodedField(name: "Packet Type", value: "Long Header (type 0)")) == true)
+        #expect(quic?.fields.contains(DecodedField(name: "Version", value: "0x6b3343cf")) == true)
+    }
+
+    @Test("A connection ID length over the 20-byte cap stays UDP")
+    func oversizedCIDStaysUDP() {
+        // A 21-byte DCID exceeds RFC 9000's 20-byte maximum: never trust the parse.
+        let dcid = [UInt8](repeating: 0x11, count: 21)
+        let frame = quicFrame(quicLongHeader(firstByte: 0xC0, version: 1, dcid: dcid, scid: [0x02]))
+        let packet = decodeFrame(frame)
+
+        #expect(packet.appProtocol == nil)
+        #expect(packet.protocolStack == [.ipv4, .udp])
+    }
+
+    @Test("A truncated long header stays UDP rather than becoming a false-positive QUIC session")
+    func truncatedHeaderStaysUDP() {
+        // Long-header form bit set, but the header is cut before the version field.
+        let frame = quicFrame([0xC0, 0x00, 0x00])
+        let packet = decodeFrame(frame)
+
+        #expect(packet.appProtocol == nil)
+        #expect(packet.protocolStack == [.ipv4, .udp])
+    }
+
+    @Test("Truncating a valid QUIC frame to every prefix never crashes")
+    func truncatedPrefixesNeverCrash() {
+        let frame = quicFrame(quicLongHeader(
+            firstByte: 0xC0, version: 1, dcid: [0x01, 0x02, 0x03, 0x04], scid: [0xAA, 0xBB]
+        ))
+        for length in 0 ..< frame.count {
+            _ = decodeFrame(Array(frame.prefix(length)))
+        }
+        #expect(decodeFrame(frame).appProtocol == .quic)
+    }
+
+    @Test("A short-header QUIC packet stays UDP per the existing gate")
+    func shortHeaderStaysUDP() {
+        // Header form bit clear (0x40) — the decoder never guesses a short header's
+        // encrypted fields, so it stays a bare UDP datagram.
+        let frame = quicFrame([0x40, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08])
+        let packet = decodeFrame(frame)
+        #expect(packet.appProtocol == nil)
+        #expect(packet.protocolStack == [.ipv4, .udp])
+    }
+
+    @Test("A long header on a non-443 port stays UDP")
+    func longHeaderOffPortStaysUDP() {
+        let frame = quicFrame(
+            quicLongHeader(firstByte: 0xC0, version: 1, dcid: [0x01, 0x02], scid: [0x03]),
+            srcPort: 55_000,
+            dstPort: 4_433
+        )
+        let packet = decodeFrame(frame)
+        #expect(packet.appProtocol == nil)
+        #expect(packet.protocolStack == [.ipv4, .udp])
+    }
+
+    @Test("Ordinary UDP/443 payload without the long-header bit is not mistaken for QUIC")
+    func nonQUICUDPStaysUDP() {
+        let frame = quicFrame([UInt8](repeating: 0x00, count: 32))
+        let packet = decodeFrame(frame)
+        #expect(packet.appProtocol == nil)
+        #expect(packet.protocolStack == [.ipv4, .udp])
+    }
+
+    @Test("An arbitrary UDP/443 payload with only the high bit set is not mistaken for QUIC")
+    func highBitAloneIsNotQUIC() {
+        let frame = quicFrame([0x80, 0x01, 0x02, 0x03, 0x04, 0xFF, 0xFF, 0xFF])
+        let packet = decodeFrame(frame)
+        #expect(packet.appProtocol == nil)
+        #expect(packet.protocolStack == [.ipv4, .udp])
+    }
+}

--- a/TracexyTests/Core/Protocol/STUNDecodeTests.swift
+++ b/TracexyTests/Core/Protocol/STUNDecodeTests.swift
@@ -1,0 +1,276 @@
+import Foundation
+import Testing
+@testable import Tracexy
+
+// MARK: - Helpers
+
+private func decodeFrame(_ frame: [UInt8], linkType: UInt32 = LinkType.ethernet) -> DecodedPacket {
+    PacketDecoder.decode(
+        PacketBuffer(frame),
+        linkType: linkType,
+        timestamp: Date(timeIntervalSince1970: 1_700_000_000),
+        originalLength: frame.count
+    )
+}
+
+/// A fixed 20-byte STUN header (RFC 5389) plus optional attribute bytes. `length`
+/// is written verbatim so tests can exercise honest and malformed declarations.
+private func stunMessage(
+    type: UInt16,
+    length: UInt16,
+    cookie: UInt32 = 0x2112A442,
+    transactionID: [UInt8] = Array(repeating: 0xAB, count: 12),
+    attributes: [UInt8] = []
+)
+    -> [UInt8]
+{
+    var bytes: [UInt8] = [UInt8(type >> 8), UInt8(type & 0xFF), UInt8(length >> 8), UInt8(length & 0xFF)]
+    bytes += [
+        UInt8((cookie >> 24) & 0xFF),
+        UInt8((cookie >> 16) & 0xFF),
+        UInt8((cookie >> 8) & 0xFF),
+        UInt8(cookie & 0xFF),
+    ]
+    bytes += transactionID
+    bytes += attributes
+    return bytes
+}
+
+/// One STUN attribute TLV (RFC 5389 §15): 2-byte type, 2-byte value length, the
+/// value, and 4-byte-boundary padding. `length` is written from the real value
+/// length so a caller can compose a well-formed attribute region.
+private func stunAttribute(type: UInt16, value: [UInt8]) -> [UInt8] {
+    var bytes: [UInt8] = [UInt8(type >> 8), UInt8(type & 0xFF), UInt8(value.count >> 8), UInt8(value.count & 0xFF)]
+    bytes += value
+    while bytes.count % 4 != 0 {
+        bytes.append(0)
+    }
+    return bytes
+}
+
+/// Wraps a STUN message in Ethernet + IPv4 + UDP on ephemeral ICE-style ports —
+/// STUN detection is content-based, so the ports are deliberately not well-known.
+private func stunFrame(
+    _ message: [UInt8],
+    src: String = "192.168.1.20",
+    dst: String = "18.184.7.9",
+    srcPort: UInt16 = 54_321,
+    dstPort: UInt16 = 51_820
+)
+    -> [UInt8]
+{
+    PacketBuilder.ethernetIPv4(
+        proto: 17,
+        src: src,
+        dst: dst,
+        payload: PacketBuilder.udp(srcPort: srcPort, dstPort: dstPort, payload: message)
+    )
+}
+
+private extension DecodedPacket {
+    func layer(_ kind: ProtocolKind) -> DecodedLayer? {
+        layers.first { $0.proto == kind }
+    }
+}
+
+// MARK: - STUNDecodeTests
+
+@Suite("STUN decode")
+struct STUNDecodeTests {
+    @Test("Binding Request decodes over the preserved UDP five-tuple")
+    func bindingRequest() {
+        let frame = stunFrame(stunMessage(type: 0x0001, length: 0))
+        let packet = decodeFrame(frame)
+
+        #expect(packet.appProtocol == .stun)
+        #expect(packet.transport == .udp)
+        #expect(packet.protocolStack == [.ipv4, .udp, .stun])
+
+        // The UDP five-tuple and endpoints are untouched by app-layer enrichment.
+        #expect(packet.sourceEndpoint == IPEndpoint(ip: "192.168.1.20", port: 54_321))
+        #expect(packet.destinationEndpoint == IPEndpoint(ip: "18.184.7.9", port: 51_820))
+        #expect(packet.fiveTuple?.proto == .udp)
+
+        let stun = packet.layer(.stun)
+        #expect(stun?.summary == "Binding Request")
+        #expect(stun?.fields.contains(DecodedField(name: "Message Type", value: "Binding Request (0x0001)")) == true)
+        #expect(stun?.fields.contains(DecodedField(name: "Message Length", value: "0")) == true)
+        #expect(stun?.fields.contains(DecodedField(name: "Magic Cookie", value: "0x2112a442")) == true)
+        #expect(stun?.fields.contains(
+            DecodedField(name: "Transaction ID", value: "abababababababababababab")
+        ) == true)
+    }
+
+    @Test("Binding Success Response with attributes reports the declared length")
+    func bindingSuccessResponse() {
+        // 8 bytes of (unparsed) attribute data; declared length must match.
+        let attributes = [UInt8](repeating: 0x20, count: 8)
+        let frame = stunFrame(stunMessage(type: 0x0101, length: 8, attributes: attributes))
+        let packet = decodeFrame(frame)
+
+        #expect(packet.appProtocol == .stun)
+        let stun = packet.layer(.stun)
+        #expect(stun?.summary == "Binding Success Response")
+        #expect(stun?.fields.contains(DecodedField(name: "Message Length", value: "8")) == true)
+    }
+
+    @Test("Content detection remains port-independent on a DNS-associated port")
+    func stunOnPort53() {
+        let frame = stunFrame(stunMessage(type: 0x0001, length: 0), dstPort: 53)
+        let packet = decodeFrame(frame)
+
+        #expect(packet.appProtocol == .stun)
+        #expect(packet.protocolStack == [.ipv4, .udp, .stun])
+    }
+
+    @Test("An unknown but valid STUN type uses an honest hex fallback")
+    func unknownTypeHexFallback() {
+        let frame = stunFrame(stunMessage(type: 0x0002, length: 0))
+        let packet = decodeFrame(frame)
+        #expect(packet.appProtocol == .stun)
+        #expect(packet.layer(.stun)?.summary == "0x0002")
+    }
+
+    @Test("A wrong magic cookie is not misclassified — the session stays UDP")
+    func invalidCookieStaysUDP() {
+        let frame = stunFrame(stunMessage(type: 0x0001, length: 0, cookie: 0xDEADBEEF))
+        let packet = decodeFrame(frame)
+        #expect(packet.appProtocol == nil)
+        #expect(packet.protocolStack == [.ipv4, .udp])
+    }
+
+    @Test("A non-aligned declared length is rejected")
+    func nonAlignedLengthStaysUDP() {
+        // 2 is not a multiple of 4, so the attribute length is malformed.
+        let frame = stunFrame(stunMessage(type: 0x0001, length: 2, attributes: [0x00, 0x00]))
+        let packet = decodeFrame(frame)
+        #expect(packet.appProtocol == nil)
+        #expect(packet.protocolStack == [.ipv4, .udp])
+    }
+
+    @Test("A declared length exceeding the captured payload is rejected")
+    func oversizedLengthStaysUDP() {
+        // Claims 100 attribute bytes that are not present in the 20-byte payload.
+        let frame = stunFrame(stunMessage(type: 0x0001, length: 100))
+        let packet = decodeFrame(frame)
+        #expect(packet.appProtocol == nil)
+        #expect(packet.protocolStack == [.ipv4, .udp])
+    }
+
+    @Test("A set leading type bit is rejected")
+    func nonZeroLeadingBitsStayUDP() {
+        // 0xC001 has both leading type bits set, which STUN forbids.
+        let frame = stunFrame(stunMessage(type: 0xC001, length: 0))
+        let packet = decodeFrame(frame)
+        #expect(packet.appProtocol == nil)
+    }
+
+    @Test("Ordinary UDP payload is never mistaken for STUN")
+    func nonSTUNUDPStaysUDP() {
+        let frame = stunFrame([UInt8](repeating: 0x00, count: 20))
+        let packet = decodeFrame(frame)
+        #expect(packet.appProtocol == nil)
+        #expect(packet.protocolStack == [.ipv4, .udp])
+    }
+
+    @Test("Truncating a valid STUN frame to every prefix never crashes or misclassifies")
+    func truncatedSTUN() {
+        let frame = stunFrame(stunMessage(type: 0x0101, length: 8, attributes: [UInt8](repeating: 0x20, count: 8)))
+        for length in 0 ..< frame.count {
+            let prefix = Array(frame.prefix(length))
+            let packet = decodeFrame(prefix)
+            // Any cut into the STUN bytes leaves the declared length unsatisfiable,
+            // so a truncated frame must never surface as STUN.
+            #expect(packet.appProtocol != .stun)
+        }
+        // The full frame still decodes as STUN (sanity).
+        #expect(decodeFrame(frame).appProtocol == .stun)
+    }
+
+    // MARK: Attributes
+
+    @Test("A MAPPED-ADDRESS attribute decodes its IPv4 reflexive address and port")
+    func mappedAddressIPv4() {
+        // reserved(0) family(IPv4=1) port(3478=0x0D96) address(198.51.100.7)
+        let value: [UInt8] = [0x00, 0x01, 0x0D, 0x96, 198, 51, 100, 7]
+        let attribute = stunAttribute(type: 0x0001, value: value)
+        let frame = stunFrame(stunMessage(type: 0x0101, length: UInt16(attribute.count), attributes: attribute))
+        let packet = decodeFrame(frame)
+
+        #expect(packet.appProtocol == .stun)
+        #expect(packet.layer(.stun)?.fields.contains(
+            DecodedField(name: "Attribute: MAPPED-ADDRESS", value: "198.51.100.7:3478")
+        ) == true)
+    }
+
+    @Test("An XOR-MAPPED-ADDRESS attribute un-masks its IPv4 address and port")
+    func xorMappedAddressIPv4() {
+        // 203.0.113.5:50000, XOR-masked with the magic cookie (address) and its
+        // high half 0x2112 (port): X-port 0xE242, X-addr EA.12.D5.47.
+        let value: [UInt8] = [0x00, 0x01, 0xE2, 0x42, 0xEA, 0x12, 0xD5, 0x47]
+        let attribute = stunAttribute(type: 0x0020, value: value)
+        let frame = stunFrame(stunMessage(type: 0x0101, length: UInt16(attribute.count), attributes: attribute))
+        let packet = decodeFrame(frame)
+
+        #expect(packet.layer(.stun)?.fields.contains(
+            DecodedField(name: "Attribute: XOR-MAPPED-ADDRESS", value: "203.0.113.5:50000")
+        ) == true)
+    }
+
+    @Test("A named non-address attribute surfaces its name and a byte count, and padding is skipped")
+    func namedAttributeWithPadding() {
+        // SOFTWARE (0x8022) with a 3-byte value → one byte of 4-boundary padding.
+        let software = stunAttribute(type: 0x8022, value: [0x61, 0x62, 0x63])
+        let mapped = stunAttribute(type: 0x0001, value: [0x00, 0x01, 0x0D, 0x96, 198, 51, 100, 7])
+        let attributes = software + mapped
+        let frame = stunFrame(stunMessage(type: 0x0101, length: UInt16(attributes.count), attributes: attributes))
+        let packet = decodeFrame(frame)
+
+        let stun = packet.layer(.stun)
+        #expect(stun?.fields.contains(DecodedField(name: "Attribute: SOFTWARE", value: "3 bytes")) == true)
+        // The second attribute is only reachable if the first's padding was skipped.
+        #expect(stun?.fields.contains(
+            DecodedField(name: "Attribute: MAPPED-ADDRESS", value: "198.51.100.7:3478")
+        ) == true)
+    }
+
+    @Test("An unknown attribute type uses an honest hex label and a byte count")
+    func unknownAttributeHexLabel() {
+        let attribute = stunAttribute(type: 0x7F00, value: [0xDE, 0xAD, 0xBE, 0xEF])
+        let frame = stunFrame(stunMessage(type: 0x0101, length: UInt16(attribute.count), attributes: attribute))
+        let packet = decodeFrame(frame)
+
+        #expect(packet.layer(.stun)?.fields.contains(
+            DecodedField(name: "Attribute: 0x7f00", value: "4 bytes")
+        ) == true)
+    }
+
+    @Test("An IPv6-family MAPPED-ADDRESS stays metadata-only rather than fabricating an address")
+    func ipv6MappedAddressStaysMetadataOnly() {
+        // Family 0x02 (IPv6) with 16 address bytes — we decode IPv4 only.
+        let value: [UInt8] = [0x00, 0x02, 0x0D, 0x96] + [UInt8](repeating: 0x11, count: 16)
+        let attribute = stunAttribute(type: 0x0001, value: value)
+        let frame = stunFrame(stunMessage(type: 0x0101, length: UInt16(attribute.count), attributes: attribute))
+        let packet = decodeFrame(frame)
+
+        #expect(packet.appProtocol == .stun)
+        #expect(packet.layer(.stun)?.fields.contains(
+            DecodedField(name: "Attribute: MAPPED-ADDRESS", value: "20 bytes")
+        ) == true)
+    }
+
+    @Test("An attribute whose declared value overruns the message keeps the record without trapping")
+    func overrunningAttributeStopsWalk() {
+        // Declared attribute value length 0xFF, but only 4 value bytes are present
+        // inside the 8-byte declared attribute region — the walk must stop safely.
+        let attributes: [UInt8] = [0x00, 0x06, 0x00, 0xFF, 0xAA, 0xBB, 0xCC, 0xDD]
+        let frame = stunFrame(stunMessage(type: 0x0101, length: 8, attributes: attributes))
+        let packet = decodeFrame(frame)
+
+        // The header-level record survives; the malformed attribute is not surfaced.
+        #expect(packet.appProtocol == .stun)
+        let stun = packet.layer(.stun)
+        #expect(stun?.fields.contains(DecodedField(name: "Message Length", value: "8")) == true)
+        #expect(stun?.fields.contains { $0.name.hasPrefix("Attribute:") } == false)
+    }
+}

--- a/TracexyTests/Core/Protocol/TLSRecordTests.swift
+++ b/TracexyTests/Core/Protocol/TLSRecordTests.swift
@@ -1,0 +1,213 @@
+import Foundation
+import Testing
+@testable import Tracexy
+
+// MARK: - Helpers
+
+private func decodeFrame(_ frame: [UInt8], linkType: UInt32 = LinkType.ethernet) -> DecodedPacket {
+    PacketDecoder.decode(
+        PacketBuffer(frame),
+        linkType: linkType,
+        timestamp: Date(timeIntervalSince1970: 1_700_000_000),
+        originalLength: frame.count
+    )
+}
+
+private extension DecodedPacket {
+    func tlsLayer() -> DecodedLayer? {
+        layers.first { $0.proto == .tls }
+    }
+}
+
+// MARK: - TLSRecordTests
+
+/// Content-based TLS *record* recognition on any TCP port — metadata only. The
+/// decoder never decrypts, parses certificates, or reassembles the TCP stream; it
+/// surfaces the honest record header (content type, version, captured-vs-declared
+/// length) so real midstream Application Data / Alert / Change Cipher Spec /
+/// Heartbeat records stop showing up as bare TCP. ClientHello/ServerHello
+/// enrichment is unchanged and lives in the sibling enrichment suites.
+@Suite("TLS record recognition")
+struct TLSRecordTests {
+    @Test("Application Data is recognized and labelled without a handshake child")
+    func applicationData() {
+        let body = [UInt8](repeating: 0xAB, count: 32)
+        let frame = PacketBuilder.tlsRecordFrame(
+            contentType: 23, version: 0x0303, body: body, src: "10.0.0.5", dst: "93.184.216.34"
+        )
+        let packet = decodeFrame(frame)
+
+        #expect(packet.appProtocol == .tls)
+        #expect(packet.transport == .tcp)
+        #expect(packet.protocolStack == [.ipv4, .tcp, .tls])
+
+        let tls = packet.tlsLayer()
+        #expect(tls?.fields.contains(DecodedField(name: "Content Type", value: "Application Data (23)")) == true)
+        #expect(tls?.fields.contains(DecodedField(name: "Version", value: "TLS 1.2")) == true)
+        #expect(tls?.fields.contains(DecodedField(name: "Record Length", value: "32")) == true)
+        // No plaintext is decoded: encrypted records must not sprout handshake children.
+        #expect(tls?.children.isEmpty == true)
+        #expect(packet.sni == nil)
+    }
+
+    @Test("Alert records are recognized and not mislabelled Handshake")
+    func alert() {
+        let frame = PacketBuilder.tlsRecordFrame(
+            contentType: 21, version: 0x0303, body: [0x02, 0x28], src: "10.0.0.5", dst: "93.184.216.34"
+        )
+        let packet = decodeFrame(frame)
+
+        #expect(packet.protocolStack == [.ipv4, .tcp, .tls])
+        #expect(packet.tlsLayer()?.fields.contains(DecodedField(name: "Content Type", value: "Alert (21)")) == true)
+        #expect(packet.tlsLayer()?.children.isEmpty == true)
+    }
+
+    @Test("Change Cipher Spec is recognized")
+    func changeCipherSpec() {
+        let frame = PacketBuilder.tlsRecordFrame(
+            contentType: 20, version: 0x0303, body: [0x01], src: "10.0.0.5", dst: "93.184.216.34"
+        )
+        let packet = decodeFrame(frame)
+        #expect(packet.protocolStack == [.ipv4, .tcp, .tls])
+        #expect(
+            packet.tlsLayer()?.fields.contains(DecodedField(name: "Content Type", value: "Change Cipher Spec (20)"))
+                == true
+        )
+    }
+
+    @Test("Heartbeat is recognized")
+    func heartbeat() {
+        let frame = PacketBuilder.tlsRecordFrame(
+            contentType: 24, version: 0x0303, body: [0x01, 0x00, 0x00], src: "10.0.0.5", dst: "93.184.216.34"
+        )
+        let packet = decodeFrame(frame)
+        #expect(packet.tlsLayer()?.fields.contains(DecodedField(name: "Content Type", value: "Heartbeat (24)")) == true)
+    }
+
+    @Test("Recognition is port-independent")
+    func anyPort() {
+        let body = [UInt8](repeating: 0x11, count: 16)
+        let frame = PacketBuilder.tlsRecordFrame(
+            contentType: 23, version: 0x0303, body: body,
+            src: "10.0.0.5", dst: "93.184.216.34", srcPort: 44_100, dstPort: 8_443
+        )
+        let packet = decodeFrame(frame)
+        #expect(packet.appProtocol == .tls)
+        #expect(packet.protocolStack == [.ipv4, .tcp, .tls])
+    }
+
+    @Test("An undefined content type is not recognized as TLS")
+    func invalidContentTypeStaysTCP() {
+        // 0x19 (25) is outside the defined 20…24 range.
+        let frame = PacketBuilder.tlsRecordFrame(
+            contentType: 25, version: 0x0303, body: [UInt8](repeating: 0x00, count: 8),
+            src: "10.0.0.5", dst: "93.184.216.34"
+        )
+        let packet = decodeFrame(frame)
+        #expect(packet.appProtocol == nil)
+        #expect(packet.protocolStack == [.ipv4, .tcp])
+    }
+
+    @Test("A non-3 record major version is not recognized as TLS")
+    func invalidVersionStaysTCP() {
+        // Major version 2 (0x02xx) is not a TLS record-layer version.
+        let frame = PacketBuilder.tlsRecordFrame(
+            contentType: 23, version: 0x0203, body: [UInt8](repeating: 0x00, count: 8),
+            src: "10.0.0.5", dst: "93.184.216.34"
+        )
+        let packet = decodeFrame(frame)
+        #expect(packet.appProtocol == nil)
+        #expect(packet.protocolStack == [.ipv4, .tcp])
+    }
+
+    @Test("A declared length beyond the ciphertext allowance is rejected")
+    func oversizedLengthStaysTCP() {
+        // 20000 > 2^14 + 2048; impossible for a real TLS record fragment.
+        let frame = PacketBuilder.tlsRecordFrame(
+            contentType: 23, version: 0x0303, body: [UInt8](repeating: 0x00, count: 8),
+            declaredLength: 20_000, src: "10.0.0.5", dst: "93.184.216.34"
+        )
+        let packet = decodeFrame(frame)
+        #expect(packet.appProtocol == nil)
+        #expect(packet.protocolStack == [.ipv4, .tcp])
+    }
+
+    @Test("An incomplete 5-byte record header is not recognized as TLS")
+    func incompleteHeaderStaysTCP() {
+        // Only 3 of the 5 required header bytes are present on the TCP payload.
+        let frame = PacketBuilder.ethernetIPv4(
+            proto: 6, src: "10.0.0.5", dst: "93.184.216.34",
+            payload: PacketBuilder.tcp(srcPort: 50_000, dstPort: 443, flags: 0x18, payload: [0x17, 0x03, 0x03])
+        )
+        let packet = decodeFrame(frame)
+        #expect(packet.appProtocol == nil)
+        #expect(packet.protocolStack == [.ipv4, .tcp])
+    }
+
+    @Test("A record whose declared body exceeds the captured bytes is labelled a fragment")
+    func fragmentedRecordLabelledHonestly() {
+        // 40 bytes captured, but the record header declares 4096 — a mid-stream
+        // fragment (no TCP reassembly). Recognition still succeeds on the header.
+        let frame = PacketBuilder.tlsRecordFrame(
+            contentType: 23, version: 0x0303, body: [UInt8](repeating: 0xCD, count: 40),
+            declaredLength: 4_096, src: "10.0.0.5", dst: "93.184.216.34"
+        )
+        let packet = decodeFrame(frame)
+        #expect(packet.appProtocol == .tls)
+        #expect(
+            packet.tlsLayer()?.fields.contains(
+                DecodedField(name: "Record Length", value: "4096 declared, 40 captured (fragment)")
+            ) == true
+        )
+    }
+
+    @Test("ClientHello enrichment still decodes SNI and a Client Hello child")
+    func clientHelloEnrichmentPreserved() {
+        let frame = PacketBuilder.tlsClientHelloFrame(sni: "secure.example.com", src: "10.0.0.5", dst: "93.184.216.34")
+        let packet = decodeFrame(frame)
+        #expect(packet.sni == "secure.example.com")
+        let hello = packet.tlsLayer()?.children.first { $0.title == "Handshake: Client Hello" }
+        #expect(hello?.fields.contains(DecodedField(name: "server_name", value: "secure.example.com")) == true)
+        #expect(packet.tlsLayer()?.fields.contains(DecodedField(name: "Content Type", value: "Handshake (22)")) == true)
+    }
+
+    @Test("Coalesced TLS records are all surfaced without duplicating the protocol stack")
+    func coalescedRecords() {
+        let first = [UInt8(22), 0x03, 0x03, 0x00, 0x01, 0x00]
+        let second = [UInt8(23), 0x03, 0x03, 0x00, 0x03, 0xAA, 0xBB, 0xCC]
+        let frame = PacketBuilder.ethernetIPv4(
+            proto: 6,
+            src: "10.0.0.5",
+            dst: "93.184.216.34",
+            payload: PacketBuilder.tcp(
+                srcPort: 50_000,
+                dstPort: 443,
+                flags: 0x18,
+                payload: first + second
+            )
+        )
+        let packet = decodeFrame(frame)
+
+        #expect(packet.layers.filter { $0.proto == .tls }.count == 2)
+        #expect(packet.protocolStack == [.ipv4, .tcp, .tls])
+        #expect(packet.layers.last?.fields.contains(
+            DecodedField(name: "Content Type", value: "Application Data (23)")
+        ) == true)
+    }
+
+    @Test("A TLS-only session stays [.tcp, .tls] and offers no application exchange")
+    func tlsOnlySessionHasNoApplicationExchange() {
+        let frame = PacketBuilder.tlsRecordFrame(
+            contentType: 23, version: 0x0303, body: [UInt8](repeating: 0xAB, count: 64),
+            src: "10.0.0.5", dst: "93.184.216.34"
+        )
+        let captured = CapturedFrame(
+            bytes: frame, timestamp: Date(timeIntervalSince1970: 1_700_000_000), originalLength: frame.count
+        )
+        let sessions = SessionBuilder.build(from: [captured], linkType: LinkType.ethernet)
+        #expect(sessions.count == 1)
+        #expect(sessions.first?.protocolStack == [.tcp, .tls])
+        // Encrypted TLS carries no decoded request/response, so no Requests facet.
+        #expect(sessions.first?.hasApplicationExchange == false)
+    }
+}

--- a/TracexyTests/Core/Services/HelperClientDecisionTests.swift
+++ b/TracexyTests/Core/Services/HelperClientDecisionTests.swift
@@ -99,28 +99,29 @@ struct HelperCompatibilityTests {
         #expect(older == .installedIncompatible)
     }
 
-    @Test("A v1 helper is incompatible against the current v2 protocol; v2 is fine")
-    func protocolV2AgainstV1() {
-        // The typed-drain migration bumped the protocol to 2. A previously
-        // installed v1 helper — even a newer build — must be classified
-        // incompatible so Start stays gated (no unsafe legacy-frame fallback),
-        // while a matching v2 helper at the shipped build is compatible.
-        let legacyV1 = HelperClient.classifyCompatibility(
-            HelperInfo(binaryVersion: "0.1.1", buildNumber: 99, protocolVersion: 1),
-            expectedProtocolVersion: 2,
-            bundledBuild: 3
+    @Test("A pre-v3 helper is incompatible against the current v3 protocol; v3 is fine")
+    func protocolV3AgainstOlder() {
+        // The typed-CaptureConfiguration start surface bumped the protocol to 3. A
+        // previously installed v2 helper — even a newer build — must be classified
+        // incompatible so Start stays gated (no downgraded start request) and the
+        // old helper must be reinstalled, while a matching v3 helper at the shipped
+        // build is compatible.
+        let legacyV2 = HelperClient.classifyCompatibility(
+            HelperInfo(binaryVersion: "0.1.2", buildNumber: 99, protocolVersion: 2),
+            expectedProtocolVersion: 3,
+            bundledBuild: 4
         )
-        let currentV2 = HelperClient.classifyCompatibility(
-            HelperInfo(binaryVersion: "0.1.2", buildNumber: 3, protocolVersion: 2),
-            expectedProtocolVersion: 2,
-            bundledBuild: 3
+        let currentV3 = HelperClient.classifyCompatibility(
+            HelperInfo(binaryVersion: "0.1.3", buildNumber: 4, protocolVersion: 3),
+            expectedProtocolVersion: 3,
+            bundledBuild: 4
         )
 
-        #expect(legacyV1 == .installedIncompatible)
-        #expect(currentV2 == .installedCompatible)
+        #expect(legacyV2 == .installedIncompatible)
+        #expect(currentV3 == .installedCompatible)
         // An incompatible helper maps Start to a clear, gated message, not ready.
         #expect(
-            HelperClient.captureAvailability(for: legacyV1, unreachableDetail: nil)
+            HelperClient.captureAvailability(for: legacyV2, unreachableDetail: nil)
                 == .unavailable("the installed helper uses an incompatible protocol. Update it in Settings → Helper.")
         )
     }

--- a/TracexyTests/Core/Session/ActivityBuilderTests.swift
+++ b/TracexyTests/Core/Session/ActivityBuilderTests.swift
@@ -47,6 +47,28 @@ struct ActivityBuilderTests {
         #expect(result.ungrouped.count == 2)
     }
 
+    @Test("A DNS answer still attributes a connection late in the 30-second window")
+    func dnsCausalWindowSpansThirtySeconds() throws {
+        let base = Date()
+        let dns = Self.session(
+            host: "dns.google", at: base, process: "MyApp",
+            stack: [.udp, .dns], dnsQuery: "api.example.com", dnsAnswers: ["93.184.16.34"]
+        )
+        // 25 seconds after the answer — well beyond the identity window but still
+        // inside the DNS causal window, which is deliberately the longer of the two.
+        let tcp = Self.session(
+            host: "api.example.com", at: base.addingTimeInterval(25), process: "MyApp",
+            stack: [.tcp, .tls], destination: "93.184.16.34:443", sni: "api.example.com"
+        )
+
+        let result = ActivityBuilder.build(from: [dns, tcp])
+        let activity = try #require(result.activities.first)
+
+        #expect(activity.sessions.count == 2)
+        #expect(activity.confidence == .causal)
+        #expect(result.ungrouped.isEmpty)
+    }
+
     @Test("A shared address is contested, and that lowers confidence")
     func sharedAddressLowersConfidence() throws {
         let base = Date()
@@ -108,7 +130,7 @@ struct ActivityBuilderTests {
 
         #expect(activity.sessions.count == 2)
         // No observed causal step, so it must not claim one.
-        #expect(activity.confidence == .causal || activity.confidence == .strong)
+        #expect(activity.confidence == .strong)
         #expect(!activity.evidence.contains {
             if case .dnsAnswerToConnection = $0 {
                 true
@@ -116,6 +138,80 @@ struct ActivityBuilderTests {
                 false
             }
         })
+    }
+
+    @Test("Same process and name within the adjacency window still groups")
+    func sameIdentityWithinWindowGroups() throws {
+        let base = Date()
+        let first = Self.session(
+            host: "api.example.com", at: base, process: "MyApp", stack: [.tcp], sni: "api.example.com"
+        )
+        // Well inside the 2-second identity window.
+        let second = Self.session(
+            host: "api.example.com", at: base.addingTimeInterval(1.5),
+            process: "MyApp", stack: [.tls], sni: "api.example.com"
+        )
+
+        let result = ActivityBuilder.build(from: [first, second])
+        let activity = try #require(result.activities.first)
+
+        #expect(activity.sessions.count == 2)
+        #expect(result.ungrouped.isEmpty)
+    }
+
+    @Test("Same process and name beyond the adjacency window does not group")
+    func sameIdentityBeyondWindowDoesNotGroup() {
+        let base = Date()
+        let first = Self.session(
+            host: "api.example.com", at: base, process: "MyApp", stack: [.tcp], sni: "api.example.com"
+        )
+        // Three seconds apart: outside the identity window, so these are two
+        // separate actions even though process and name agree.
+        let second = Self.session(
+            host: "api.example.com", at: base.addingTimeInterval(3),
+            process: "MyApp", stack: [.tls], sni: "api.example.com"
+        )
+
+        let result = ActivityBuilder.build(from: [first, second])
+
+        #expect(result.activities.isEmpty)
+        #expect(result.ungrouped.count == 2)
+    }
+
+    @Test("Missing process attribution is never second-pass grouped")
+    func missingProcessNeverGroups() {
+        let base = Date()
+        // Same name, adjacent in time, but no observed process on either session.
+        // An absent process is not a matching process.
+        let first = Self.session(
+            host: "api.example.com", at: base, process: nil, stack: [.tcp], sni: "api.example.com"
+        )
+        let second = Self.session(
+            host: "api.example.com", at: base.addingTimeInterval(0.2),
+            process: nil, stack: [.tls], sni: "api.example.com"
+        )
+
+        let result = ActivityBuilder.build(from: [first, second])
+
+        #expect(result.activities.isEmpty)
+        #expect(result.ungrouped.count == 2)
+    }
+
+    @Test("Whitespace-only process attribution is never second-pass grouped")
+    func blankProcessNeverGroups() {
+        let base = Date()
+        let first = Self.session(
+            host: "api.example.com", at: base, process: "   ", stack: [.tcp], sni: "api.example.com"
+        )
+        let second = Self.session(
+            host: "api.example.com", at: base.addingTimeInterval(0.2),
+            process: "\t", stack: [.tls], sni: "api.example.com"
+        )
+
+        let result = ActivityBuilder.build(from: [first, second])
+
+        #expect(result.activities.isEmpty)
+        #expect(result.ungrouped.count == 2)
     }
 
     @Test("Unattributable sessions stay visible rather than being absorbed")

--- a/TracexyTests/Core/Session/SessionBuilderTests.swift
+++ b/TracexyTests/Core/Session/SessionBuilderTests.swift
@@ -10,9 +10,95 @@ import Foundation
 import Testing
 @testable import Tracexy
 
+// MARK: - SessionBuilderTests
+
 @Suite("SessionBuilder end-to-end")
 struct SessionBuilderTests {
     // MARK: Internal
+
+    @Test("A ClientHello split across TCP segments is reassembled into session metadata")
+    func splitTLSClientHello() {
+        let payload = PacketBuilder.tlsClientHello(sni: "split.example.com")
+        let cut = 3
+        let frames = [
+            tcpFrame(payload: Array(payload[..<cut]), sequence: 1_000, timestamp: 1),
+            tcpFrame(payload: Array(payload[cut...]), sequence: 1_000 + UInt32(cut), timestamp: 2),
+        ]
+
+        let session = SessionBuilder.build(from: frames, linkType: LinkType.ethernet).first
+        #expect(session?.sni == "split.example.com")
+        #expect(session?.host == "split.example.com")
+        #expect(session?.protocolStack == [.tcp, .tls])
+        #expect(session?.decodedLayers.first { $0.proto == .tls }?.byteRange == nil)
+    }
+
+    @Test("Out-of-order TCP segments drain deterministically before TLS classification")
+    func outOfOrderTLSClientHello() {
+        let payload = PacketBuilder.tlsClientHello(sni: "ordered.example.com")
+        let firstEnd = 3
+        let secondEnd = 18
+        let frames = [
+            tcpFrame(payload: Array(payload[..<firstEnd]), sequence: 4_000, timestamp: 1),
+            tcpFrame(
+                payload: Array(payload[secondEnd...]),
+                sequence: 4_000 + UInt32(secondEnd),
+                timestamp: 2
+            ),
+            tcpFrame(
+                payload: Array(payload[firstEnd ..< secondEnd]),
+                sequence: 4_000 + UInt32(firstEnd),
+                timestamp: 3
+            ),
+        ]
+
+        let session = SessionBuilder.build(from: frames, linkType: LinkType.ethernet).first
+        #expect(session?.sni == "ordered.example.com")
+        #expect(session?.protocolStack == [.tcp, .tls])
+    }
+
+    @Test("An HTTP header split across TCP segments retains its Host metadata")
+    func splitHTTPRequest() {
+        let payload = Array("GET /health HTTP/1.1\r\nHost: split-http.example\r\n\r\n".utf8)
+        let cut = 2
+        let frames = [
+            tcpFrame(
+                payload: Array(payload[..<cut]), sequence: 6_000, timestamp: 1,
+                sourcePort: 51_000, destinationPort: 80
+            ),
+            tcpFrame(
+                payload: Array(payload[cut...]), sequence: 6_000 + UInt32(cut), timestamp: 2,
+                sourcePort: 51_000, destinationPort: 80
+            ),
+        ]
+
+        let session = SessionBuilder.build(from: frames, linkType: LinkType.ethernet).first
+        #expect(session?.host == "split-http.example")
+        #expect(session?.protocolStack == [.tcp, .http])
+        #expect(session?.decodedLayers.first { $0.proto == .http }?.byteRange == nil)
+    }
+
+    @Test("A length-prefixed DNS query split across TCP segments is reassembled")
+    func splitTCPDNSQuery() {
+        let dns = PacketBuilder.dnsQuery(name: "split-dns.example")
+        let payload = [UInt8(dns.count >> 8), UInt8(dns.count & 0xFF)] + dns
+        let cut = 1
+        let frames = [
+            tcpFrame(
+                payload: Array(payload[..<cut]), sequence: 8_000, timestamp: 1,
+                sourcePort: 52_000, destinationPort: 53
+            ),
+            tcpFrame(
+                payload: Array(payload[cut...]), sequence: 8_000 + UInt32(cut), timestamp: 2,
+                sourcePort: 52_000, destinationPort: 53
+            ),
+        ]
+
+        let session = SessionBuilder.build(from: frames, linkType: LinkType.ethernet).first
+        #expect(session?.dnsQuery == "split-dns.example")
+        #expect(session?.host == "split-dns.example")
+        #expect(session?.protocolStack == [.tcp, .dns])
+        #expect(session?.decodedLayers.first { $0.proto == .dns }?.byteRange == nil)
+    }
 
     @Test
     func producesRealSessions() {
@@ -41,9 +127,39 @@ struct SessionBuilderTests {
     }
 
     @Test
-    func incompleteHandshakeIsWarning() {
+    func bareSynIsVisibleButNotWarned() {
+        // A SYN with no response is a real session and must stay visible, but the
+        // absence of an application protocol (or any reply) is not evidence of a
+        // problem — so it stays `.ok` rather than a fabricated warning.
         let syn = sessions().first { $0.host == "203.0.113.9" }
-        #expect(syn?.status == .warning)
+        #expect(syn != nil)
+        #expect(syn?.status == .ok)
+    }
+
+    @Test
+    func midstreamTCPWithoutAppDataIsNotWarned() {
+        // A TCP segment carrying payload we cannot classify — a captured tunnel,
+        // an unrecognised binary protocol, or a mid-stream capture that missed the
+        // handshake. It is a real session and stays visible, but "no application
+        // protocol decoded" is not evidence of a problem, so it stays `.ok`.
+        let frame = CapturedFrame(
+            bytes: PacketBuilder.ethernetIPv4(
+                proto: 6,
+                src: "10.0.0.5",
+                dst: "198.51.100.20",
+                payload: PacketBuilder.tcp(
+                    srcPort: 55_000, dstPort: 8_443, flags: 0x18,
+                    payload: [0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07]
+                )
+            ),
+            timestamp: Date(),
+            originalLength: 74
+        )
+        let result = SessionBuilder.build(from: [frame], linkType: LinkType.ethernet)
+        let session = result.first { $0.destinationEndpoint.contains("198.51.100.20") }
+        #expect(session != nil)
+        #expect(session?.protocolStack.contains(.tcp) == true)
+        #expect(session?.status == .ok)
     }
 
     @Test
@@ -178,4 +294,32 @@ struct SessionBuilderTests {
     private func sessions() -> [SessionSummary] {
         SessionBuilder.build(from: SampleCapture.frames(now: Date()), linkType: LinkType.ethernet)
     }
+}
+
+private func tcpFrame(
+    payload: [UInt8],
+    sequence: UInt32,
+    timestamp: TimeInterval,
+    sourcePort: UInt16 = 50_000,
+    destinationPort: UInt16 = 443
+)
+    -> CapturedFrame
+{
+    let bytes = PacketBuilder.ethernetIPv4(
+        proto: 6,
+        src: "10.0.0.5",
+        dst: "93.184.216.34",
+        payload: PacketBuilder.tcp(
+            srcPort: sourcePort,
+            dstPort: destinationPort,
+            flags: 0x18,
+            payload: payload,
+            sequence: sequence
+        )
+    )
+    return CapturedFrame(
+        bytes: bytes,
+        timestamp: Date(timeIntervalSince1970: timestamp),
+        originalLength: bytes.count
+    )
 }

--- a/TracexyTests/Core/Session/TCPStreamReassemblerTests.swift
+++ b/TracexyTests/Core/Session/TCPStreamReassemblerTests.swift
@@ -1,0 +1,76 @@
+import Testing
+@testable import Tracexy
+
+@Suite("Bounded TCP stream reassembly")
+struct TCPStreamReassemblerTests {
+    @Test("In-order segments extend one contiguous prefix")
+    func inOrder() {
+        var stream = TCPStreamReassembler()
+        #expect(stream.ingest(sequence: 100, payload: [1, 2]).contiguous == [1, 2])
+        #expect(stream.ingest(sequence: 102, payload: [3, 4]).contiguous == [1, 2, 3, 4])
+    }
+
+    @Test("A gap buffers until the missing segment arrives")
+    func outOfOrderGap() {
+        var stream = TCPStreamReassembler()
+        _ = stream.ingest(sequence: 100, payload: [1])
+        let buffered = stream.ingest(sequence: 103, payload: [4])
+        #expect(buffered.disposition == .buffered)
+        #expect(buffered.contiguous == [1])
+        #expect(stream.ingest(sequence: 101, payload: [2, 3]).contiguous == [1, 2, 3, 4])
+    }
+
+    @Test("Duplicate and overlapping retransmits emit no duplicate bytes")
+    func retransmitsAndOverlap() {
+        var stream = TCPStreamReassembler()
+        _ = stream.ingest(sequence: 10, payload: [1, 2, 3])
+        #expect(stream.ingest(sequence: 10, payload: [1, 2, 3]).disposition == .duplicate)
+        #expect(stream.ingest(sequence: 12, payload: [3, 4, 5]).contiguous == [1, 2, 3, 4, 5])
+    }
+
+    @Test("Overlapping pending segments drain deterministically")
+    func overlappingPending() {
+        var stream = TCPStreamReassembler()
+        _ = stream.ingest(sequence: 50, payload: [0])
+        _ = stream.ingest(sequence: 54, payload: [4, 5])
+        _ = stream.ingest(sequence: 53, payload: [3, 4])
+        #expect(stream.ingest(sequence: 51, payload: [1, 2]).contiguous == [0, 1, 2, 3, 4, 5])
+    }
+
+    @Test("UInt32 sequence wrap preserves contiguous order")
+    func sequenceWrap() {
+        var stream = TCPStreamReassembler()
+        _ = stream.ingest(sequence: UInt32.max - 1, payload: [1, 2])
+        #expect(stream.ingest(sequence: 0, payload: [3, 4]).contiguous == [1, 2, 3, 4])
+    }
+
+    @Test("Buffered-byte overflow resets to a bounded new anchor")
+    func byteCapacityReset() {
+        var stream = TCPStreamReassembler(maxBufferedBytes: 8, maxPendingSegments: 8)
+        _ = stream.ingest(sequence: 0, payload: [0, 1])
+        let reset = stream.ingest(sequence: 100, payload: [2, 3, 4, 5, 6, 7, 8])
+        #expect(reset.disposition == .reset)
+        #expect(reset.contiguous.count <= 8)
+        #expect(stream.didOverflow)
+    }
+
+    @Test("Pending segment count is bounded")
+    func pendingCountReset() {
+        var stream = TCPStreamReassembler(maxBufferedBytes: 64, maxPendingSegments: 2)
+        _ = stream.ingest(sequence: 0, payload: [0])
+        _ = stream.ingest(sequence: 10, payload: [1])
+        _ = stream.ingest(sequence: 20, payload: [2])
+        let reset = stream.ingest(sequence: 30, payload: [3])
+        #expect(reset.disposition == .reset)
+        #expect(reset.contiguous == [3])
+    }
+
+    @Test("Empty payload is a no-op")
+    func emptyPayload() {
+        var stream = TCPStreamReassembler()
+        _ = stream.ingest(sequence: 42, payload: [1])
+        let empty = stream.ingest(sequence: 43, payload: [])
+        #expect(empty.disposition == .duplicate)
+        #expect(empty.contiguous == [1])
+    }
+}

--- a/TracexyTests/Models/UI/CaptureSettingsTests.swift
+++ b/TracexyTests/Models/UI/CaptureSettingsTests.swift
@@ -1,0 +1,106 @@
+import Foundation
+import Testing
+@testable import Tracexy
+
+// MARK: - CaptureSettingsTests
+
+@Suite("Capture settings and configuration")
+struct CaptureSettingsTests {
+    @Test("Configuration validates, normalizes, and clamps untrusted values")
+    func validation() throws {
+        let raw = CaptureConfiguration(
+            interface: "  en0  ",
+            snapLength: Int.max,
+            promiscuous: true,
+            bpf: "  tcp port 443  "
+        )
+        let validated = try raw.validated().get()
+
+        #expect(validated.interface == "en0")
+        #expect(validated.snapLength == CaptureConfiguration.snapLengthRange.upperBound)
+        #expect(validated.promiscuous)
+        #expect(validated.bpf == "tcp port 443")
+        #expect(CaptureConfiguration.clampedSnapLength(0) == CaptureConfiguration.defaultSnapLength)
+    }
+
+    @Test("Configuration rejects an empty interface and oversized BPF")
+    func rejection() {
+        let empty = CaptureConfiguration(interface: "  ", snapLength: 64, promiscuous: false, bpf: nil)
+        let oversized = CaptureConfiguration(
+            interface: "en0",
+            snapLength: 64,
+            promiscuous: false,
+            bpf: String(repeating: "x", count: CaptureConfiguration.maxBPFLength + 1)
+        )
+
+        #expect(empty.validated().failure == .emptyInterface)
+        #expect(oversized.validated().failure == .bpfTooLong)
+    }
+
+    @Test("Secure coding round-trip preserves the typed XPC command")
+    func secureCodingRoundTrip() throws {
+        let original = CaptureConfiguration(
+            interface: "utun4",
+            snapLength: 131_072,
+            promiscuous: false,
+            bpf: "udp port 53"
+        )
+        let data = try NSKeyedArchiver.archivedData(withRootObject: original, requiringSecureCoding: true)
+        let unarchived = try NSKeyedUnarchiver.unarchivedObject(
+            ofClass: CaptureConfiguration.self,
+            from: data
+        )
+        let decoded = try #require(unarchived)
+
+        #expect(decoded.interface == original.interface)
+        #expect(decoded.snapLength == original.snapLength)
+        #expect(decoded.promiscuous == original.promiscuous)
+        #expect(decoded.bpf == original.bpf)
+    }
+
+    @Test("Persisted settings resolve to bounded capture inputs")
+    func settingsResolution() throws {
+        let suiteName = "CaptureSettingsTests.\(UUID().uuidString)"
+        let suite = try #require(UserDefaults(suiteName: suiteName))
+        defer { suite.removePersistentDomain(forName: suiteName) }
+        suite.set(-1, forKey: SettingsKeys.snapLength)
+        suite.set(true, forKey: SettingsKeys.promiscuous)
+        suite.set(CaptureFilterMode.custom.rawValue, forKey: SettingsKeys.captureFilterMode)
+        suite.set("  host 1.1.1.1  ", forKey: SettingsKeys.bpfExpression)
+        suite.set(50_000, forKey: SettingsKeys.retainPackets)
+
+        let configuration = CaptureSettingsResolver.configuration(interface: "en0", defaults: suite)
+        #expect(configuration.snapLength == CaptureConfiguration.defaultSnapLength)
+        #expect(configuration.promiscuous)
+        #expect(configuration.bpf == "host 1.1.1.1")
+        #expect(CaptureSettingsResolver.retainCapacity(defaults: suite) == 50_000)
+        #expect(CaptureSettingsResolver.resolvedRetainPackets(1_000_000) == 8_000)
+    }
+
+    @Test("Tunnel guidance appears only for a selected tunnel source")
+    func tunnelGuidance() {
+        let interfaces = [
+            NetworkInterface(
+                id: "en0", displayName: "Wi-Fi", category: .wifi,
+                ipv4: "192.0.2.10", isUp: true, isLoopback: false
+            ),
+            NetworkInterface(
+                id: "utun4", displayName: "VPN", category: .tunnels,
+                ipv4: nil, isUp: true, isLoopback: false
+            ),
+        ]
+
+        #expect(CaptureSourceGuidance.tunnelNote(for: "", in: interfaces) == nil)
+        #expect(CaptureSourceGuidance.tunnelNote(for: "en0", in: interfaces) == nil)
+        #expect(CaptureSourceGuidance.tunnelNote(for: "utun4", in: interfaces)?.contains("pre-encryption") == true)
+    }
+}
+
+private extension Result {
+    var failure: Failure? {
+        guard case let .failure(error) = self else {
+            return nil
+        }
+        return error
+    }
+}

--- a/TracexyTests/Models/UI/WorkspaceStateTests.swift
+++ b/TracexyTests/Models/UI/WorkspaceStateTests.swift
@@ -1,0 +1,29 @@
+import Foundation
+import Testing
+@testable import Tracexy
+
+@Suite("WorkspaceState defaults")
+struct WorkspaceStateTests {
+    @Test("A fresh workspace shows raw observed sessions, not inferred actions")
+    func defaultsToFlatSessions() {
+        let workspace = WorkspaceState(title: "Capture")
+        // Action grouping is inference and must be opt-in; the honest default is
+        // every observed session, flat.
+        #expect(workspace.sessionGrouping == .none)
+    }
+
+    @Test("The inferred and observed grouping choices all remain available")
+    func groupingChoicesRemainAvailable() {
+        // The default changed, but switching to Action/Host/Process must still work.
+        let workspace = WorkspaceState(title: "Capture")
+        for grouping in SessionGrouping.allCases {
+            workspace.sessionGrouping = grouping
+            #expect(workspace.sessionGrouping == grouping)
+        }
+        #expect(SessionGrouping.allCases.contains(.action))
+        #expect(SessionGrouping.action.isInferred)
+        #expect(!SessionGrouping.host.isInferred)
+        #expect(!SessionGrouping.process.isInferred)
+        #expect(!SessionGrouping.none.isInferred)
+    }
+}

--- a/TracexyTests/ViewModels/SessionSearchCommandTests.swift
+++ b/TracexyTests/ViewModels/SessionSearchCommandTests.swift
@@ -1,0 +1,59 @@
+import Foundation
+import Testing
+@testable import Tracexy
+
+@MainActor
+@Suite("Session search command")
+struct SessionSearchCommandTests {
+    // MARK: Internal
+
+    @Test("Find routes to Sessions and makes the existing search field usable")
+    func revealsSessionSearch() throws {
+        let environment = try makeCoordinator()
+        defer { environment.teardown() }
+        let coordinator = environment.coordinator
+        let workspace = coordinator.activeWorkspace
+        workspace.sidebarSelection = .overview
+        workspace.isFilterBarVisible = false
+        workspace.isSearchEnabled = false
+
+        coordinator.beginSessionSearch()
+
+        #expect(workspace.sidebarSelection == .sessions)
+        #expect(workspace.isFilterBarVisible)
+        #expect(workspace.isSearchEnabled)
+        #expect(workspace.searchFocusRequest != nil)
+    }
+
+    @Test("Every Find request receives a fresh focus identity")
+    func repeatedRequestsRefocus() throws {
+        let environment = try makeCoordinator()
+        defer { environment.teardown() }
+        let coordinator = environment.coordinator
+
+        coordinator.beginSessionSearch()
+        let firstRequest = coordinator.activeWorkspace.searchFocusRequest
+        coordinator.beginSessionSearch()
+
+        #expect(firstRequest != nil)
+        #expect(coordinator.activeWorkspace.searchFocusRequest != firstRequest)
+    }
+
+    // MARK: Private
+
+    private struct Environment {
+        let coordinator: MainContentCoordinator
+        let teardown: () -> Void
+    }
+
+    private func makeCoordinator(function: String = #function) throws -> Environment {
+        let suiteName = "com.amunx.tracexy.tests.\(function).\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        let coordinator = MainContentCoordinator(
+            layoutPreferences: WorkspaceLayoutPreferences(defaults: defaults)
+        )
+        return Environment(coordinator: coordinator) {
+            defaults.removePersistentDomain(forName: suiteName)
+        }
+    }
+}

--- a/TracexyTests/Views/Inspector/DecodedClipboardTextTests.swift
+++ b/TracexyTests/Views/Inspector/DecodedClipboardTextTests.swift
@@ -1,0 +1,28 @@
+import Testing
+@testable import Tracexy
+
+@Suite("Decoded inspector clipboard text")
+struct DecodedClipboardTextTests {
+    @Test("Field actions preserve the decoded name and value verbatim")
+    func fieldText() {
+        let field = DecodedField(name: "Server Name", value: "api.example.test")
+
+        #expect(DecodedClipboardText.value(field) == "api.example.test")
+        #expect(DecodedClipboardText.name(field) == "Server Name")
+        #expect(DecodedClipboardText.nameValue(field) == "Server Name: api.example.test")
+    }
+
+    @Test("Layer summary mirrors the visible header without duplicating its fields")
+    func layerSummary() {
+        let summarized = DecodedLayer(
+            proto: .tls,
+            title: "Transport Layer Security",
+            summary: "TLS 1.3",
+            fields: [DecodedField(name: "Server Name", value: "api.example.test")]
+        )
+        let titleOnly = DecodedLayer(proto: .tcp, title: "Transmission Control Protocol")
+
+        #expect(DecodedClipboardText.layerSummary(summarized) == "Transport Layer Security: TLS 1.3")
+        #expect(DecodedClipboardText.layerSummary(titleOnly) == "Transmission Control Protocol")
+    }
+}

--- a/TracexyTests/Views/Main/WorkspaceFooterModelTests.swift
+++ b/TracexyTests/Views/Main/WorkspaceFooterModelTests.swift
@@ -21,20 +21,25 @@ struct WorkspaceFooterModelTests {
     func placementAndIdentity() {
         let actions = makeActions()
 
-        // Exactly the six real effects — no invented controls.
-        #expect(actions.count == 6)
+        // Exactly the seven real effects — no invented controls.
+        #expect(actions.count == 7)
         #expect(Set(actions.map(\.kind)) == Set(FooterActionDescriptor.Kind.allCases))
 
         // Identity is the kind, so every surface variant agrees, and ids are unique.
         #expect(actions.map(\.id) == actions.map(\.kind))
         #expect(Set(actions.map(\.id)).count == actions.count)
 
-        // Clear / Advanced Filters / Auto Select are List Options, never inline.
+        // Capture/session maintenance and list behavior stay in List Options.
         let listOptions = actions.filter { $0.placement == .listOptions }
-        #expect(listOptions.map(\.kind) == [.clearSessions, .advancedFilters, .autoSelectLatest])
+        #expect(listOptions.map(\.kind) == [
+            .clearSessions,
+            .restoreRemovedSessions,
+            .advancedFilters,
+            .autoSelectLatest,
+        ])
 
         // Priority is monotonic across the whole catalog, primaries first.
-        #expect(actions.map(\.priority) == [0, 1, 2, 3, 4, 5])
+        #expect(actions.map(\.priority) == [0, 1, 2, 3, 4, 5, 6])
     }
 
     @Test("Every descriptor carries a distinct, non-empty title and help")
@@ -82,6 +87,18 @@ struct WorkspaceFooterModelTests {
 
         // Only Clear is destructive.
         #expect(makeActions().filter(\.isDestructive).map(\.kind) == [.clearSessions])
+    }
+
+    @Test("Restore Removed Sessions is enabled only when rows can be restored")
+    func restoreRemovedSessionsMetadata() {
+        let empty = action(.restoreRemovedSessions, in: makeActions(removedSessionCount: 0))
+        #expect(empty?.isEnabled == false)
+        #expect(empty?.title == "Restore Removed Sessions (0)")
+        #expect(empty?.isDestructive == false)
+
+        let available = action(.restoreRemovedSessions, in: makeActions(removedSessionCount: 3))
+        #expect(available?.isEnabled == true)
+        #expect(available?.title == "Restore Removed Sessions (3)")
     }
 
     @Test("Advanced Filters shows active/check state from the builder or live rules")
@@ -337,6 +354,7 @@ struct WorkspaceFooterModelTests {
         canAddFocusSet: Bool = true,
         isNoiseControlActive: Bool = false,
         hasSessions: Bool = true,
+        removedSessionCount: Int = 0,
         activeFilterRuleCount: Int = 0,
         isAdvancedFilterVisible: Bool = false,
         autoSelectLatest: Bool = false
@@ -348,6 +366,7 @@ struct WorkspaceFooterModelTests {
             canAddFocusSet: canAddFocusSet,
             isNoiseControlActive: isNoiseControlActive,
             hasSessions: hasSessions,
+            removedSessionCount: removedSessionCount,
             activeFilterRuleCount: activeFilterRuleCount,
             isAdvancedFilterVisible: isAdvancedFilterVisible,
             autoSelectLatest: autoSelectLatest

--- a/TracexyTests/Views/Main/WorkspaceFooterModelTests.swift
+++ b/TracexyTests/Views/Main/WorkspaceFooterModelTests.swift
@@ -275,16 +275,17 @@ struct WorkspaceFooterModelTests {
         ) == nil)
     }
 
-    // MARK: - Retention truncation (save/export bound, never capture loss)
+    // MARK: - Retention truncation (inspection-memory bound, never capture loss)
 
     @Test("Retention truncation is a neutral notice, never a capture-loss alarm")
     func retentionTruncationPresence() {
         #expect(telemetry(retainedFrameEvictionCount: 0, kind: .retentionTruncation) == nil)
 
         let truncated = telemetry(retainedFrameEvictionCount: 5_000, kind: .retentionTruncation)
-        // Neutral, not warning/error — sessions are intact; only the save tail was trimmed.
+        // Neutral, not warning/error — sessions and the disk-backed save are intact.
         #expect(truncated?.role == .neutral)
-        #expect(truncated?.text.contains("not retained") == true)
+        #expect(truncated?.text.contains("outside memory window") == true)
+        #expect(truncated?.help.contains("complete disk-backed save remain unaffected") == true)
         // It never masquerades as kernel packet loss.
         #expect(truncated?.kind != .packetDrops)
         // A pure retention eviction produces no packet-drop or helper-drop chip.

--- a/TracexyTests/Views/Main/WorkspacePresentationContractTests.swift
+++ b/TracexyTests/Views/Main/WorkspacePresentationContractTests.swift
@@ -98,6 +98,46 @@ struct WorkspacePresentationContractTests {
         #expect(filters.contains("systemImage: category == .security ? \"exclamationmark.shield\" : nil"))
     }
 
+    @Test("Saved captures expose native context actions and recoverable removal")
+    func savedCaptureRemovalUsesTrash() throws {
+        let sidebar = try readProjectFile("Tracexy/Views/Sidebar/SidebarView.swift")
+        let persistence = try readProjectFile(
+            "Tracexy/ViewModels/MainContentCoordinator+CapturePersistence.swift"
+        )
+
+        #expect(sidebar.contains("Button(\"Open\", systemImage: \"eye\")"))
+        #expect(sidebar.contains("Button(\"Reveal in Finder\", systemImage: \"folder\")"))
+        #expect(sidebar.contains("Button(\"Copy Path\", systemImage: \"doc.on.doc\")"))
+        #expect(sidebar.contains("Button(\"Move to Trash…\", systemImage: \"trash\", role: .destructive)"))
+        #expect(sidebar.contains(".confirmationDialog("))
+        #expect(persistence.contains("FileManager.default.trashItem(at: capture.url"))
+        #expect(!persistence.contains("removeItem(at: capture.url)"))
+    }
+
+    @Test("Sources category rows expose full-width context actions")
+    func sourceCategoryRowsHaveContextMenus() throws {
+        let sidebar = try readProjectFile("Tracexy/Views/Sidebar/SidebarView.swift")
+        let visibility = try readProjectFile(
+            "Tracexy/ViewModels/MainContentCoordinator+SourceVisibility.swift"
+        )
+
+        #expect(sidebar.contains("sourceCategoryLabel("))
+        #expect(sidebar.contains("copyLabel: \"Copy App Names\""))
+        #expect(sidebar.contains("copyLabel: \"Copy Domains\""))
+        #expect(sidebar.contains("copyLabel: \"Copy IP Addresses\""))
+        #expect(sidebar.contains("Button(\"Show All Sessions\", systemImage: \"rectangle.stack\")"))
+        #expect(sidebar.contains("Button(\"Remove from Sources\", systemImage: \"trash\", role: .destructive)"))
+        #expect(sidebar.contains("restoreLabel: \"Restore Hidden Apps\""))
+        #expect(sidebar.contains("restoreLabel: \"Restore Hidden Domains\""))
+        #expect(sidebar.contains("restoreLabel: \"Restore Hidden IP Addresses\""))
+        #expect(sidebar.contains(".frame(maxWidth: .infinity, alignment: .leading)"))
+        #expect(visibility.contains("sources.hiddenApps"))
+        #expect(visibility.contains("sources.hiddenDomains"))
+        #expect(visibility.contains("sources.hiddenIPs"))
+        #expect(visibility.contains("persistHiddenSources()"))
+        #expect(!visibility.contains("sessions.removeAll"))
+    }
+
     @Test("AI Assistant uses a truthful conversation shell")
     func assistantUsesConversationShell() throws {
         let source = try readProjectFile("Tracexy/Views/Inspector/AIAssistantDockView.swift")

--- a/TracexyTests/Views/Main/WorkspacePresentationContractTests.swift
+++ b/TracexyTests/Views/Main/WorkspacePresentationContractTests.swift
@@ -6,12 +6,37 @@ import Testing
 struct WorkspacePresentationContractTests {
     // MARK: Internal
 
+    @Test("Monitor navigation is exactly Overview, Sessions, Flow Map, in that order")
+    func monitorOrder() {
+        #expect(SidebarSection.monitor.items == [.overview, .sessions, .flow])
+    }
+
     @Test("Toolbar update badge keeps the approved capsule geometry")
     func updateBadgeMetrics() {
         #expect(Theme.Metrics.toolbarControlHeight == 32)
         #expect(Theme.Metrics.updateBadgeHeight == 24)
         #expect(Theme.Metrics.updateBadgeHorizontalPadding == 9)
         #expect(Theme.Metrics.updateBadgeStrokeWidth == 0.75)
+    }
+
+    @Test("Overview stays inside the workspace when the native sidebar is open")
+    func overviewUsesTheWorkspaceViewport() throws {
+        let source = try readProjectFile("Tracexy/Views/Overview/OverviewView.swift")
+
+        #expect(source.contains("GeometryReader { proxy in"))
+        #expect(source.contains("proxy.size.width >= Self.wideDashboardMinimumWidth"))
+        #expect(source.contains("proxy.size.width - Theme.Metrics.spacingL * 2"))
+    }
+
+    @Test("Overview summarizes findings and leaves evidence to Sessions")
+    func overviewDoesNotDuplicateTheFindingList() throws {
+        let source = try readProjectFile("Tracexy/Views/Overview/OverviewView.swift")
+
+        #expect(source.contains("findingSummaryBar"))
+        #expect(source.contains("Review \\(all.count.formatted()) in Sessions"))
+        #expect(!source.contains("findingPreviewLimit"))
+        #expect(!source.contains("findingRow("))
+        #expect(!source.contains("Open evidence"))
     }
 
     @Test("Details uses stacked inspector tables instead of List sections")

--- a/TracexyTests/Views/Main/WorkspacePresentationContractTests.swift
+++ b/TracexyTests/Views/Main/WorkspacePresentationContractTests.swift
@@ -71,6 +71,19 @@ struct WorkspacePresentationContractTests {
         #expect(source.contains(".accessibilityLabel(\"Add field\")"))
     }
 
+    @Test("Command-F focuses the existing Sessions search without adding a new search surface")
+    func sessionSearchUsesNativeFindCommand() throws {
+        let app = try readProjectFile("Tracexy/TracexyApp.swift")
+        let filterBar = try readProjectFile("Tracexy/Views/Sessions/SessionFilterBar.swift")
+
+        #expect(app.contains("coordinator.beginSessionSearch()"))
+        #expect(app.contains(".keyboardShortcut(\"f\", modifiers: .command)"))
+        #expect(filterBar.contains("@FocusState private var isSearchFieldFocused"))
+        #expect(filterBar.contains(".task(id: workspace.searchFocusRequest)"))
+        #expect(filterBar.contains(".focused($isSearchFieldFocused)"))
+        #expect(!filterBar.contains(".searchable"))
+    }
+
     @Test("Security is a toolbar-only quick filter over the scalable session workflow")
     func securityUsesSessionQuickFilter() throws {
         let root = try readProjectFile("Tracexy/Views/Main/RootView.swift")

--- a/TracexyTests/Views/Overview/OverviewScopeTests.swift
+++ b/TracexyTests/Views/Overview/OverviewScopeTests.swift
@@ -65,6 +65,48 @@ struct OverviewScopeTests {
         #expect(env.coordinator.captureStatistics == nil)
     }
 
+    @Test("Opening a saved file records truthful provenance and a real activity aggregation")
+    func savedCaptureExposesProvenance() throws {
+        let env = try makeLoadedCoordinator()
+        defer { env.teardown() }
+        let coordinator = env.coordinator
+
+        // The Overview labels the exact file it opened rather than guessing.
+        #expect(coordinator.isViewingSavedCapture)
+        #expect(coordinator.activeSavedCapture?.name == "sample")
+
+        // Frame count and duration come from the real file, not a fabricated total.
+        let activity = try #require(coordinator.savedCaptureActivity)
+        #expect(activity.totalFrames == coordinator.retainedFrameCount)
+        #expect(activity.totalFrames > 0)
+        #expect(activity.duration >= 0)
+        // A frames-over-time aggregation exists — the saved surface draws this, not
+        // the live "waiting for traffic" throughput state.
+        #expect(!activity.isEmpty)
+
+        // A file is shown in full: no fidelity, and neither capture-source loss nor
+        // local retention eviction is reported for it.
+        #expect(coordinator.captureStatistics == nil)
+        #expect(coordinator.helperBufferDropCount == 0)
+        #expect(coordinator.retainedFrameEvictionCount == 0)
+    }
+
+    @Test("Live/new/clear boundaries drop the saved-file identity so it never outlives the capture")
+    func clearingDropsSavedProvenance() throws {
+        let env = try makeLoadedCoordinator()
+        defer { env.teardown() }
+        let coordinator = env.coordinator
+
+        try #require(coordinator.activeSavedCapture != nil)
+        try #require(coordinator.savedCaptureActivity != nil)
+
+        coordinator.clearSessions()
+
+        #expect(coordinator.activeSavedCapture == nil)
+        #expect(coordinator.savedCaptureActivity == nil)
+        #expect(!coordinator.isViewingSavedCapture)
+    }
+
     @Test("Plaintext-HTTP finding states only the decoded fact, never exposure")
     func plaintextHTTPFindingIsEvidenceHonest() throws {
         let env = try makeLoadedCoordinator()

--- a/TracexyTests/Views/Overview/OverviewScopeTests.swift
+++ b/TracexyTests/Views/Overview/OverviewScopeTests.swift
@@ -150,6 +150,58 @@ struct OverviewScopeTests {
         #expect(matchingSessionIDs == findingSessionIDs)
     }
 
+    @Test("Removing sessions hides them across presentation surfaces and remains reversible")
+    func removedSessionsStayOutOfPresentation() throws {
+        let env = try makeLoadedCoordinator()
+        defer { env.teardown() }
+        let coordinator = env.coordinator
+        let target = try #require(coordinator.sessions.first)
+        let rawCount = coordinator.sessions.count
+        let rawBytes = coordinator.totalBytes
+        let targetHostCount = coordinator.sessions.filter { $0.host == target.host }.count
+
+        coordinator.select(target)
+        coordinator.removeSessionsFromView(Set([target.id]))
+
+        // Removal is a reversible presentation operation, never evidence loss.
+        #expect(coordinator.sessions.count == rawCount)
+        #expect(coordinator.sessions.contains { $0.id == target.id })
+        #expect(coordinator.removedSessionCount == 1)
+
+        // Every UI-facing seam excludes the removed identity and its rollups.
+        #expect(!coordinator.presentedSessions.contains { $0.id == target.id })
+        #expect(!coordinator.visibleSessions.contains { $0.id == target.id })
+        #expect(!coordinator.sessionRows.contains { $0.id == target.id })
+        #expect(coordinator.selectedSession == nil)
+        #expect(coordinator.activeWorkspace.selectedSessionID == nil)
+        #expect(coordinator.totalBytes == rawBytes - target.totalBytes)
+        #expect(coordinator.findings.allSatisfy { $0.sessionID != target.id })
+        #expect((coordinator.hosts.first { $0.name == target.host }?.count ?? 0) == targetHostCount - 1)
+
+        coordinator.restoreRemovedSessions()
+
+        #expect(coordinator.removedSessionCount == 0)
+        #expect(coordinator.presentedSessions.count == rawCount)
+        #expect(coordinator.visibleSessions.contains { $0.id == target.id })
+        #expect(coordinator.totalBytes == rawBytes)
+    }
+
+    @Test("Capture boundaries discard removed-session presentation state")
+    func clearDiscardsRemovedSessions() throws {
+        let env = try makeLoadedCoordinator()
+        defer { env.teardown() }
+        let coordinator = env.coordinator
+        let target = try #require(coordinator.sessions.first)
+
+        coordinator.removeSessionsFromView(Set([target.id]))
+        try #require(coordinator.removedSessionCount == 1)
+
+        coordinator.clearSessions()
+
+        #expect(coordinator.removedSessionCount == 0)
+        #expect(coordinator.removedSessionIDs.isEmpty)
+    }
+
     // MARK: Private
 
     private struct Environment {

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,14 +18,15 @@ This documentation describes what is actually in the source today, and clearly m
 
 ## Status at a glance
 
-**Implemented:** live libpcap capture through a signed helper, PCAP read/write and PCAPNG read,
-interface discovery, a bounds-checked packet decoder (L2–L4 plus DNS/TLS/HTTP-1/QUIC summaries),
-five-tuple session grouping, action correlation with confidence levels, per-process attribution where
-macOS reports it, and a native SwiftUI/AppKit interface with workspaces, filtering, focus sets, and an
-inspector.
+**Implemented:** live libpcap capture through a signed helper, PCAP read/write, PCAPNG read and
+disk-backed live-save, interface discovery, a bounds-checked packet decoder (L2–L4 plus
+DNS/TLS/HTTP-1/QUIC/STUN summaries), incremental five-tuple session grouping, action correlation with
+confidence levels, per-process attribution where macOS reports it, and a native SwiftUI/AppKit
+interface with workspaces, filtering, focus sets, and an inspector.
 
-**Partial:** application-layer decode is naming-level only — DNS records, TLS handshake metadata, the
-HTTP/1 request line, QUIC identification. Session building is a batch rebuild, not a stateful engine.
+**Partial:** application-layer decode remains metadata-focused — DNS records, TLS handshake and record
+metadata, HTTP/1 headers, QUIC long-header metadata, and STUN attributes. TCP prefix reassembly is
+bounded to initial TLS/HTTP/DNS metadata; a general stateful connection/reassembly engine is not present.
 
 **Planned / not yet implemented:** a decoder registry with dispatch-table handoff, a stateful
 connection table with TCP reassembly, an analysis/security engine, persistent SQLite storage, an

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -13,8 +13,9 @@ hostile capture file can never crash the app.
 ## The pipeline today
 
 **Capture** (`Tracexy/Core/Capture`) acquires frames and reads/writes capture files. Live capture
-runs through the privileged helper over libpcap; the app also reads classic PCAP and PCAPNG files and
-writes PCAP. Interface discovery and capture statistics live here.
+runs through the privileged helper over libpcap; the app also reads classic PCAP and PCAPNG files,
+writes classic PCAP where required, and saves complete live captures as PCAPNG. Interface discovery
+and capture statistics live here.
 
 **Protocol** (`Tracexy/Core/Protocol`) turns raw bytes into a `DecodedPacket`. `PacketBuffer` is a
 bounds-checked, zero-copy view over the frame: every read is offset-checked and **throws** on a short
@@ -92,9 +93,9 @@ never folded into one another:
   never imply a complete capture when the helper stage lost frames. Stop returns the worker's final
   flushed frames and final accounting in one typed reply, so teardown does not silently lose the tail
   or race a separate fetch against the next capture generation.
-- **Local raw-retention eviction** (`RetainedFrameBuffer`), a save/export memory bound. It is reported
-  separately as retention truncation and is never presented as captured-packet loss, since every
-  session is still accounted for — a `.pcap` save contains only the retained recent tail.
+- **Local inspection-window eviction** (`RetainedFrameBuffer`), a UI memory bound. It is reported
+  separately and is never presented as captured-packet loss: sessions remain accounted for while the
+  complete accepted raw stream is written off-main to a disk-backed pcapng spool for save/export.
 
 ## Planned / not yet implemented
 
@@ -102,7 +103,8 @@ These are design intent — do not write code, or read these docs, as if they ex
 
 - a **decoder registry** with dispatch-table handoff between protocols (replacing the current monolithic
   decoder);
-- a **stateful connection table** with TCP **reassembly** (today's grouping folds packets into
+- a full **stateful connection table** with general TCP **reassembly** (today's grouping includes only
+  bounded per-direction prefix reassembly for initial TLS/HTTP/DNS metadata and otherwise folds packets into
   per-tuple summaries, incrementally on the live path, but tracks no connection state or byte streams);
 - an **analysis / security** engine deriving latency, errors, and findings;
 - **persistent storage** (a SQLite session store with large-payload offload);

--- a/docs/protocol-support.md
+++ b/docs/protocol-support.md
@@ -33,16 +33,17 @@ field-by-field parse.
 | Protocol | Support | Not covered |
 |---|---|---|
 | DNS | Question name; answer records A, AAAA, CNAME, NS, PTR, MX, TXT, SRV, SOA (others shown by type); compression pointers; DNS-over-TCP length prefix | Full record-set decode; DNSSEC |
-| TLS | Handshake metadata only: record version, ClientHello (offered version, cipher-suite count, **SNI**, **ALPN**), ServerHello (chosen version and cipher) | **No decryption**; no certificate parsing; no application data |
+| TLS | Record metadata for all coalesced records in a payload; ClientHello (offered version, cipher-suite count, **SNI**, **ALPN**) and ServerHello (chosen version and cipher); bounded per-direction TCP prefix recovery when the first record is segmented | **No decryption**; no certificate parsing; no application data; no general stream tracking |
 | HTTP/1 | **Request-line recognition only** — the first line (method / target / version) plus the `Host` header | Full header set, response/status parsing, bodies, chunked/compressed content |
-| QUIC | **Identification only** — detected on UDP/443 by the long-header bit and labeled "QUIC (encrypted transport)" | Version, connection IDs, frames, any payload |
+| STUN | Detected by the magic cookie (port-independent): message type, length, magic cookie, transaction ID, and a bounds-checked walk of the RFC 5389 attribute TLVs — attributes named where known (else an honest hex type), with MAPPED-ADDRESS / XOR-MAPPED-ADDRESS **IPv4** reflexive `address:port` decoded when fully present | IPv6 reflexive addresses (metadata-only); attribute value bodies beyond addresses; ICE negotiation and TURN allocation state |
+| QUIC | **Long-header metadata only** — conservatively detected on UDP/443 from a complete clear-text prefix, valid fixed-bit semantics, and bounded connection IDs: packet type (Initial / 0-RTT / Handshake / Retry for v1, raw type otherwise), version (version 0 → Version Negotiation), and the destination/source connection IDs (≤ 20 bytes) | Frames and any encrypted payload; short or malformed headers (stay UDP); 0-RTT/handshake decryption; HTTP/3 |
 
 ## Explicitly not implemented
 
 - **No decryption** of TLS or QUIC. Tracexy reads only what is on the wire in the clear.
-- **No TCP reassembly.** Every application parser runs against a single packet's payload; there is no
-  stream buffer, so an HTTP request split across segments is only recognized from the segment that
-  carries its start.
+- **No general TCP connection/reassembly engine.** Session accumulation keeps only a bounded 16 KiB
+  prefix per direction until it can classify the first TLS record, HTTP header, or DNS-over-TCP
+  message, then releases the bytes. It does not reconstruct long-lived streams or application bodies.
 - **No deep HTTP/2** parsing, **no HTTP/3**, and **no WebSocket** decode. (`http2` and `websocket`
   exist as protocol labels for grouping, but the decoder never produces them from bytes.)
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -106,7 +106,8 @@ The **search row** below has an on/off checkbox, a field-scope menu (**All Field
 Protocol, Source, Destination, Summary — default All Fields), a search box with a clear button, an
 **Add Field** button, and the **Group By** menu. All Fields searches the host, client process, protocol
 labels, both endpoints, the info summary, and DNS answers. Turning the search off keeps the typed text
-but stops it constraining the list.
+but stops it constraining the list. Press **Command-F** from any main surface to return to Sessions,
+reveal this filter area if needed, enable search, and place the cursor in the existing search box.
 
 For finer control, **Add Field** opens the advanced rule builder: rows of *field · operator · value*,
 each independently on/off and joined to the previous row by AND or OR. Connectors evaluate strictly
@@ -123,10 +124,11 @@ investigation with its own filter, selection, and inspector layout.
 
 ## Inspector
 
-Selecting a session opens the inspector, in a right-hand or bottom layout. It shows the decoded
+Selecting a session opens the bottom evidence inspector. It shows the decoded
 protocol **layers** and fields for the representative packet, and a **hex** pane whose byte ranges line
-up with those fields — click a field to highlight the bytes it came from. When a session carries an
-application-layer exchange (HTTP, DNS), a requests facet is offered.
+up with those fields — click a field to highlight the bytes it came from. Right-click a layer or field
+to copy its visible summary, name, value, or combined name/value text without retyping it. When a
+session carries an application-layer exchange (HTTP, DNS), a requests facet is offered.
 
 The right-hand **Details** dock uses compact two-column tables for assessment, decoded layer facts,
 host baseline, related actions, findings, and grouping evidence. Technical values are selectable and

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -50,8 +50,9 @@ compact findings severity summary are kept in one native dashboard. Overview nev
 finding evidence list; its security summary links to the existing filtered Sessions workflow.
 
 For a live capture, the activity chart shows measured throughput and the storage card distinguishes
-kernel/interface loss, helper-buffer drops, and trimming of the local save/export retention window.
-Retention trimming does not remove accumulated sessions and is never reported as capture-source loss.
+kernel/interface loss, helper-buffer drops, and trimming of the bounded in-memory inspection window.
+Window trimming does not remove accumulated sessions or frames from the disk-backed live spool, and is
+never reported as capture-source loss.
 For an opened file, Overview shows file provenance and activity derived from its real frame timestamps;
 capture fidelity and original drop counters remain **Unknown** because a savefile cannot reconstruct
 what was missed when it was recorded.
@@ -73,25 +74,37 @@ session rather than disappearing.
 
 Select a session to enable the toolbar's **Export** menu beside the independent **Start** and inspector
 controls. The same menu is available from the session row's **Export** submenu. **Export Session**
-writes a versioned `.tracexysession` document containing the session summary and its locally retained
+writes a versioned `.tracexysession` document containing the session summary and its captured
 packet frames. **Export as pcap** writes a classic capture when all matching frames share one link type;
 **Export as pcapng** preserves mixed per-frame link types. Export is always an explicit local save-panel
-action and is limited to frames still present in the bounded raw-retention window.
+action. Live export reads the complete local pcapng spool; saved-capture export re-reads the source file,
+so the bounded in-memory inspection window does not silently truncate an export.
 
 ## Correlation into actions
 
-Related sessions are correlated into a higher-level **action** — for example a DNS lookup, the TCP
-connect to the address it returned, and the TLS handshake carrying that hostname. Grouping is an
-*inference*, so every action reports the strength of the evidence behind it: **causal** (a DNS answer
-named the very address the next connection dialed, or one process owned every session), **strong** (the
-DNS name, TLS SNI, and host all agree), or **weak** (sessions merely began close together). When two
+The session list opens **flat by default** — one row per session, exactly as decoded, so a busy
+capture shows every observed conversation rather than a handful of collapsed rows. Grouping into
+higher-level actions is *inference layered on top of the raw sessions*, so it is **opt-in**: choose
+**Action** from the **Group By** menu when you want the interpretation, and switch back to **None
+(flat)** — always one click away — whenever the grouping looks wrong. **Host** and **Process**
+grouping are also available; unlike Action they group on a recorded session attribute rather than
+inferring a causal relationship.
+
+When Action grouping is on, related sessions are correlated into a higher-level **action** — for
+example a DNS lookup, the TCP connect to the address it returned, and the TLS handshake carrying that
+hostname. Every action reports the strength of the evidence behind it: **causal** (a DNS answer named
+the very address the next connection dialed within a 30-second window), **strong** (the same observed
+process owns the sessions, or DNS name, TLS SNI, and host agree), or **weak** (sessions merely began
+close together). Correlation on identifiers alone — the same process talking to the same name with no
+observed causal step — is held to a tight bar: it needs a real observed process **and** an agreed
+name, and only groups sessions that began within a couple of seconds of each other. When two
 hostnames resolve to the same address (a shared CDN IP), the attribution is **contested**: Tracexy
 lowers the confidence and shows the competing names rather than silently guessing.
 
 ## Focus sets and filtering
 
 The filter area above the session list has two rows. The **protocol/category pills** narrow by
-protocol (DNS, TCP, UDP, TLS, HTTP, HTTP/2, QUIC, WebSocket), by evidence-backed **Security**
+protocol (DNS, TCP, UDP, TLS, HTTP, HTTP/2, QUIC, WebSocket, STUN), by evidence-backed **Security**
 findings, and by exact status (**Errors**). Selected protocol pills combine with OR, selected
 investigation pills combine with OR, and the two groups combine with AND — so choosing *TCP* and
 *Errors* shows TCP sessions that failed. *Errors* means exactly an error; a warning is not swept in.
@@ -128,7 +141,25 @@ Selecting a session opens the bottom evidence inspector. It shows the decoded
 protocol **layers** and fields for the representative packet, and a **hex** pane whose byte ranges line
 up with those fields — click a field to highlight the bytes it came from. Right-click a layer or field
 to copy its visible summary, name, value, or combined name/value text without retyping it. When a
-session carries an application-layer exchange (HTTP, DNS), a requests facet is offered.
+session carries an application-layer exchange (HTTP, DNS, STUN), a requests facet is offered.
+
+**STUN** is recognized by its RFC 5389 magic cookie on any port (it rides on ephemeral ICE ports, not
+a well-known one), so the traffic a capture would otherwise show as bare UDP is surfaced with its
+message type — Binding Request/Indication/Success/Error, or an honest hex value for other types —
+along with the declared length, magic cookie, and transaction ID. This is header **metadata only**:
+Tracexy does not track ICE state, follow TURN allocation state, or decrypt any payload.
+
+**TLS** is recognized by its record header on any TCP port, so an encrypted connection captured
+mid-stream is surfaced as TCP · TLS instead of bare TCP. Each recognized record reports its actual
+content type — Handshake, Application Data, Alert, Change Cipher Spec, or Heartbeat — with the
+record-layer version and record length. A ClientHello or ServerHello is enriched further with SNI,
+ALPN, negotiated version, and cipher suite. A bounded 16 KiB, per-direction TCP prefix reassembler in
+the session layer recovers this metadata when a first TLS record, HTTP header, or DNS-over-TCP message
+is split across nearby segments; it handles gaps, overlap, retransmission, and sequence wrap without
+retaining an unbounded stream. Tracexy still does **not** decrypt payloads, parse certificates, or offer
+a general connection/reassembly engine. When a record remains incomplete, its captured and declared
+lengths are labelled honestly, for example "4096 declared, 40 captured (fragment)". Encrypted TLS
+records carry no plaintext exchange, so a TLS-only session offers no requests facet.
 
 The right-hand **Details** dock uses compact two-column tables for assessment, decoded layer facts,
 host baseline, related actions, findings, and grouping evidence. Technical values are selectable and

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -88,6 +88,13 @@ packet frames. **Export as pcap** writes a classic capture when all matching fra
 action. Live export reads the complete local pcapng spool; saved-capture export re-reads the source file,
 so the bounded in-memory inspection window does not silently truncate an export.
 
+Secondary-click any flat session row, disclosed action member, inferred action, host group, or process
+group to **Remove from View**. Removing a row hides its session identity and derived values from
+Sessions, Overview, Flow Map, Sources, Findings, related-session cards, and UI totals for the current
+capture. It is intentionally reversible and does not rewrite packet evidence or silently redact a
+saved/exported capture. Use **List Options → Restore Removed Sessions** to bring every removed row back;
+starting, opening, or clearing a capture also resets this presentation state.
+
 ## Correlation into actions
 
 The session list opens **flat by default** — one row per session, exactly as decoded, so a busy

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -41,6 +41,14 @@ Open a `.pcap` (classic libpcap) or `.pcapng` file from disk — no helper or ad
 Tracexy sniffs the file format, reads its frames, and runs them through the same decode → session
 pipeline as live capture. This is the most predictable way to exercise the full pipeline.
 
+## Sidebar sources
+
+The **Sources** groups in Browse are derived from the current capture. Secondary-click an app,
+domain, or IP row to open its sessions, copy its identity, pin an address, or **Remove from Sources**.
+Removing a source hides only that sidebar row and persists the presentation preference; it never
+deletes captured sessions or packet evidence. Secondary-click the Apps, Domains, or IP Addresses
+category to restore every hidden row in that category.
+
 ## Overview
 
 **Overview** is the first destination under **Monitor**, followed by **Sessions** and **Flow Map**. It

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -41,6 +41,21 @@ Open a `.pcap` (classic libpcap) or `.pcapng` file from disk — no helper or ad
 Tracexy sniffs the file format, reads its frames, and runs them through the same decode → session
 pipeline as live capture. This is the most predictable way to exercise the full pipeline.
 
+## Overview
+
+**Overview** is the first destination under **Monitor**, followed by **Sessions** and **Flow Map**. It
+summarizes the current capture without replacing the session workflow: capture identity, frames,
+sessions, traffic, duration, activity, storage, top talkers, protocol mix, observed sources, and a
+compact findings severity summary are kept in one native dashboard. Overview never duplicates the
+finding evidence list; its security summary links to the existing filtered Sessions workflow.
+
+For a live capture, the activity chart shows measured throughput and the storage card distinguishes
+kernel/interface loss, helper-buffer drops, and trimming of the local save/export retention window.
+Retention trimming does not remove accumulated sessions and is never reported as capture-source loss.
+For an opened file, Overview shows file provenance and activity derived from its real frame timestamps;
+capture fidelity and original drop counters remain **Unknown** because a savefile cannot reconstruct
+what was missed when it was recorded.
+
 ## Sessions
 
 Frames are grouped by their canonical **five-tuple** (protocol + the two endpoints, direction-


### PR DESCRIPTION
## Summary

- introduce a native capture Overview with activity, fidelity, storage, protocol, source, and security rollups
- strengthen the live capture pipeline with complete local spooling, bounded UI retention, richer transport metadata, and additional protocol and session decoding
- add native session search, grouping, evidence copy and export actions, and contextual inspector workflows
- add source-management context menus plus reversible session removal across Sessions, Overview, Flow Map, Sources, Findings, and related-session surfaces
- expand focused coverage for capture I/O, session construction, protocol parsing, UI contracts, and privacy-preserving presentation behavior

## Why

Tracexy’s capture engine and individual views were functional, but the end-to-end investigation workflow was fragmented and some live-state reporting could be misleading or incomplete. This change aligns capture accounting, session presentation, Overview rollups, and native interaction patterns around one evidence-backed workflow while keeping raw capture data local and intact.

## User impact

Users can move from capture health and traffic activity into sessions, sources, flow, and evidence with clearer native macOS navigation. Sensitive rows can be removed from presentation and restored without silently mutating packet evidence. Complete live save and export remain independent from the bounded in-memory inspection window.

## Validation

- `xcodebuild -project Tracexy.xcodeproj -scheme Tracexy -destination "platform=macOS" test`
- `swiftformat --lint .`
- `swiftlint lint --strict`
- manual macOS validation of live capture, flat and grouped context menus, remove-from-view, and restore workflows