### PR TITLE
docs(readme): clarify session-first positioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,17 @@
 <h1 align="center">Tracexy</h1>
 
 <p align="center">
-  <strong>The AGPL-licensed public source edition of Tracexy for macOS.</strong>
+  <strong>A native, session-first Wireshark alternative for macOS.</strong>
 </p>
 
 <p align="center">
   Native macOS network intelligence, organized around sessions—not packet noise.<br>
   Capture live traffic or open a saved capture, then investigate hosts, processes, protocols,
   timing, and raw packet evidence in one local-first workspace.
+</p>
+
+<p align="center">
+  <sub>The AGPL-licensed public source edition of Tracexy for macOS.</sub>
 </p>
 
 <p align="center">


### PR DESCRIPTION
## Summary

- lead the README hero with a concise macOS and session-first product position
- preserve the public-source AGPL edition notice as supporting metadata
- keep the existing local-first investigation description and project badges prominent

## Validation

- `git diff --check origin/main...origin/develop`
- SwiftLint passes
- application tests are running in GitHub Actions
- the Public Safety Check currently reports six pre-existing merge commits already reachable from `origin/main`; this commit uses the repository-safe noreply identity and introduces no new safety finding

Documentation-only product change; no local application build was required.