### PR TITLE
release: promote privacy and capture hardening

### DIFF
--- a/Shared/CallerValidation.swift
+++ b/Shared/CallerValidation.swift
@@ -2,10 +2,14 @@ import Foundation
 import Security
 
 /// Testable caller-validation primitives shared between the helper and app test targets.
-/// `ConnectionValidator` delegates to these for its two-layer validation:
+/// `ConnectionValidator` resolves a caller `SecCode` from the connection's audit token and
+/// delegates to `validateCallerCode(_:allowedIdentifiers:)` for its two-layer validation:
 /// 1. Team identifier comparison (same-developer check), with exact certificate
 ///    chain comparison as a fallback when the signing team cannot be read.
 /// 2. Bundle identity requirement (allowlist check)
+///
+/// Both layers evaluate the same supplied `SecCode`, so authorization derives from one
+/// audit-token-anchored identity rather than a PID that could be recycled between checks.
 enum CallerValidation {
     // MARK: Internal
 
@@ -53,20 +57,23 @@ enum CallerValidation {
         certificates.map { SecCertificateCopyData($0) as Data }
     }
 
-    // MARK: - Full Caller Validation by PID
+    // MARK: - Full Caller Validation
 
-    /// Performs the same two-layer validation as `ConnectionValidator.isValidCaller(_:)`
-    /// but accepts a `pid_t` directly, making it testable without a real `NSXPCConnection`.
+    /// Runs the full two-layer validation against a single, already-resolved caller `SecCode`.
+    /// This is the one place the two layers are composed; every caller-authentication path
+    /// (production audit-token, diagnostic PID) funnels through here so the signing logic is
+    /// never duplicated.
     ///
-    /// Layer 1: Extracts signing TeamIdentifiers for the current process and caller PID,
+    /// Layer 1: Extracts signing TeamIdentifiers for the current process and the caller code,
     ///          then compares them (same-developer check). If either team is unavailable,
-    ///          falls back to exact certificate-chain comparison.
-    /// Layer 2: Constructs `SecRequirement` for each allowed identifier and validates
-    ///          the caller's `SecCode` against them (bundle identity check).
-    static func validateCaller(pid: pid_t, allowedIdentifiers: [String]) -> Bool {
-        guard let selfCode = secCodeForSelf(),
-              let callerCode = secCodeForPID(pid) else
-        {
+    ///          falls back to exact certificate-chain comparison, then to the local Xcode
+    ///          ad-hoc DerivedData pairing.
+    /// Layer 2: Constructs `SecRequirement` for each allowed identifier and validates the
+    ///          caller's `SecCode` against them (bundle identity check).
+    ///
+    /// Fails closed: if the current process's own `SecCode` cannot be read, no caller is trusted.
+    static func validateCallerCode(_ callerCode: SecCode, allowedIdentifiers: [String]) -> Bool {
+        guard let selfCode = secCodeForSelf() else {
             return false
         }
 
@@ -75,6 +82,24 @@ enum CallerValidation {
         }
 
         return callerSatisfiesAnyIdentifier(callerCode: callerCode, allowedIdentifiers: allowedIdentifiers)
+    }
+
+    /// Diagnostics/tests only: resolves a caller `SecCode` from a `pid_t` and runs the full
+    /// two-layer validation. This path is subject to PID-recycling TOCTOU and must NOT be used
+    /// by the production XPC entrypoint — `ConnectionValidator` authenticates from the
+    /// connection's audit token instead. Retained for local diagnostics and unit tests.
+    static func validateCaller(pid: pid_t, allowedIdentifiers: [String]) -> Bool {
+        guard let callerCode = secCodeForPID(pid) else {
+            return false
+        }
+        return validateCallerCode(callerCode, allowedIdentifiers: allowedIdentifiers)
+    }
+
+    /// Testable accessor: the code-signing identifier (`kSecCodeInfoIdentifier`) of a `SecCode`.
+    /// Lets tests derive the running host's own identifier to exercise the success path without
+    /// hardcoding a bundle id that varies by signing configuration.
+    static func signingIdentifier(of code: SecCode) -> String? {
+        signingProfile(from: code)?.identifier
     }
 
     // MARK: - Security Framework Helpers

--- a/Shared/ConnectionValidator.swift
+++ b/Shared/ConnectionValidator.swift
@@ -2,19 +2,25 @@ import Foundation
 import os
 import Security
 
-/// XPC Caller Validation Model (two-layer defense-in-depth):
+/// XPC Caller Validation Model (audit-token-first, two-layer defense-in-depth):
 ///
-/// 1. **Team identifier comparison**: extracts the helper's and caller's signing
-///    TeamIdentifier and requires the same Apple team. This keeps one canonical helper
-///    usable across Apple Development Xcode builds and Developer ID release builds.
-///    When a TeamIdentifier is unavailable, validation falls back to exact certificate
-///    chain comparison.
+/// Authorization is derived entirely from the connection's **audit token**. The token is
+/// resolved to a single caller `SecCode`, and BOTH of the following layers are evaluated
+/// against that one code. The caller's PID is used only as logging context — never as
+/// authorization evidence — which eliminates the PID-recycling TOCTOU window and the old
+/// permissive "PID passed, token absent" fallback. Validation fails closed on any audit-token
+/// problem (unavailable, wrong-sized, or unresolvable to a `SecCode`).
+///
+/// 1. **Signing-authority match**: requires the caller and this process to share the same Apple
+///    TeamIdentifier, keeping one canonical helper usable across Apple Development Xcode builds
+///    and Developer ID release builds. When a TeamIdentifier is unavailable, validation falls
+///    back to exact certificate-chain comparison, then to the local Xcode ad-hoc DerivedData
+///    pairing.
 ///
 /// 2. **Bundle identity requirement** (Apple SecRequirement pattern): validates the caller
 ///    matches one of the configured Tracexy app bundle identifiers, not just any app sharing
-///    the same developer certificate. Uses the connection's audit token for
-///    PID-race-resistant caller identification, then checks against a `SecRequirement`
-///    string for each allowed bundle identifier.
+///    the same developer certificate, by checking the audit-token-derived `SecCode` against a
+///    `SecRequirement` for each allowed identifier.
 ///
 /// Both checks must pass for a connection to be accepted.
 ///
@@ -29,44 +35,47 @@ enum ConnectionValidator {
     // MARK: - Public API
 
     /// Production entrypoint: validates a real incoming XPC connection.
+    ///
+    /// Fails closed when the audit token cannot be extracted; the PID is logged for diagnostics
+    /// only and never authorizes the caller on its own.
     static func isValidCaller(_ connection: NSXPCConnection) -> Bool {
-        let auditTokenData = extractAuditTokenData(from: connection)
-        return validateCaller(
-            pid: connection.processIdentifier,
-            auditTokenData: auditTokenData
-        )
+        let pid = connection.processIdentifier
+        guard let auditTokenData = extractAuditTokenData(from: connection) else {
+            logger.error("SECURITY: rejecting caller (pid \(pid)) — audit token unavailable; failing closed")
+            return false
+        }
+        return validateCaller(auditTokenData: auditTokenData, pid: pid)
     }
 
-    /// Testable entrypoint: validates a caller by PID and optional audit token data.
-    /// The production `isValidCaller(_:)` delegates here after extracting the
-    /// PID and audit token from the connection object.
-    static func validateCaller(pid: pid_t, auditTokenData: Data?) -> Bool {
-        let pidValid = CallerValidation.validateCaller(
-            pid: pid,
-            allowedIdentifiers: allowedCallerIdentifiers
-        )
-
-        guard pidValid else {
-            logger.error("SECURITY: Caller validation failed for pid \(pid)")
+    /// Testable entrypoint: authorizes a caller solely from its audit token data.
+    /// The production `isValidCaller(_:)` delegates here after extracting the token; the `pid`
+    /// argument is logging context only and does not participate in the authorization decision.
+    ///
+    /// Rejects (fails closed) when the token is missing, the wrong size, or cannot be resolved to
+    /// a `SecCode`. On a resolvable token, the derived caller code must satisfy the full two-layer
+    /// validation (signing-authority match AND bundle-identity allowlist).
+    static func validateCaller(auditTokenData: Data?, pid: pid_t) -> Bool {
+        guard let tokenData = auditTokenData else {
+            logger.error("SECURITY: rejecting caller (pid \(pid)) — audit token missing; failing closed")
             return false
         }
 
-        // Defense-in-depth: if audit token data is available, recheck identity
-        // via the audit-token-derived SecCode (immune to PID recycling).
-        if let tokenData = auditTokenData,
-           let auditCode = CallerValidation.secCodeFromAuditToken(tokenData)
-        {
-            let auditSatisfied = CallerValidation.callerSatisfiesAnyIdentifier(
-                callerCode: auditCode,
-                allowedIdentifiers: allowedCallerIdentifiers
+        guard let callerCode = CallerValidation.secCodeFromAuditToken(tokenData) else {
+            logger.error(
+                "SECURITY: rejecting caller (pid \(pid)) — audit token malformed or unresolvable; failing closed"
             )
-            if !auditSatisfied {
-                logger.error("SECURITY: PID validation passed but audit token check failed for pid \(pid)")
-                return false
-            }
+            return false
         }
 
-        logger.info("SECURITY: Two-layer validation passed for pid \(pid)")
+        guard CallerValidation.validateCallerCode(
+            callerCode,
+            allowedIdentifiers: allowedCallerIdentifiers
+        ) else {
+            logger.error("SECURITY: audit-token two-layer validation failed for caller (pid \(pid))")
+            return false
+        }
+
+        logger.info("SECURITY: audit-token two-layer validation passed for caller (pid \(pid))")
         return true
     }
 

--- a/Tracexy/Core/Capture/LiveCaptureSpool.swift
+++ b/Tracexy/Core/Capture/LiveCaptureSpool.swift
@@ -12,13 +12,24 @@ actor LiveCaptureSpool {
     init(directoryName: String) {
         let base = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first
             ?? FileManager.default.temporaryDirectory
-        directory = base
+        self.init(directory: base
             .appendingPathComponent(directoryName, isDirectory: true)
-            .appendingPathComponent("LiveCaptureSpool", isDirectory: true)
+            .appendingPathComponent("LiveCaptureSpool", isDirectory: true))
+    }
+
+    /// Test/inspection seam: root the spool at an explicit directory. Production
+    /// code uses `init(directoryName:)`, which places the spool under the app cache.
+    init(directory: URL) {
+        self.directory = directory
     }
 
     deinit {
+        // Normal teardown: release the advisory lock and drop this actor's own
+        // current spool file so it is never left behind for later cleanup.
         try? handle?.close()
+        if let url {
+            try? FileManager.default.removeItem(at: url)
+        }
     }
 
     // MARK: Internal
@@ -183,15 +194,93 @@ actor LiveCaptureSpool {
         withUnsafeBytes(of: &little) { data.append(contentsOf: $0) }
     }
 
+    private static func isOrphanCandidate(_ url: URL) -> Bool {
+        let name = url.lastPathComponent
+        let published = name.hasPrefix("capture-") && name.hasSuffix(".pcapng")
+        let staging = name.hasPrefix(".capture-") && name.hasSuffix(".pcapng.staging")
+        return published || staging
+    }
+
     private func prepareFile() throws {
         try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
-        let nextURL = directory.appendingPathComponent("capture-\(UUID().uuidString).pcapng")
-        guard FileManager.default.createFile(atPath: nextURL.path, contents: nil) else {
+        removeInactiveOrphans()
+
+        // Stage under a hidden name the cleanup pattern never matches, lock it, then
+        // publish it under the final `capture-*.pcapng` name via an atomic rename. The
+        // file is therefore already locked the instant it becomes a cleanup candidate,
+        // so a concurrent spool can never delete this actor's file mid-preparation.
+        let name = UUID().uuidString
+        let stagingURL = directory.appendingPathComponent(".capture-\(name).pcapng.staging")
+        let finalURL = directory.appendingPathComponent("capture-\(name).pcapng")
+
+        guard FileManager.default.createFile(atPath: stagingURL.path, contents: nil) else {
             throw Failure.unavailable("Couldn’t create the local capture spool.")
         }
-        let nextHandle = try FileHandle(forWritingTo: nextURL)
-        try nextHandle.write(contentsOf: Self.sectionHeaderBlock())
-        url = nextURL
+
+        let nextHandle: FileHandle
+        do {
+            nextHandle = try FileHandle(forWritingTo: stagingURL)
+        } catch {
+            try? FileManager.default.removeItem(at: stagingURL)
+            throw Failure.unavailable(error.localizedDescription)
+        }
+
+        guard flock(nextHandle.fileDescriptor, LOCK_EX | LOCK_NB) == 0 else {
+            try? nextHandle.close()
+            try? FileManager.default.removeItem(at: stagingURL)
+            throw Failure.unavailable("Couldn’t lock the local capture spool.")
+        }
+
+        do {
+            try nextHandle.write(contentsOf: Self.sectionHeaderBlock())
+            try FileManager.default.moveItem(at: stagingURL, to: finalURL)
+        } catch {
+            try? nextHandle.close() // releases the advisory lock
+            try? FileManager.default.removeItem(at: stagingURL)
+            try? FileManager.default.removeItem(at: finalURL)
+            throw Failure.unavailable(error.localizedDescription)
+        }
+
+        url = finalURL
         handle = nextHandle
+    }
+
+    /// Best-effort recovery of spool files left by crashed instances. Scoped strictly
+    /// to this spool's directory and exact filename pattern; a candidate is removed only
+    /// when an exclusive advisory lock proves no live handle holds it. Never throws.
+    private func removeInactiveOrphans() {
+        guard let entries = try? FileManager.default.contentsOfDirectory(
+            at: directory,
+            includingPropertiesForKeys: nil,
+            options: [.skipsSubdirectoryDescendants]
+        ) else {
+            return
+        }
+        for entry in entries where Self.isOrphanCandidate(entry) {
+            removeIfUnlocked(entry)
+        }
+    }
+
+    private func removeIfUnlocked(_ candidate: URL) {
+        // O_NOFOLLOW refuses symlinks; O_NONBLOCK avoids blocking on special files.
+        let descriptor = open(candidate.path, O_RDONLY | O_NONBLOCK | O_NOFOLLOW)
+        guard descriptor >= 0 else {
+            return
+        }
+        defer { close(descriptor) }
+        // A directory can be named like a spool file. Prove the opened object is
+        // a regular file before any removal so cleanup never recurses into a
+        // directory or touches another filesystem object type.
+        var metadata = stat()
+        guard fstat(descriptor, &metadata) == 0,
+              metadata.st_mode & S_IFMT == S_IFREG else
+        {
+            return
+        }
+        // A live spool holds LOCK_EX on its open handle, so this fails for active files.
+        guard flock(descriptor, LOCK_EX | LOCK_NB) == 0 else {
+            return
+        }
+        try? FileManager.default.removeItem(at: candidate)
     }
 }

--- a/Tracexy/Models/Session/SessionExport.swift
+++ b/Tracexy/Models/Session/SessionExport.swift
@@ -1,5 +1,55 @@
+import Darwin
 import Foundation
 import UniformTypeIdentifiers
+
+// MARK: - SessionExportPrivacyPolicy
+
+/// Conservative, non-UI privacy controls applied when producing an export
+/// artifact. Every protection is opt-in and defaults off so existing callers
+/// keep their current raw round trips (see ``none``).
+///
+/// The policy governs only the native `.tracexysession` document and the raw
+/// pcap/pcapng refusal gate. It never rewrites packets: because on-wire frame
+/// bytes carry payloads, credentials, and addresses that cannot be honestly
+/// scrubbed in place, any active protection removes the raw frame bytes from the
+/// native document instead of pretending to redact them.
+nonisolated struct SessionExportPrivacyPolicy: Sendable, Equatable {
+    // MARK: Lifecycle
+
+    init(redactPayloadBodies: Bool = false, stripCredentials: Bool = false, maskIPAddresses: Bool = false) {
+        self.redactPayloadBodies = redactPayloadBodies
+        self.stripCredentials = stripCredentials
+        self.maskIPAddresses = maskIPAddresses
+    }
+
+    // MARK: Internal
+
+    /// The permissive default: no protection, raw bytes preserved.
+    static let none = SessionExportPrivacyPolicy()
+
+    /// Drop captured frame payload bodies from the native document.
+    var redactPayloadBodies: Bool
+    /// Remove free-form decoded metadata that can carry credentials (DNS
+    /// query/answer strings and the human-readable info summary).
+    var stripCredentials: Bool
+    /// Replace literal IPv4/IPv6 addresses in decoded strings with a fixed
+    /// placeholder. Because addresses also live in raw packet headers, this
+    /// protection likewise removes the raw frame bytes.
+    var maskIPAddresses: Bool
+
+    /// Whether any protection is active. Raw pcap/pcapng export is refused while
+    /// this is true.
+    var hasProtections: Bool {
+        redactPayloadBodies || stripCredentials || maskIPAddresses
+    }
+
+    /// Whether the policy makes the on-wire frame bytes unsafe to include in the
+    /// native document. Each protection independently forces raw-byte removal,
+    /// because payloads, credentials, and addresses all survive in raw frames.
+    var removesRawFrameBytes: Bool {
+        redactPayloadBodies || stripCredentials || maskIPAddresses
+    }
+}
 
 // MARK: - SessionExportFormat
 
@@ -56,17 +106,27 @@ nonisolated enum SessionExportError: LocalizedError {
     case noRetainedFrames
     case mixedLinkTypes
     case unsupportedLinkType
+    case rawExportRequiresAcknowledgement
 
     // MARK: Internal
 
     nonisolated var errorDescription: String? {
         switch self {
         case .noRetainedFrames:
-            "The packet frames for this session are no longer in the local export window."
+            String(localized: "The packet frames for this session are no longer in the local export window.")
         case .mixedLinkTypes:
-            "Classic pcap cannot represent a session containing multiple link types. Use pcapng instead."
+            String(
+                localized: "Classic pcap cannot represent a session containing multiple link types. Use pcapng instead."
+            )
         case .unsupportedLinkType:
-            "The session contains a link type that cannot be represented by pcapng."
+            String(localized: "The session contains a link type that cannot be represented by pcapng.")
+        case .rawExportRequiresAcknowledgement:
+            String(
+                localized: """
+                Raw pcap/pcapng export cannot apply the active privacy protections. \
+                Explicitly acknowledge an unredacted raw export, or export the protected session document instead.
+                """
+            )
         }
     }
 }
@@ -96,7 +156,8 @@ nonisolated enum SessionExporter {
         for session: SessionSummary,
         frames: [CapturedFrame],
         defaultLinkType: UInt32,
-        format: SessionExportFormat
+        format: SessionExportFormat,
+        privacy: SessionExportPrivacyPolicy = .none
     )
         throws -> SessionExportArtifact
     {
@@ -110,15 +171,24 @@ nonisolated enum SessionExporter {
             data = try sessionDocumentData(
                 session: session,
                 frames: frames,
-                defaultLinkType: defaultLinkType
+                defaultLinkType: defaultLinkType,
+                privacy: privacy
             )
         case .pcap:
+            // Raw formats emit unmodified on-wire bytes; we cannot honor a
+            // privacy policy in place, so refuse rather than silently leak.
+            guard !privacy.hasProtections else {
+                throw SessionExportError.rawExportRequiresAcknowledgement
+            }
             let linkTypes = Set(frames.map { $0.linkType ?? defaultLinkType })
             guard linkTypes.count == 1, let linkType = linkTypes.first else {
                 throw SessionExportError.mixedLinkTypes
             }
             data = PcapWriter.data(linkType: linkType, frames: frames)
         case .pcapng:
+            guard !privacy.hasProtections else {
+                throw SessionExportError.rawExportRequiresAcknowledgement
+            }
             data = try PcapngWriter.data(defaultLinkType: defaultLinkType, frames: frames)
         }
 
@@ -131,11 +201,32 @@ nonisolated enum SessionExporter {
 
     // MARK: Private
 
+    /// Unprotected native document. Version 1; carries raw frame bytes and is
+    /// preserved for backward compatibility whenever the policy is ``none``.
     private struct Document: Codable {
         let formatVersion: Int
         let exportedAt: Date
         let session: Summary
         let frames: [Frame]
+    }
+
+    /// Protected native document. Version 2; omits the `bytes` key entirely and
+    /// carries machine-readable ``PrivacyMetadata`` describing what was applied.
+    private struct ProtectedDocument: Codable {
+        let formatVersion: Int
+        let exportedAt: Date
+        let privacy: PrivacyMetadata
+        let session: Summary
+        let frames: [ProtectedFrame]
+    }
+
+    /// Machine-readable record of the applied protections. `includesRawFrameBytes`
+    /// is always false here — an honest statement that no on-wire bytes are present.
+    private struct PrivacyMetadata: Codable {
+        let redactedPayloadBodies: Bool
+        let strippedCredentials: Bool
+        let maskedIPAddresses: Bool
+        let includesRawFrameBytes: Bool
     }
 
     private struct Summary: Codable {
@@ -166,49 +257,112 @@ nonisolated enum SessionExporter {
         let bytes: Data
     }
 
+    /// Frame metadata with the `bytes` key deliberately absent, so no raw payload
+    /// can survive in a protected document.
+    private struct ProtectedFrame: Codable {
+        let timestamp: Date
+        let originalLength: Int
+        let capturedLength: Int
+        let linkType: UInt32
+        let processName: String?
+    }
+
     private static func sessionDocumentData(
         session: SessionSummary,
         frames: [CapturedFrame],
-        defaultLinkType: UInt32
+        defaultLinkType: UInt32,
+        privacy: SessionExportPrivacyPolicy
     )
         throws -> Data
     {
-        let document = Document(
-            formatVersion: 1,
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+
+        guard privacy.removesRawFrameBytes else {
+            let document = Document(
+                formatVersion: 1,
+                exportedAt: Date(),
+                session: summary(for: session, privacy: privacy),
+                frames: frames.map { frame in
+                    Frame(
+                        timestamp: frame.timestamp,
+                        originalLength: frame.originalLength,
+                        capturedLength: frame.capturedLength,
+                        linkType: frame.linkType ?? defaultLinkType,
+                        processName: frame.processName,
+                        bytes: Data(frame.bytes)
+                    )
+                }
+            )
+            return try encoder.encode(document)
+        }
+
+        let document = ProtectedDocument(
+            formatVersion: 2,
             exportedAt: Date(),
-            session: Summary(
-                id: session.id,
-                startTime: session.startTime,
-                duration: session.duration,
-                processName: session.processName,
-                host: session.host,
-                sourceEndpoint: session.sourceEndpoint,
-                destinationEndpoint: session.destinationEndpoint,
-                protocols: session.protocolStack.map(\.rawValue),
-                status: session.status.rawValue,
-                latencyMilliseconds: session.latencyMilliseconds,
-                bytesUp: session.bytesUp,
-                bytesDown: session.bytesDown,
-                sni: session.sni,
-                dnsQuery: session.dnsQuery,
-                dnsAnswers: session.dnsAnswers,
-                summary: session.infoSummary
+            privacy: PrivacyMetadata(
+                redactedPayloadBodies: privacy.redactPayloadBodies,
+                strippedCredentials: privacy.stripCredentials,
+                maskedIPAddresses: privacy.maskIPAddresses,
+                includesRawFrameBytes: false
             ),
+            session: summary(for: session, privacy: privacy),
             frames: frames.map { frame in
-                Frame(
+                ProtectedFrame(
                     timestamp: frame.timestamp,
                     originalLength: frame.originalLength,
                     capturedLength: frame.capturedLength,
                     linkType: frame.linkType ?? defaultLinkType,
-                    processName: frame.processName,
-                    bytes: Data(frame.bytes)
+                    processName: frame.processName
                 )
             }
         )
-        let encoder = JSONEncoder()
-        encoder.dateEncodingStrategy = .iso8601
-        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
         return try encoder.encode(document)
+    }
+
+    /// Builds the encoded ``Summary``, applying credential stripping and address
+    /// masking as the policy requires. Never invents decoded data: stripped
+    /// fields become empty/nil and the summary collapses to protocol labels.
+    private static func summary(
+        for session: SessionSummary,
+        privacy: SessionExportPrivacyPolicy
+    )
+        -> Summary
+    {
+        let mask = privacy.maskIPAddresses
+        let strip = privacy.stripCredentials
+
+        func masked(_ value: String) -> String {
+            mask ? PrivacyMask.maskingAddresses(in: value) : value
+        }
+        func maskedEndpoint(_ value: String) -> String {
+            mask ? PrivacyMask.maskingEndpoint(value) : value
+        }
+        func maskedOptional(_ value: String?) -> String? {
+            value.map { masked($0) }
+        }
+
+        let protocolLabels = session.protocolStack.map(\.label).joined(separator: " · ")
+
+        return Summary(
+            id: session.id,
+            startTime: session.startTime,
+            duration: session.duration,
+            processName: session.processName,
+            host: masked(session.host),
+            sourceEndpoint: maskedEndpoint(session.sourceEndpoint),
+            destinationEndpoint: maskedEndpoint(session.destinationEndpoint),
+            protocols: session.protocolStack.map(\.rawValue),
+            status: session.status.rawValue,
+            latencyMilliseconds: session.latencyMilliseconds,
+            bytesUp: session.bytesUp,
+            bytesDown: session.bytesDown,
+            sni: maskedOptional(session.sni),
+            dnsQuery: strip ? nil : maskedOptional(session.dnsQuery),
+            dnsAnswers: strip ? [] : session.dnsAnswers.map { masked($0) },
+            summary: strip ? protocolLabels : masked(session.infoSummary)
+        )
     }
 
     private static func safeFileComponent(_ value: String) -> String {
@@ -219,5 +373,114 @@ nonisolated enum SessionExporter {
         let cleaned = components.joined(separator: "-")
             .trimmingCharacters(in: .whitespacesAndNewlines)
         return cleaned.isEmpty || cleaned == "—" ? "Traffic" : String(cleaned.prefix(80))
+    }
+}
+
+// MARK: - PrivacyMask
+
+/// Deterministic, offline address masker. It replaces genuine IPv4/IPv6 literals
+/// with a fixed placeholder while leaving hostnames, punctuation, and arbitrary
+/// text byte-for-byte intact. Address validity is decided by the platform parser
+/// (`inet_pton`) rather than a broad regex, so ordinary hostnames are never
+/// corrupted. Malformed or unknown input is handled totally — it is simply left
+/// unchanged. No network calls, no hashing of sensitive input.
+private enum PrivacyMask {
+    // MARK: Internal
+
+    /// The honest, fixed stand-in written wherever an address is removed.
+    static let placeholder = "[masked-ip]"
+
+    /// Replaces every embedded IPv4/IPv6 literal in `text` with ``placeholder``.
+    /// Runs of address-shaped characters are validated as whole tokens, so a
+    /// fragment such as `16.34` inside other text is not a valid address and is
+    /// preserved verbatim.
+    static func maskingAddresses(in text: String) -> String {
+        guard !text.isEmpty else {
+            return text
+        }
+        var result = ""
+        result.reserveCapacity(text.count)
+        var token = ""
+
+        func flush() {
+            if !token.isEmpty {
+                result += maskingAddressToken(token)
+                token = ""
+            }
+        }
+
+        for character in text {
+            if isAddressCharacter(character) {
+                token.append(character)
+            } else {
+                flush()
+                result.append(character)
+            }
+        }
+        flush()
+        return result
+    }
+
+    /// Endpoint-aware masking that preserves a trailing numeric `:port`. When the
+    /// value is not an `address:port` pair (including the `—` placeholder or an
+    /// IPv6 literal without a port), it falls back to whole-string masking.
+    static func maskingEndpoint(_ endpoint: String) -> String {
+        guard let separator = endpoint.lastIndex(of: ":") else {
+            return maskingAddresses(in: endpoint)
+        }
+        let address = String(endpoint[endpoint.startIndex ..< separator])
+        let port = String(endpoint[endpoint.index(after: separator)...])
+        if !port.isEmpty, port.allSatisfy(\.isNumber), isIPAddress(address) {
+            return "\(placeholder):\(port)"
+        }
+        return maskingAddresses(in: endpoint)
+    }
+
+    // MARK: Private
+
+    private static func isAddressCharacter(_ character: Character) -> Bool {
+        guard character.unicodeScalars.count == 1, let scalar = character.unicodeScalars.first else {
+            return false
+        }
+        if scalar == "." || scalar == ":" {
+            return true
+        }
+        return character.isHexDigit
+    }
+
+    /// A sentence-ending period is address-shaped but is not part of the
+    /// address. Try the whole token first, then peel only trailing periods so an
+    /// address at the end of prose cannot escape masking. Preserve the punctuation
+    /// exactly; malformed tokens remain untouched.
+    private static func maskingAddressToken(_ token: String) -> String {
+        if isIPAddress(token) {
+            return placeholder
+        }
+
+        var candidate = token
+        var suffix = ""
+        while candidate.last == "." {
+            candidate.removeLast()
+            suffix.append(".")
+            if isIPAddress(candidate) {
+                return placeholder + suffix
+            }
+        }
+        return token
+    }
+
+    private static func isIPAddress(_ token: String) -> Bool {
+        guard token.contains(".") || token.contains(":") else {
+            return false
+        }
+        var v4 = in_addr()
+        if token.withCString({ inet_pton(AF_INET, $0, &v4) }) == 1 {
+            return true
+        }
+        var v6 = in6_addr()
+        if token.withCString({ inet_pton(AF_INET6, $0, &v6) }) == 1 {
+            return true
+        }
+        return false
     }
 }

--- a/Tracexy/Models/UI/AppSettings.swift
+++ b/Tracexy/Models/UI/AppSettings.swift
@@ -229,6 +229,48 @@ enum CaptureSettingsResolver {
     }
 }
 
+// MARK: - PrivacySettingsResolver
+
+/// Resolves export protections from persisted preferences without treating an
+/// unset `UserDefaults` key as `false`. The Privacy pane's shipped defaults are
+/// protective, so a fresh install must apply them before the user has opened
+/// Settings or caused `@AppStorage` to materialize the keys.
+enum PrivacySettingsResolver {
+    // MARK: Internal
+
+    static func exportPolicy(defaults: UserDefaults = .standard) -> SessionExportPrivacyPolicy {
+        SessionExportPrivacyPolicy(
+            redactPayloadBodies: resolvedBool(
+                forKey: SettingsKeys.redactBodies,
+                defaultValue: true,
+                defaults: defaults
+            ),
+            stripCredentials: resolvedBool(
+                forKey: SettingsKeys.stripCredentials,
+                defaultValue: true,
+                defaults: defaults
+            ),
+            maskIPAddresses: resolvedBool(
+                forKey: SettingsKeys.maskIPs,
+                defaultValue: false,
+                defaults: defaults
+            )
+        )
+    }
+
+    // MARK: Private
+
+    private static func resolvedBool(
+        forKey key: String,
+        defaultValue: Bool,
+        defaults: UserDefaults
+    )
+        -> Bool
+    {
+        (defaults.object(forKey: key) as? Bool) ?? defaultValue
+    }
+}
+
 // MARK: - AutoClear
 
 enum AutoClear: String, CaseIterable, Identifiable {

--- a/Tracexy/ViewModels/MainContentCoordinator+SessionExport.swift
+++ b/Tracexy/ViewModels/MainContentCoordinator+SessionExport.swift
@@ -32,6 +32,13 @@ extension MainContentCoordinator {
         guard !isExportingSession else {
             return
         }
+        let configuredPrivacy = PrivacySettingsResolver.exportPolicy()
+        guard let exportPrivacy = confirmedPrivacyPolicy(
+            for: format,
+            configuredPrivacy: configuredPrivacy
+        ) else {
+            return
+        }
         setSessionExporting(true)
 
         Task { [weak self] in
@@ -51,7 +58,8 @@ extension MainContentCoordinator {
                         for: session,
                         frames: sessionFrames,
                         defaultLinkType: capture.linkType,
-                        format: format
+                        format: format,
+                        privacy: exportPrivacy
                     )
                 }.value
                 let panel = NSSavePanel()
@@ -82,5 +90,32 @@ extension MainContentCoordinator {
                 self?.captureError = "Couldn’t export session: \(error.localizedDescription)"
             }
         }
+    }
+
+    /// Native session documents can enforce the configured protections by
+    /// omitting raw frames. Pcap formats are evidence-preserving byte streams, so
+    /// exporting one while protections are active requires an explicit, per-action
+    /// acknowledgement and then deliberately uses the unprotected policy.
+    private func confirmedPrivacyPolicy(
+        for format: SessionExportFormat,
+        configuredPrivacy: SessionExportPrivacyPolicy
+    )
+        -> SessionExportPrivacyPolicy?
+    {
+        guard format != .session, configuredPrivacy.hasProtections else {
+            return configuredPrivacy
+        }
+
+        let alert = NSAlert()
+        alert.alertStyle = .warning
+        alert.messageText = "Export unprotected packet data?"
+        alert.informativeText = """
+        \(format.fileExtension.uppercased()) files preserve the exact captured packet bytes. \
+        Redacting payloads, stripping credentials, and masking IP addresses cannot be applied to this raw format. \
+        Export only if you intend to handle the file as sensitive data.
+        """
+        alert.addButton(withTitle: "Export Raw Capture")
+        alert.addButton(withTitle: "Cancel")
+        return alert.runModal() == .alertFirstButtonReturn ? .none : nil
     }
 }

--- a/Tracexy/Views/Settings/PrivacySettingsView.swift
+++ b/Tracexy/Views/Settings/PrivacySettingsView.swift
@@ -2,19 +2,19 @@ import SwiftUI
 
 // MARK: - PrivacySettingsView
 
-/// Privacy preferences. These persist the user's choices; the redaction / masking
-/// pipeline and retention timer that consume them are not yet implemented (they
-/// arrive with the export & analysis engines). Local-first is the default posture.
+/// Privacy preferences for protected native session exports. Raw capture formats
+/// preserve packet evidence and therefore require explicit acknowledgement when
+/// any protection is active. Local-first remains the default posture.
 struct PrivacySettingsView: View {
     // MARK: Internal
 
     var body: some View {
         SettingsPane {
-            SettingsSection("On Export & Share") {
+            SettingsSection("Protected Session Export") {
                 SettingsCheckbox(
                     isOn: $redactBodies,
                     title: "Redact payload bodies",
-                    description: "Replace request and response bodies with placeholders in exported captures."
+                    description: "Exclude captured packet bytes from protected Tracexy session documents."
                 )
 
                 SettingsDivider()
@@ -22,7 +22,7 @@ struct PrivacySettingsView: View {
                 SettingsCheckbox(
                     isOn: $stripCredentials,
                     title: "Strip credentials & tokens",
-                    description: "Remove Authorization headers, cookies, and API keys before sharing."
+                    description: "Remove DNS-derived and free-form decoded metadata that may carry secrets."
                 )
 
                 SettingsDivider()
@@ -30,8 +30,19 @@ struct PrivacySettingsView: View {
                 SettingsCheckbox(
                     isOn: $maskIPs,
                     title: "Mask IP addresses",
-                    description: "Anonymize source and destination addresses in exports and shared sessions."
+                    description: "Replace literal addresses in protected session summaries with a fixed placeholder."
                 )
+
+                SettingsDivider()
+
+                SettingsIndented {
+                    SettingsFootnote(
+                        """
+                        These protections apply to .tracexysession documents. Raw pcap and pcapng exports preserve \
+                        captured bytes and always require confirmation while a protection is enabled.
+                        """
+                    )
+                }
             }
 
             SettingsSection("Data") {

--- a/TracexyTests/Core/Capture/LiveCaptureSpoolTests.swift
+++ b/TracexyTests/Core/Capture/LiveCaptureSpoolTests.swift
@@ -8,7 +8,8 @@ struct LiveCaptureSpoolTests {
 
     @Test("Spool round-trips every appended frame across batches")
     func roundTrip() async throws {
-        let spool = LiveCaptureSpool(directoryName: "LiveCaptureSpoolTests")
+        let directory = Self.uniqueDirectory()
+        let spool = LiveCaptureSpool(directory: directory)
         try await spool.reset(epoch: 7)
         let first = frame(byte: 1, timestamp: 1, linkType: LinkType.ethernet)
         let second = frame(byte: 2, timestamp: 2, linkType: LinkType.raw)
@@ -25,7 +26,8 @@ struct LiveCaptureSpoolTests {
 
     @Test("Stale capture generations cannot append into a new spool")
     func staleEpochIgnored() async throws {
-        let spool = LiveCaptureSpool(directoryName: "LiveCaptureSpoolTests")
+        let directory = Self.uniqueDirectory()
+        let spool = LiveCaptureSpool(directory: directory)
         try await spool.reset(epoch: 2)
         try await spool.append([frame(byte: 1, timestamp: 1)], defaultLinkType: LinkType.ethernet, epoch: 1)
         try await spool.append([frame(byte: 2, timestamp: 2)], defaultLinkType: LinkType.ethernet, epoch: 2)
@@ -34,7 +36,130 @@ struct LiveCaptureSpoolTests {
         #expect(capture.frames.map(\.bytes) == [[2, 2, 2]])
     }
 
+    @Test("Normal teardown removes the spool's own current file")
+    func teardownRemovesCurrentFile() async throws {
+        let directory = Self.uniqueDirectory()
+        // Confine the spool to a helper whose frame is destroyed on return, so the
+        // actor's last reference is dropped and its deinit runs before we observe.
+        try await Self.writeThenRelease(in: directory)
+        try await Self.waitUntil { Self.spoolFiles(in: directory).isEmpty }
+        #expect(Self.spoolFiles(in: directory).isEmpty)
+    }
+
+    @Test("Reset removes an inactive orphan left by a prior instance")
+    func cleanupRemovesUnlockedOrphan() async throws {
+        let directory = Self.uniqueDirectory()
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let orphan = directory.appendingPathComponent("capture-orphan.pcapng")
+        try Data([0x0A]).write(to: orphan)
+
+        let spool = LiveCaptureSpool(directory: directory)
+        try await spool.reset(epoch: 1)
+
+        #expect(!FileManager.default.fileExists(atPath: orphan.path))
+        withExtendedLifetime(spool) {}
+    }
+
+    @Test("Reset removes an inactive staging orphan left by a crash")
+    func cleanupRemovesUnlockedStagingOrphan() async throws {
+        let directory = Self.uniqueDirectory()
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let orphan = directory.appendingPathComponent(".capture-orphan.pcapng.staging")
+        try Data([0x0A]).write(to: orphan)
+
+        let spool = LiveCaptureSpool(directory: directory)
+        try await spool.reset(epoch: 1)
+
+        #expect(!FileManager.default.fileExists(atPath: orphan.path))
+        withExtendedLifetime(spool) {}
+    }
+
+    @Test("Reset preserves an actively locked candidate")
+    func cleanupPreservesLockedCandidate() async throws {
+        let directory = Self.uniqueDirectory()
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let active = directory.appendingPathComponent("capture-active.pcapng")
+        try Data([0x0A]).write(to: active)
+
+        // Simulate a concurrent live spool holding an exclusive advisory lock.
+        let descriptor = open(active.path, O_RDONLY)
+        #expect(descriptor >= 0)
+        #expect(flock(descriptor, LOCK_EX | LOCK_NB) == 0)
+        defer { close(descriptor) }
+
+        let spool = LiveCaptureSpool(directory: directory)
+        try await spool.reset(epoch: 1)
+
+        #expect(FileManager.default.fileExists(atPath: active.path))
+        withExtendedLifetime(spool) {}
+    }
+
+    @Test("Reset never removes files outside the exact spool pattern")
+    func cleanupPreservesUnrelatedFiles() async throws {
+        let directory = Self.uniqueDirectory()
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let unrelated = ["readme.txt", "session.pcapng", "capture-note.txt", "capturex.pcapng"]
+        for name in unrelated {
+            try Data([0x0A]).write(to: directory.appendingPathComponent(name))
+        }
+
+        let spool = LiveCaptureSpool(directory: directory)
+        try await spool.reset(epoch: 1)
+
+        for name in unrelated {
+            #expect(FileManager.default.fileExists(atPath: directory.appendingPathComponent(name).path))
+        }
+        withExtendedLifetime(spool) {}
+    }
+
+    @Test("Reset never removes a directory named like a spool file")
+    func cleanupPreservesMatchingDirectory() async throws {
+        let directory = Self.uniqueDirectory()
+        let matchingDirectory = directory.appendingPathComponent("capture-not-a-file.pcapng", isDirectory: true)
+        try FileManager.default.createDirectory(at: matchingDirectory, withIntermediateDirectories: true)
+        let child = matchingDirectory.appendingPathComponent("keep.txt")
+        try Data([0x0A]).write(to: child)
+
+        let spool = LiveCaptureSpool(directory: directory)
+        try await spool.reset(epoch: 1)
+
+        #expect(FileManager.default.fileExists(atPath: child.path))
+        withExtendedLifetime(spool) {}
+    }
+
     // MARK: Private
+
+    private static func writeThenRelease(in directory: URL) async throws {
+        let spool = LiveCaptureSpool(directory: directory)
+        try await spool.reset(epoch: 1)
+        let frame = CapturedFrame(
+            bytes: [1, 1, 1],
+            timestamp: Date(timeIntervalSince1970: 1),
+            originalLength: 7,
+            linkType: nil
+        )
+        try await spool.append([frame], defaultLinkType: LinkType.ethernet, epoch: 1)
+        #expect(spoolFiles(in: directory).count == 1)
+    }
+
+    private static func uniqueDirectory() -> URL {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent("LiveCaptureSpoolTests-\(UUID().uuidString)", isDirectory: true)
+    }
+
+    private static func spoolFiles(in directory: URL) -> [String] {
+        let names = (try? FileManager.default.contentsOfDirectory(atPath: directory.path)) ?? []
+        return names.filter { $0.hasPrefix("capture-") && $0.hasSuffix(".pcapng") }
+    }
+
+    private static func waitUntil(_ condition: () -> Bool) async throws {
+        for _ in 0 ..< 100 {
+            if condition() {
+                return
+            }
+            try await Task.sleep(nanoseconds: 20_000_000)
+        }
+    }
 
     private func frame(byte: UInt8, timestamp: TimeInterval, linkType: UInt32? = nil) -> CapturedFrame {
         CapturedFrame(

--- a/TracexyTests/Core/Services/ConnectionValidatorAuditTokenTests.swift
+++ b/TracexyTests/Core/Services/ConnectionValidatorAuditTokenTests.swift
@@ -1,0 +1,79 @@
+import Foundation
+import Security
+import Testing
+@testable import Tracexy
+
+// MARK: - ConnectionValidatorAuditTokenTests
+
+/// Pins the audit-token-first authorization contract of the privileged-helper XPC entrypoint:
+/// authorization derives from the connection's audit token, both validation layers evaluate the
+/// same audit-token-derived `SecCode`, and every audit-token problem fails closed. The caller's
+/// PID is logging context only and can never authorize a connection on its own.
+@Suite("Audit-token caller authorization")
+struct ConnectionValidatorAuditTokenTests {
+    // MARK: Internal
+
+    @Test("A missing audit token is rejected (fails closed)")
+    func missingTokenFailsClosed() {
+        // PID is deliberately the current process, which the diagnostic PID path would accept —
+        // proving the entrypoint never authorizes on PID when the token is absent.
+        let ownPid = ProcessInfo.processInfo.processIdentifier
+        #expect(ConnectionValidator.validateCaller(auditTokenData: nil, pid: ownPid) == false)
+    }
+
+    @Test("Never accept because PID validation would pass when the audit token is absent")
+    func pidPassButTokenAbsentIsRejected() throws {
+        let token = try #require(CallerValidation.currentProcessAuditToken())
+        let code = try #require(CallerValidation.secCodeFromAuditToken(token))
+        let ownIdentifier = try #require(CallerValidation.signingIdentifier(of: code))
+        let ownPid = ProcessInfo.processInfo.processIdentifier
+
+        // The diagnostics-only PID path authorizes this host against its own identifier...
+        #expect(CallerValidation.validateCaller(pid: ownPid, allowedIdentifiers: [ownIdentifier]))
+        // ...but the production entrypoint still fails closed with no audit token.
+        #expect(ConnectionValidator.validateCaller(auditTokenData: nil, pid: ownPid) == false)
+    }
+
+    @Test("A wrong-sized audit token cannot resolve to a SecCode and is rejected")
+    func wrongSizedTokenFailsClosed() {
+        let ownPid = ProcessInfo.processInfo.processIdentifier
+        let undersized = Data(count: 8) // audit_token_t is 32 bytes
+        #expect(CallerValidation.secCodeFromAuditToken(undersized) == nil)
+        #expect(ConnectionValidator.validateCaller(auditTokenData: undersized, pid: ownPid) == false)
+    }
+
+    @Test("A correctly-sized but unresolvable audit token is rejected")
+    func unresolvableTokenFailsClosed() {
+        let ownPid = ProcessInfo.processInfo.processIdentifier
+        // Correctly sized (32 bytes) but filled with a pattern that maps to no live guest.
+        let bogus = Data(repeating: 0xFF, count: MemoryLayout<audit_token_t>.size)
+        // The security-relevant invariant: whether Security resolves it or not, it is never us,
+        // so the caller is rejected and never authorized on the accompanying PID.
+        #expect(ConnectionValidator.validateCaller(auditTokenData: bogus, pid: ownPid) == false)
+    }
+
+    @Test("A resolvable token whose identifier is not on the allowlist is rejected")
+    func allowedIdentifierMismatchIsRejected() throws {
+        let token = try #require(CallerValidation.currentProcessAuditToken())
+        let code = try #require(CallerValidation.secCodeFromAuditToken(token))
+        // Layer 1 (signing-authority match) passes for self, but layer 2 (bundle identity) must
+        // fail because the running host's identifier is not on this allowlist.
+        #expect(CallerValidation.validateCallerCode(code, allowedIdentifiers: notAllowedIdentifiers) == false)
+    }
+
+    @Test("The current process's own audit token passes full two-layer validation")
+    func currentProcessTokenPassesWhenAllowed() throws {
+        // Holds under the supported signing contexts: local Xcode DerivedData ad-hoc builds and
+        // Apple-anchored (Developer ID) release builds. Both the token and its SecCode must exist
+        // in this macOS test environment, so they are required rather than expected.
+        let token = try #require(CallerValidation.currentProcessAuditToken())
+        let code = try #require(CallerValidation.secCodeFromAuditToken(token))
+        let ownIdentifier = try #require(CallerValidation.signingIdentifier(of: code))
+
+        #expect(CallerValidation.validateCallerCode(code, allowedIdentifiers: [ownIdentifier]))
+    }
+
+    // MARK: Private
+
+    private let notAllowedIdentifiers = ["com.example.definitely.not.a.tracexy.caller"]
+}

--- a/TracexyTests/Core/Session/SessionExporterTests.swift
+++ b/TracexyTests/Core/Session/SessionExporterTests.swift
@@ -53,7 +53,7 @@ struct SessionExporterTests {
         #expect(parsed.frames.count == fixture.frames.count)
         #expect(parsed.frames.allSatisfy { $0.linkType == LinkType.ethernet })
         #expect(zip(parsed.frames, fixture.frames).allSatisfy { lhs, rhs in
-            abs(lhs.timestamp.timeIntervalSince(rhs.timestamp)) < 0.000_01
+            abs(lhs.timestamp.timeIntervalSince(rhs.timestamp)) < 0.00001
         })
         #expect(artifact.suggestedFileName.hasSuffix(".pcapng"))
     }
@@ -107,7 +107,255 @@ struct SessionExporterTests {
         #expect(artifact.suggestedFileName.hasSuffix(".tracexysession"))
     }
 
+    @Test("Protected session document drops frame bytes entirely with no sentinel payload")
+    func protectedDocumentOmitsFrameBytes() throws {
+        let fixture = try makeFixture()
+        let artifact = try SessionExporter.artifact(
+            for: fixture.session,
+            frames: fixture.frames,
+            defaultLinkType: LinkType.ethernet,
+            format: .session,
+            privacy: SessionExportPrivacyPolicy(redactPayloadBodies: true)
+        )
+
+        let object = try #require(JSONSerialization.jsonObject(with: artifact.data) as? [String: Any])
+        #expect(object["formatVersion"] as? Int == 2)
+        let frames = try #require(object["frames"] as? [[String: Any]])
+        #expect(frames.count == fixture.frames.count)
+        // No frame carries a `bytes` key and none substitutes a sentinel payload.
+        #expect(frames.allSatisfy { $0["bytes"] == nil })
+        #expect(frames.allSatisfy { $0["payload"] == nil })
+        // Timing/length/link/process metadata survives.
+        #expect(frames.allSatisfy { $0["timestamp"] != nil })
+        #expect(frames.allSatisfy { $0["originalLength"] != nil })
+        #expect(frames.allSatisfy { $0["linkType"] != nil })
+    }
+
+    @Test("Protected document declares machine-readable privacy metadata and version 2")
+    func protectedDocumentPrivacyMetadata() throws {
+        let fixture = try makeFixture()
+        let artifact = try SessionExporter.artifact(
+            for: fixture.session,
+            frames: fixture.frames,
+            defaultLinkType: LinkType.ethernet,
+            format: .session,
+            privacy: SessionExportPrivacyPolicy(redactPayloadBodies: true, stripCredentials: true)
+        )
+
+        let object = try #require(JSONSerialization.jsonObject(with: artifact.data) as? [String: Any])
+        #expect(object["formatVersion"] as? Int == 2)
+        let privacy = try #require(object["privacy"] as? [String: Any])
+        #expect(privacy["redactedPayloadBodies"] as? Bool == true)
+        #expect(privacy["strippedCredentials"] as? Bool == true)
+        #expect(privacy["maskedIPAddresses"] as? Bool == false)
+        #expect(privacy["includesRawFrameBytes"] as? Bool == false)
+    }
+
+    @Test("Unprotected document stays backward-compatible version 1 with bytes present")
+    func unprotectedDocumentBackwardCompatible() throws {
+        let fixture = try makeFixture()
+        let artifact = try SessionExporter.artifact(
+            for: fixture.session,
+            frames: fixture.frames,
+            defaultLinkType: LinkType.ethernet,
+            format: .session,
+            privacy: .none
+        )
+
+        let object = try #require(JSONSerialization.jsonObject(with: artifact.data) as? [String: Any])
+        #expect(object["formatVersion"] as? Int == 1)
+        #expect(object["privacy"] == nil)
+        let frames = try #require(object["frames"] as? [[String: Any]])
+        #expect(frames.allSatisfy { $0["bytes"] != nil })
+    }
+
+    @Test("Stripping credentials removes DNS and free-form summary metadata")
+    func stripCredentialsRemovesDecodedMetadata() throws {
+        let session = makeRichSession(
+            host: "internal.corp.example",
+            sourceEndpoint: "192.168.1.42:54001",
+            destinationEndpoint: "203.0.113.53:53",
+            protocolStack: [.udp, .dns],
+            sni: nil,
+            dnsQuery: "vault.secret.corp",
+            dnsAnswers: ["198.51.100.77"]
+        )
+        let fixture = try makeFixture()
+        let artifact = try SessionExporter.artifact(
+            for: session,
+            frames: fixture.frames,
+            defaultLinkType: LinkType.ethernet,
+            format: .session,
+            privacy: SessionExportPrivacyPolicy(stripCredentials: true)
+        )
+
+        let object = try #require(JSONSerialization.jsonObject(with: artifact.data) as? [String: Any])
+        let summary = try #require(object["session"] as? [String: Any])
+        #expect(summary["dnsQuery"] == nil)
+        #expect((summary["dnsAnswers"] as? [Any])?.isEmpty == true)
+        // The free-form info line collapses to protocol labels only — no invented data.
+        #expect(summary["summary"] as? String == "UDP · DNS")
+
+        // The credential-bearing strings must be structurally absent from the artifact.
+        let text = try #require(String(bytes: artifact.data, encoding: .utf8))
+        #expect(!text.contains("vault.secret.corp"))
+        #expect(!text.contains("198.51.100.77"))
+    }
+
+    @Test("Masking rewrites IPv4 literals but preserves hostnames and ports")
+    func maskingRewritesIPv4() throws {
+        let session = makeRichSession(
+            host: "93.184.16.34",
+            sourceEndpoint: "192.168.1.42:52344",
+            destinationEndpoint: "93.184.16.34:443",
+            protocolStack: [.tcp, .tls],
+            sni: "api.example.com",
+            dnsQuery: "api.example.com",
+            dnsAnswers: ["93.184.16.34"]
+        )
+        let fixture = try makeFixture()
+        let artifact = try SessionExporter.artifact(
+            for: session,
+            frames: fixture.frames,
+            defaultLinkType: LinkType.ethernet,
+            format: .session,
+            privacy: SessionExportPrivacyPolicy(maskIPAddresses: true)
+        )
+
+        let object = try #require(JSONSerialization.jsonObject(with: artifact.data) as? [String: Any])
+        // Masking addresses also removes raw bytes, so this is a protected document.
+        #expect(object["formatVersion"] as? Int == 2)
+        let summary = try #require(object["session"] as? [String: Any])
+        #expect(summary["host"] as? String == "[masked-ip]")
+        #expect(summary["sourceEndpoint"] as? String == "[masked-ip]:52344")
+        #expect(summary["destinationEndpoint"] as? String == "[masked-ip]:443")
+        // Hostnames must never be corrupted by the masker.
+        #expect(summary["sni"] as? String == "api.example.com")
+        #expect(summary["dnsQuery"] as? String == "api.example.com")
+        #expect((summary["dnsAnswers"] as? [String]) == ["[masked-ip]"])
+        #expect(summary["summary"] as? String == "DNS api.example.com → [masked-ip]")
+
+        let text = try #require(String(bytes: artifact.data, encoding: .utf8))
+        #expect(!text.contains("93.184.16.34"))
+        #expect(!text.contains("192.168.1.42"))
+    }
+
+    @Test("Masking catches an address immediately followed by sentence punctuation")
+    func maskingRewritesAddressBeforePeriod() throws {
+        let session = makeRichSession(
+            host: "api.example.com",
+            sourceEndpoint: "192.168.1.42:52344",
+            destinationEndpoint: "93.184.16.34:443",
+            protocolStack: [.tcp, .http],
+            sni: nil,
+            dnsQuery: nil,
+            dnsAnswers: []
+        )
+        let fixture = try makeFixture()
+        var punctuated = session
+        punctuated.decodedLayers = [
+            DecodedLayer(proto: .http, title: "HTTP", summary: "Connected to 93.184.16.34."),
+        ]
+
+        let artifact = try SessionExporter.artifact(
+            for: punctuated,
+            frames: fixture.frames,
+            defaultLinkType: LinkType.ethernet,
+            format: .session,
+            privacy: SessionExportPrivacyPolicy(maskIPAddresses: true)
+        )
+
+        let object = try #require(JSONSerialization.jsonObject(with: artifact.data) as? [String: Any])
+        let summary = try #require(object["session"] as? [String: Any])
+        #expect(summary["summary"] as? String == "Connected to [masked-ip].")
+    }
+
+    @Test("Masking rewrites IPv6 literals while preserving endpoint ports")
+    func maskingRewritesIPv6() throws {
+        let session = makeRichSession(
+            host: "2606:4700:4700::1111",
+            sourceEndpoint: "192.168.1.42:52344",
+            destinationEndpoint: "2606:4700:4700::1111:443",
+            protocolStack: [.tcp, .tls],
+            sni: "api.example.com",
+            dnsQuery: nil,
+            dnsAnswers: ["2606:4700:4700::64"]
+        )
+        let fixture = try makeFixture()
+        let artifact = try SessionExporter.artifact(
+            for: session,
+            frames: fixture.frames,
+            defaultLinkType: LinkType.ethernet,
+            format: .session,
+            privacy: SessionExportPrivacyPolicy(maskIPAddresses: true)
+        )
+
+        let object = try #require(JSONSerialization.jsonObject(with: artifact.data) as? [String: Any])
+        let summary = try #require(object["session"] as? [String: Any])
+        #expect(summary["host"] as? String == "[masked-ip]")
+        #expect(summary["destinationEndpoint"] as? String == "[masked-ip]:443")
+        #expect((summary["dnsAnswers"] as? [String]) == ["[masked-ip]"])
+
+        let text = try #require(String(bytes: artifact.data, encoding: .utf8))
+        #expect(!text.contains("2606:4700:4700::1111"))
+        #expect(!text.contains("2606:4700:4700::64"))
+    }
+
+    @Test("Raw pcap and pcapng refuse any active privacy protection")
+    func rawFormatsRefuseActiveProtection() throws {
+        let fixture = try makeFixture()
+        let policy = SessionExportPrivacyPolicy(redactPayloadBodies: true)
+
+        for format in [SessionExportFormat.pcap, .pcapng] {
+            do {
+                _ = try SessionExporter.artifact(
+                    for: fixture.session,
+                    frames: fixture.frames,
+                    defaultLinkType: LinkType.ethernet,
+                    format: format,
+                    privacy: policy
+                )
+                Issue.record("Expected raw export refusal for \(format)")
+            } catch let error as SessionExportError {
+                guard case .rawExportRequiresAcknowledgement = error else {
+                    Issue.record("Unexpected error \(error) for \(format)")
+                    continue
+                }
+            }
+        }
+    }
+
     // MARK: Private
+
+    private func makeRichSession(
+        host: String,
+        sourceEndpoint: String,
+        destinationEndpoint: String,
+        protocolStack: [ProtocolKind],
+        sni: String?,
+        dnsQuery: String?,
+        dnsAnswers: [String]
+    )
+        -> SessionSummary
+    {
+        SessionSummary(
+            id: UUID(),
+            startTime: Date(timeIntervalSince1970: 1_700_000_000),
+            duration: 1.5,
+            processName: "curl",
+            host: host,
+            sourceEndpoint: sourceEndpoint,
+            destinationEndpoint: destinationEndpoint,
+            protocolStack: protocolStack,
+            status: .ok,
+            latencyMilliseconds: 12.0,
+            bytesUp: 128,
+            bytesDown: 512,
+            sni: sni,
+            dnsQuery: dnsQuery,
+            dnsAnswers: dnsAnswers
+        )
+    }
 
     private func makeFixture() throws -> (session: SessionSummary, frames: [CapturedFrame]) {
         let allFrames = SampleCapture.frames(now: Date(timeIntervalSince1970: 1_700_000_000))

--- a/TracexyTests/Models/UI/PrivacySettingsTests.swift
+++ b/TracexyTests/Models/UI/PrivacySettingsTests.swift
@@ -1,0 +1,42 @@
+import Foundation
+import Testing
+@testable import Tracexy
+
+@Suite("Privacy settings")
+struct PrivacySettingsTests {
+    // MARK: Internal
+
+    @Test("Fresh defaults resolve to protective session export settings")
+    func protectiveDefaults() throws {
+        let defaults = try scratchDefaults()
+
+        let policy = PrivacySettingsResolver.exportPolicy(defaults: defaults)
+
+        #expect(policy.redactPayloadBodies)
+        #expect(policy.stripCredentials)
+        #expect(!policy.maskIPAddresses)
+    }
+
+    @Test("Persisted privacy choices override every shipped default")
+    func persistedChoices() throws {
+        let defaults = try scratchDefaults()
+        defaults.set(false, forKey: SettingsKeys.redactBodies)
+        defaults.set(false, forKey: SettingsKeys.stripCredentials)
+        defaults.set(true, forKey: SettingsKeys.maskIPs)
+
+        let policy = PrivacySettingsResolver.exportPolicy(defaults: defaults)
+
+        #expect(!policy.redactPayloadBodies)
+        #expect(!policy.stripCredentials)
+        #expect(policy.maskIPAddresses)
+    }
+
+    // MARK: Private
+
+    private func scratchDefaults() throws -> UserDefaults {
+        let suiteName = "PrivacySettingsTests.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defaults.removePersistentDomain(forName: suiteName)
+        return defaults
+    }
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -27,9 +27,11 @@ interface with workspaces, filtering, focus sets, and an inspector.
 **Partial:** application-layer decode remains metadata-focused — DNS records, TLS handshake and record
 metadata, HTTP/1 headers, QUIC long-header metadata, and STUN attributes. TCP prefix reassembly is
 bounded to initial TLS/HTTP/DNS metadata; a general stateful connection/reassembly engine is not present.
+Protected `.tracexysession` export enforces the Privacy settings by omitting raw frames and sensitive
+decoded metadata. Raw pcap/pcapng remains evidence-preserving and is never presented as redacted.
 
 **Planned / not yet implemented:** a decoder registry with dispatch-table handoff, a stateful
 connection table with TCP reassembly, an analysis/security engine, persistent SQLite storage, an
-MCP/AI bridge, and an enforced export-redaction pipeline. Do not treat these as present.
+MCP/AI bridge, and packet-rewriting redaction for raw capture formats. Do not treat these as present.
 
 When the source and these docs disagree, the source is correct — please open an issue or a fix.

--- a/docs/privacy-and-security.md
+++ b/docs/privacy-and-security.md
@@ -12,18 +12,23 @@ page states plainly what the app does and does not do today.
   after launch setup completes. The gate on capturing is the one-time operating-system approval of
   the privileged helper (System Settings → Login Items) — there is no separate per-capture consent
   dialog, and this documentation does not claim one.
-- **Exports are sensitive — redact them yourself.** Exporting or sharing a capture writes the raw
-  captured frame bytes. A `.pcap` is a recording of everything that crossed the wire, including things
-  you may have forgotten were in it. Treat every export as sensitive and redact before sharing.
+- **Raw exports are sensitive.** A `.pcap` or `.pcapng` is a recording of captured packet bytes,
+  including data you may have forgotten was present. Tracexy does not claim to rewrite or redact these
+  evidence-preserving formats. When a Privacy protection is enabled, every raw export requires explicit
+  acknowledgement before the save panel opens.
 
-### Redaction preferences vs. enforcement
+### Protected session export
 
-Settings → Privacy offers redaction and retention **preferences** — redact payload bodies, strip
-credentials and tokens, mask IP addresses, auto-clear. These persist your choices, but the
-end-to-end pipeline that would **enforce** them on export is **not implemented yet**. In other words:
-turning on "redact bodies" records the intent, but today's export path does not yet act on it. Until
-that lands, do your own redaction before sharing a capture, and don't rely on these toggles to sanitize
-output.
+Settings → Privacy controls the native `.tracexysession` export path. Redacting payloads, stripping
+credentials, or masking addresses produces a version-2 protected document that contains session and
+frame metadata but no raw packet bytes. Credential stripping also removes DNS query/answer strings and
+the free-form decoded summary; IP masking replaces literal IPv4/IPv6 addresses in exported summary
+fields with a fixed placeholder. The document records the applied protections as machine-readable
+metadata. A version-1 document with packet bytes is produced only when every protection is disabled.
+
+These controls do not sanitize raw pcap/pcapng files. Use the warning as a hard trust boundary: export
+those formats only when you intend to handle the result as sensitive evidence. Automatic retention
+cleanup remains planned; the Auto-clear choice currently records intent only.
 
 ## The privileged helper and trust boundary
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -82,9 +82,13 @@ session rather than disappearing.
 
 Select a session to enable the toolbar's **Export** menu beside the independent **Start** and inspector
 controls. The same menu is available from the session row's **Export** submenu. **Export Session**
-writes a versioned `.tracexysession` document containing the session summary and its captured
-packet frames. **Export as pcap** writes a classic capture when all matching frames share one link type;
-**Export as pcapng** preserves mixed per-frame link types. Export is always an explicit local save-panel
+writes a versioned `.tracexysession` document. With the default Privacy settings, the protected document
+keeps session and frame metadata but omits captured packet bytes, DNS-derived strings, and the free-form
+summary; optional IP masking replaces literal addresses with a fixed placeholder. Turning every export
+protection off preserves the original version-1 document with packet frames. **Export as pcap** writes a
+classic capture when all matching frames share one link type; **Export as pcapng** preserves mixed
+per-frame link types. Those raw formats always preserve captured bytes and require a per-export warning
+acknowledgement while any privacy protection is enabled. Export is always an explicit local save-panel
 action. Live export reads the complete local pcapng spool; saved-capture export re-reads the source file,
 so the bounded in-memory inspection window does not silently truncate an export.
 


### PR DESCRIPTION
## Summary

Promote the production-readiness hardening integrated on `develop` into `main`:

- Enforce Privacy settings for protected `.tracexysession` exports by omitting raw frame bytes, removing sensitive decoded metadata, and masking IPv4/IPv6 values.
- Preserve `.pcap` and `.pcapng` as raw evidence formats and require explicit acknowledgement when active privacy protections cannot be applied to packet bytes.
- Authenticate privileged helper callers from the XPC audit token and fail closed when caller identity cannot be resolved or validated.
- Recover inactive live-capture spool artifacts through advisory locking without deleting active captures, directories, symlinks, or unrelated files.
- Add regression coverage and documentation for the export, authorization, and recovery boundaries.

## Why

These changes tighten three production-critical trust boundaries without redesigning the established workflow:

1. Export privacy controls now make a truthful distinction between protected native documents and raw packet captures.
2. Helper authorization derives identity from the XPC connection itself, avoiding PID reuse and validation race risks.
3. Interrupted live captures can be cleaned up safely without risking concurrent active spool files.

## Release impact

- Existing Privacy settings now directly govern native session export contents.
- Raw capture exports remain byte-preserving and display an explicit warning rather than implying redaction.
- The privileged helper rejects callers whose signing identity cannot be proven.
- Inactive capture-spool files no longer accumulate indefinitely after interrupted runs.
- No major UI layout or UX pattern changes are included.

This PR promotes source changes only. It does not create a version tag or publish a GitHub release.

## Validation

The promoted `develop` tree is identical to the locally validated hardening branch tree.

- `xcodebuild -project Tracexy.xcodeproj -scheme Tracexy -destination 'platform=macOS' test -only-testing:TracexyTests -quiet`
- `xcodebuild -project Tracexy.xcodeproj -scheme TracexyCaptureHelper -destination 'platform=macOS' build -quiet`
- `swiftformat --lint .`
- `swiftlint lint --strict`
- `git diff --check origin/main...origin/develop`
- Clean pre-merge simulation against the then-current `main`

All listed local checks passed before promotion.

## Post-merge CI status

This PR was merged while GitHub Actions still reported the following blockers:

- **Public Safety Check:** the `develop` merge commit and the final `main` merge commit carry a personal webmail author identity. No source-content leak was reported, but the published metadata requires remediation.
- **Test:** 417 of 419 unit tests pass. Two audit-token authorization tests require a signing identifier, while CI intentionally disables code signing; the Security framework therefore returns no identifier. The unsigned environment needs explicit fail-closed coverage without weakening production validation.
- **SwiftLint:** passes.
- **Release build:** was skipped because it depends on the test job.

A follow-up correction is required before treating `main` as fully green.

## Remaining manual verification

- Reinstall the freshly built privileged helper and verify live capture plus caller rejection end to end.
- Exercise protected `.tracexysession` export and raw `.pcap`/`.pcapng` acknowledgement using synthetic traffic.
