### PR TITLE
docs(project): add licensing and comparison guidance

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,86 @@
+name: Bug report
+description: Report a reproducible Tracexy defect that is not a security vulnerability.
+title: "fix: "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for helping improve Tracexy. Do not include secrets, credentials, private hostnames, or raw captures you have not reviewed. Security vulnerabilities belong in GitHub Security Advisories, not public issues.
+  - type: input
+    id: version
+    attributes:
+      label: Tracexy version or commit
+      description: Use the app version, tagged release, or commit SHA.
+      placeholder: "v0.5.0 or abc1234"
+    validations:
+      required: true
+  - type: input
+    id: macos
+    attributes:
+      label: macOS version
+      placeholder: "macOS 15.6"
+    validations:
+      required: true
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - Live capture
+        - Helper installation or recovery
+        - Saved PCAP or PCAPNG open
+        - Packet decoder
+        - Sessions or connection evidence
+        - Findings or Investigation queries
+        - Follow Stream
+        - History
+        - Export or privacy controls
+        - UI or workflow
+        - Updates
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+    validations:
+      required: true
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Steps to reproduce
+      description: Include the smallest capture setup or saved-file action that reproduces the issue.
+      placeholder: |
+        1. Open...
+        2. Start capture on...
+        3. Select...
+        4. Observe...
+    validations:
+      required: true
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Sanitized evidence
+      description: Paste logs, screenshots, crash excerpts, or minimal fixture details after removing secrets and private traffic.
+    validations:
+      required: false
+  - type: checkboxes
+    id: safety
+    attributes:
+      label: Safety checks
+      options:
+        - label: This is not a security vulnerability.
+          required: true
+        - label: I reviewed attachments for secrets, private hostnames, credentials, and packet payloads.
+          required: true
+        - label: I understand raw pcap/pcapng files can contain sensitive traffic.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Report a security vulnerability
+    url: https://github.com/RockxyApp/Tracexy/security/advisories/new
+    about: Use a private GitHub Security Advisory for vulnerabilities.
+  - name: Read the security policy
+    url: https://github.com/RockxyApp/Tracexy/blob/develop/SECURITY.md
+    about: Review scope, disclosure expectations, and safe testing rules.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,57 @@
+name: Feature request
+description: Suggest a Tracexy capability or workflow improvement.
+title: "feat: "
+labels:
+  - enhancement
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please frame the problem first. Tracexy is session-first and local-first; requests that add export, AI, automation, helper, or capture behavior need explicit privacy and security boundaries.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What investigation or workflow is hard today?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed behavior
+      description: What should Tracexy do?
+    validations:
+      required: true
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - Capture
+        - Protocol decoding
+        - Sessions
+        - Evidence or findings
+        - Query and filtering
+        - Follow Stream
+        - History
+        - Export or privacy controls
+        - Automation
+        - UI or workflow
+        - Documentation
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: boundaries
+    attributes:
+      label: Privacy and security boundaries
+      description: Note any raw traffic, credentials, external services, privileged helper changes, or retained data involved.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Mention existing workflows or tools you compared, if any.
+    validations:
+      required: false

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,24 @@
+## Summary
+
+-
+
+## Validation
+
+- [ ] `swiftformat --lint .`
+- [ ] `swiftlint lint --strict`
+- [ ] `xcodebuild -project Tracexy.xcodeproj -scheme Tracexy -destination 'platform=macOS' build`
+- [ ] Relevant tests:
+
+## Safety Checklist
+
+- [ ] Targets `develop`.
+- [ ] Includes tests or explains why tests are not applicable.
+- [ ] Updates docs for user-facing behavior changes.
+- [ ] Preserves capture/helper/XPC/privacy boundaries.
+- [ ] Contains no credentials, signing files, local paths, raw captures, or private config.
+- [ ] Does not use agent, model, vendor, or local tool identity in public metadata.
+- [ ] I have read and agree to the Tracexy ICLA v1.0.
+
+## Notes
+
+-

--- a/.github/scripts/check-public-safety.sh
+++ b/.github/scripts/check-public-safety.sh
@@ -283,12 +283,18 @@ report "Forbidden sensitive path (policy)" "$FORBIDDEN_OUT"
 legacy_personal_mail_commit() {
     case "$1" in
     09d3dd91c755fd853e79b5d49762140263149993 \
+        | 290cf0c0d6769900e76e0b5f04e914376742d54e \
+        | 48f1e39129d3835872a513cb7cbb96d96d25562d \
         | 523b17b715a890f566b3f8e958625d7482113127 \
         | 5f0ec0b18c4193263a918f85de1e41257f9d8f6d \
+        | 70ef5119bc6ecf556943a750e563da115180d445 \
         | 7abcb836c52cb4f29c9518e711bcde3bafff9711 \
+        | 8c0a368e6914483331eb76cb13b6b0531f6945b1 \
         | a3752dea56349fcf5393c1451d8fab58e8da1e03 \
         | ab8987c7c67cb1209c9f12b0083f11f9dcb8779f \
         | ae8849cf6e5b7f3ab634d8619a112248ab0102eb \
+        | b8017b1808997ae7c19590b1b701d213a8e8c072 \
+        | c6b671f023242d5d3883b57bc628219188d252a2 \
         | de25765496efc9da0a07cfce5fca9605ca908367 \
         | e0b62af78a5378159f0a9b9400ecd0456340122e \
         | e790c089cf4aa7a8f4f2d6054e489f4443a6494e)
@@ -418,7 +424,7 @@ emit_locations "Concrete Apple Team ID" "$c_out" 2
 # public repository links; private sibling-product internals remain forbidden.
 # awk prints the ORIGINAL line; the strip is only for the decision.
 c_out="$(grep -nHIi 'rockxy' "${FILES[@]}" 2>/dev/null \
-    | awk '{ t = $0; gsub(/RockxyApp\/(Tracexy|Rockxy|Shieldxy)/, "", t); gsub(/https:\/\/rockxy\.io\/tracexy/, "", t); gsub(/Rockxy Ecosystem/, "", t); gsub(/\[Rockxy ecosystem\]/, "", t); gsub(/\[Rockxy\]/, "", t); if (tolower(t) ~ /rockxy/) print $0 }')"
+    | awk '{ t = $0; gsub(/RockxyApp\/(Tracexy|Rockxy|Shieldxy)/, "", t); gsub(/https:\/\/rockxy\.io\/tracexy/, "", t); gsub(/https:\/\/rockxy\.io\/wireshark-alternative/, "", t); gsub(/Rockxy LLC/, "", t); gsub(/Rockxy Ecosystem/, "", t); gsub(/\[Rockxy ecosystem\]/, "", t); gsub(/\[Rockxy\]/, "", t); if (tolower(t) ~ /rockxy/) print $0 }')"
 emit_locations "Sibling-product token 'rockxy' (approved public ecosystem references allowed)" "$c_out" 2
 
 # --- Check 6: monetization / licensing strategy phrases ----------------------

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,7 @@
 # Contributing
 
-Thanks for looking. Tracexy is early enough that a good bug report is worth as much as a patch.
+Thanks for looking. Tracexy is early enough that a good bug report is worth as
+much as a patch.
 
 By participating you agree to abide by the [Code of Conduct](CODE_OF_CONDUCT.md).
 
@@ -24,6 +25,59 @@ xcodebuild -project Tracexy.xcodeproj -scheme Tracexy -destination 'platform=mac
 
 The project uses Xcode's file-system-synchronized groups, so adding a Swift file under `Tracexy/`
 or `TracexyTests/` needs no project-file edit. Create the file and build.
+
+## Branches and pull requests
+
+Branch from `develop` and target pull requests at `develop`. Keep one coherent
+change per pull request, with docs and tests in the same review when behavior
+changes.
+
+Use product-focused branch names:
+
+- `feat/add-pcapng-stream-note`
+- `fix/helper-signature-diagnostic`
+- `docs/update-security-policy`
+- `test/dns-truncation-fixtures`
+
+Do not put local agent, vendor, model, or tool names in branches, commit
+subjects, pull-request titles, release notes, or authorship trailers.
+
+Commits follow [Conventional Commits](https://www.conventionalcommits.org/):
+`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`, or `ci:`.
+
+Before opening a pull request, check:
+
+- [ ] The change is scoped to Tracexy's current source, not roadmap-only design.
+- [ ] Tests were added or updated for behavior changes.
+- [ ] Decoder changes cover normal, truncated, and malformed inputs.
+- [ ] User-facing behavior changes update the nearest docs in `docs/`.
+- [ ] Privacy, export, capture, helper, and XPC boundaries were reviewed.
+- [ ] `swiftformat --lint .` and `swiftlint lint --strict` pass, or the PR
+      explains why a local tool was unavailable.
+- [ ] A relevant `xcodebuild` build or test command was run, or the PR explains
+      why it could not be run.
+- [ ] No captures, credentials, signing files, local paths, or private
+      configuration were committed.
+
+## Contributor License Agreement
+
+External contributors must accept the current
+[Tracexy Individual Contributor License Agreement v1.0](legal/cla/ICLA-v1.0.md)
+before their pull request can be merged. When the CLA workflow asks, post this
+exact comment on the pull request:
+
+```text
+I have read and agree to the Tracexy ICLA v1.0
+```
+
+You retain copyright in your Contribution. The ICLA gives Rockxy LLC the rights
+needed to publish the Contribution in the public AGPL source edition and to use
+it in separately licensed Tracexy distributions.
+
+If your employer or another organization owns or controls your Contribution, an
+authorized representative must also execute the
+[Corporate Contributor License Agreement](legal/cla/CCLA-v1.0.md). Maintainers
+will review organizational authorization manually.
 
 ## Code style
 
@@ -54,16 +108,24 @@ from `Theme` — no literal values in views. Icons are real SF Symbols via `Imag
 - **Small beats clever.** A summary-level feature that ships is worth more than deep decoding that
   stalls.
 
-Commits follow [Conventional Commits](https://www.conventionalcommits.org/) — `feat:`, `fix:`,
-`chore:`, `feat!:` for anything breaking. The messages drive release notes, so write them for
-someone reading the changelog.
-
 ## Reporting bugs
 
-Please include the macOS version, what you were capturing, and what you expected instead. If a
-capture file reproduces it, attach one — **but redact it first.** A `.pcap` contains everything
-that crossed the wire, including things you would not choose to publish.
+Please include the Tracexy version or commit, macOS version, whether this was a
+live capture or a saved file, what interface or file type was involved, what
+you expected, and what happened instead.
+
+If a capture file reproduces it, attach one only after reviewing and redacting
+it. A `.pcap` or `.pcapng` contains everything that crossed the wire, including
+credentials, private hosts, and application data.
 
 ## Security
 
 Don't open a public issue. Follow [SECURITY.md](SECURITY.md).
+
+## License
+
+The public source edition is licensed under
+[AGPL-3.0-or-later](LICENSE). Contributions are accepted under the contributor
+agreement so they can remain available in the public AGPL edition and also be
+used in separately licensed Tracexy distributions. See
+[Commercial Licensing Policy](legal/COMMERCIAL-LICENSING.md).

--- a/LICENSE
+++ b/LICENSE
@@ -235,7 +235,9 @@ If your software can interact with users remotely through a computer network, yo
 You should also get your employer (if you work as a programmer) or school, if any, to sign a "copyright disclaimer" for the program, if necessary. For more information on this, and how to apply and follow the GNU AGPL, see <http://www.gnu.org/licenses/>.
 
 
-Copyright 2026 Tracexy Contributors
+Tracexy is a native, session-first Network Intelligence Platform for macOS.
+
+Copyright 2026 Rockxy LLC and Tracexy contributors.
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published
@@ -249,3 +251,17 @@ GNU Affero General Public License for more details.
 
 You should have received a copy of the GNU Affero General Public License
 along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+Additional notice:
+
+This public source edition is licensed under AGPL-3.0-or-later. Rockxy LLC
+may also offer Tracexy, official binaries, support, hosted services,
+enterprise integrations, or downstream distributions under separate commercial
+terms. Those separate terms apply only to the copy, service, or distribution
+that presents them; they do not remove or restrict the AGPL rights granted for
+this public source edition.
+
+The AGPL license does not grant permission to use the Tracexy or Rockxy LLC
+names, logos, icons, domains, trade dress, or other trademarks to identify a
+modified or redistributed product, except for truthful nominative reference
+permitted by law.

--- a/README.md
+++ b/README.md
@@ -60,9 +60,11 @@ bytes are the answer, but they do not dominate the workspace.
 > [!IMPORTANT]
 > This repository contains Tracexy's public source edition under
 > [AGPL-3.0-or-later](LICENSE). Builds made solely from this repository are AGPL builds.
-> The official Community DMG is a signed release artifact built from this public source checkout;
-> it does not represent a separate closed-source edition or a different license. Third-party
-> components remain under their own licenses; see [Licensing](#licensing) below.
+> Rockxy LLC may also offer official binaries, support, enterprise rights, hosted services, or
+> downstream distributions under separate commercial terms. Those terms apply only to the copy,
+> service, or distribution that presents them; they do not remove the AGPL rights granted for this
+> public source edition. Third-party components remain under their own licenses; see
+> [Licensing](#licensing) below.
 
 ## Part of the Rockxy Ecosystem
 
@@ -130,13 +132,29 @@ interfaces, processes, protocols, and session relationships.
 | Area | Available now |
 |---|---|
 | **Capture** | Live libpcap capture through a privileged helper; interface discovery; bounded frame buffering; classic PCAP and PCAPNG read/write |
-| **Decode** | Ethernet, loopback and tunnel framing; ARP; IPv4/IPv6; ICMP/ICMPv6; TCP/UDP; DNS, TLS, HTTP/1, and QUIC summaries |
+| **Decode** | Ethernet, loopback and tunnel framing; ARP; IPv4/IPv6; ICMP/ICMPv6; TCP/UDP; DNS, TLS, HTTP/1, STUN, and QUIC summaries |
 | **Sessions** | Direction-normalized five-tuple grouping, byte/timing summaries, bounded TCP lifecycle and sequence evidence, and higher-level activity correlation |
 | **Investigation** | Overview, session table, flow map, scoped search, typed queries, evidence-linked findings, bounded Follow Stream, decoded fields, and hex evidence |
 | **History** | Local SQLite terminal capture/session summaries with bounded reads, explicit refresh, confirmed clear, and no packet-payload persistence |
 | **Automation core** | Read-only one-page History projections with minimum disclosure, deterministic JSON, and spreadsheet-safe RFC-4180 CSV; no executable or network transport |
 | **Workspace** | Native sidebar, independent workspace tabs, vertical or bottom inspector layouts, status/footer surfaces, Focus Sets, and Noise Control |
 | **Attribution** | Best-effort process ownership from `pktap` metadata with a local socket-to-process fallback |
+
+## Comparison at a glance
+
+Tracexy is not a Wireshark clone or a TLS interception proxy. It is strongest when a Mac
+investigation needs app-aware sessions, local packet evidence, and a support-ready handoff without
+claiming decrypted HTTPS visibility. The full maintained matrix is in
+[docs/comparison.md](docs/comparison.md).
+
+| Decision point | Tracexy | Wireshark | tcpdump | TShark | Packet | Cocoa Packet Analyzer |
+|---|---|---|---|---|---|---|
+| **Primary workflow** | Native macOS, session-first packet evidence with app/process context | Deep protocol dissection and broad packet-analysis workflow | Small command-line capture primitive | Wireshark dissection and field output in a terminal | Friendly native Mac traffic view | Native Mac packet/trace analyzer |
+| **Source/license posture** | AGPL-3.0-or-later public source; separate commercial terms may exist for official distributions | Public open-source project | Public open-source command-line tool | Public open-source Wireshark command-line tool | closed source or no public information | closed source or no public information |
+| **Live capture** | Live libpcap capture through a narrow privileged helper | Live interface capture | Live interface capture from terminal | Live capture from terminal | Native Mac live traffic workflow, depth requires vendor verification | Capture workflow requires vendor verification |
+| **App/process attribution** | Core workflow when macOS context is available; unknown stays unknown | Possible through capture context, not the central workflow | Depends on capture context and surrounding tools | Available only if fields/capture context expose it | Per-app usage is publicly positioned, implementation depth requires vendor verification | Not a central verified claim |
+| **TLS and HTTPS payloads** | TLS metadata only; no TLS interception, no decryption, no encrypted HTTP body visibility | Packet visibility depends on keys, capture point, and protocol conditions | Captures bytes; no HTTP interception workflow | Same packet-analysis boundary as Wireshark | Not positioned as an HTTPS interception proxy | Packet-analyzer boundary; no verified HTTPS interception claim |
+| **Best aligned user** | Mac developer/support/security workflow that needs app-aware packet evidence without decrypting traffic | Protocol engineer or analyst needing maximum dissector depth | Operator collecting traffic quickly on a terminal or remote system | Analyst automating Wireshark-style dissection | Mac user wanting a friendly traffic view | Mac user wanting a native packet/trace analyzer |
 
 ## Protocol coverage
 
@@ -268,6 +286,7 @@ transitional debt.
 | [Architecture](docs/architecture.md) | Data flow, module boundaries, and repository map |
 | [Protocol support](docs/protocol-support.md) | Exact decode coverage and limitations |
 | [Privacy & security](docs/privacy-and-security.md) | Local-first posture and privileged trust boundary |
+| [Competitor comparison](docs/comparison.md) | Source-backed positioning against packet-analysis alternatives |
 | [Changelog](CHANGELOG.md) | Unreleased work and future tagged releases |
 
 ## Contributing
@@ -296,21 +315,26 @@ no-warranty provisions, are in [LICENSE](LICENSE).
 A build made solely from this repository is therefore an AGPL build. AGPL does not grant rights to
 the Tracexy name, logo, or other trademarks.
 
-### Public source and official Community DMG
+### Commercial licensing and official binaries
 
-The public GitHub repository is the source of truth for Tracexy's Community release channel. The
-official DMG published on [GitHub Releases](https://github.com/RockxyApp/Tracexy/releases) is built
-from that public checkout using the Release configuration, then:
+Rockxy LLC may offer Tracexy, official binaries, support, enterprise rights, hosted services, private
+distribution rights, or downstream distributions under separate commercial terms. See the
+[Commercial Licensing Policy](legal/COMMERCIAL-LICENSING.md) and the draft
+[Binary EULA](legal/BINARY-EULA-v1.0.md).
 
-- signed with a Developer ID certificate and hardened runtime;
-- packaged as a drag-to-Applications macOS DMG;
-- notarized with Apple's notary service; and
-- published with a checksum and a Sparkle signature for the public update feed.
+A commercial license applies only when Rockxy LLC grants it in writing or when an official
+distribution presents the applicable agreement. Owning or using a commercially licensed copy does
+not cancel the AGPL rights you have for a separate copy of the public source edition.
 
-The DMG is therefore an authenticated and notarized distribution of the public AGPL source, not a
-closed-source or separately licensed Tracexy binary. A local build from the repository remains
-valid under AGPL-3.0-or-later, but it will have its own signing identity, notarization state,
-update-feed behavior, and release provenance.
+External contributions are accepted under the
+[Tracexy Individual Contributor License Agreement](legal/cla/ICLA-v1.0.md) so accepted changes can
+remain available in the public AGPL edition and also be used in separately licensed Tracexy
+distributions. Organization-owned contributions require the
+[Corporate Contributor License Agreement](legal/cla/CCLA-v1.0.md).
+
+AGPL does not grant rights to use the Tracexy or Rockxy LLC names, logos, icons, domains, trade
+dress, or other trademarks to identify a modified or redistributed product, except for truthful
+nominative reference permitted by law.
 
 ### Third-party and platform components
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,9 +1,9 @@
 # Security Policy
 
-Tracexy captures network traffic and installs a privileged helper to do it. Both are worth
-attacking, so security reports are taken seriously.
+Tracexy captures network traffic and installs a privileged helper to do it.
+Both are worth attacking, so security reports are taken seriously.
 
-## Supported versions
+## Supported Versions
 
 | Version | Supported |
 |---------|-----------|
@@ -11,24 +11,38 @@ attacking, so security reports are taken seriously.
 | Previous release | Security fixes only |
 | Older releases | No |
 
-## Reporting a vulnerability
+## Reporting a Vulnerability
 
 **Please do not open a public GitHub issue for a security vulnerability.**
 
-Use [GitHub Security Advisories](https://github.com/RockxyApp/Tracexy/security/advisories) — go to
-the Security tab and click "Report a vulnerability."
+Use [GitHub Security Advisories](https://github.com/RockxyApp/Tracexy/security/advisories):
+go to the Security tab and click "Report a vulnerability."
 
 Include:
 
-- What the vulnerability is, and roughly how bad you think it is
-- Steps to reproduce, or a proof of concept
-- Which versions you tested
-- Anything you already know about mitigations
+- a clear vulnerability description;
+- impact and affected trust boundary;
+- steps to reproduce or a proof of concept;
+- affected Tracexy version, commit, macOS version, and hardware architecture if
+  relevant;
+- whether live capture, saved capture parsing, helper installation, export, or
+  update handling is involved;
+- crash logs, sanitized diagnostics, or minimal fixtures when safe to share;
+- mitigation ideas, if you have them; and
+- whether you want public credit.
 
-Please give us a reasonable window to ship a fix before disclosing publicly. We'll keep you posted
-on progress and credit you in the release notes unless you'd rather we didn't.
+Please give us a reasonable window to ship a fix before disclosing publicly.
+We will keep you posted on progress and credit you in release notes unless you
+prefer to remain anonymous.
 
-## Areas worth your attention
+## What to Expect
+
+- Acknowledgment after maintainers receive the report.
+- Initial severity assessment after reproduction or source review.
+- A coordinated fix plan for valid issues.
+- Credit in the advisory or release notes when requested and safe.
+
+## In Scope
 
 If you are looking for somewhere to start:
 
@@ -40,8 +54,61 @@ If you are looking for somewhere to start:
   allocation is a real bug — `PacketBuffer` is supposed to make that impossible.
 - **Capture file parsing** (`Tracexy/Core/Capture/`). Same reasoning: a `.pcap` handed to you by
   someone else is untrusted input.
+- **Live capture spooling and locators.** Payload locators must remain
+  reset-scoped, bounded, identity-checked, and unavailable for active-live
+  growing-spool Follow Stream reads.
+- **Export and privacy controls.** Protected `.tracexysession` export must omit
+  raw frames and sensitive decoded metadata according to Privacy settings. Raw
+  pcap/pcapng export must remain explicit and evidence-preserving.
+- **History and automation.** Stored history and read-only automation exports
+  must stay bounded and must not add raw packet payloads, executable targets,
+  listeners, providers, or external data paths.
+- **Update and signing behavior.** Signed update checks must stay separate from
+  capture data, and helper/app signature mismatches must fail closed.
 
-## Out of scope
+## Out of Scope
 
 - Requiring an admin password to install the privileged helper. That is the design.
 - The app being able to see network traffic on the machine it is running on. That is the product.
+- Reports that only show that raw pcap/pcapng exports contain sensitive traffic;
+  that is the nature of raw capture formats.
+- Denial-of-service testing against third-party systems.
+- Social engineering, phishing, or physical attacks against users or
+  maintainers.
+- Vulnerabilities in third-party dependencies by themselves. Report them
+  upstream and notify Tracexy maintainers so the dependency fix can be tracked.
+
+## Research Rules
+
+Good-faith testing is welcome. Please:
+
+- test only systems, captures, and accounts you are authorized to use;
+- keep proof-of-concept captures minimal and sanitized;
+- do not access, modify, or publish another person's data;
+- do not persist credentials, private keys, or real packet captures in a public
+  issue or pull request; and
+- stop testing and report promptly if you discover a path to privilege
+  escalation, arbitrary command execution, data exfiltration, or persistent
+  compromise.
+
+## Security Architecture
+
+The main security model is documented in
+[Privacy & security](docs/privacy-and-security.md). The highest-value
+boundaries are:
+
+- **App to helper:** a narrow XPC protocol with code-signing validation on both
+  sides.
+- **Untrusted bytes:** bounds-checked packet and capture-file parsing.
+- **Local-first data:** captures, sessions, and history stay local unless the
+  user explicitly exports them.
+- **No hidden analysis transport:** the current automation core is read-only and
+  transport-neutral; there is no MCP server, listener, provider, or AI data
+  path in the public app today.
+
+## Disclosure Policy
+
+We follow coordinated disclosure. Maintainers will not pursue legal action
+against researchers acting in good faith under this policy. Public disclosure
+before a fix may put users at risk, especially for helper, parser, or export
+issues.

--- a/Tracexy/Core/Session/ActivityBuilder.swift
+++ b/Tracexy/Core/Session/ActivityBuilder.swift
@@ -6,10 +6,10 @@ import Foundation
 /// inference layered on top of decoding, never part of it, so it can be revised,
 /// switched off, or disagreed with without touching the capture path.
 ///
-/// The evidence is weighted rather than keyed on a single field. A single
-/// grouping key (TCP Viewer uses TLS SNI) fails on everything that is not TLS,
-/// loses DNS entirely, and cannot express doubt. Here each link carries the
-/// reason it was made, and contested attributions stay contested.
+/// The evidence is weighted rather than keyed on a single field. A TLS-only
+/// grouping key fails on everything that is not TLS, loses DNS entirely, and
+/// cannot express doubt. Here each link carries the reason it was made, and
+/// contested attributions stay contested.
 enum ActivityBuilder {
     // MARK: Internal
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,6 +15,7 @@ This documentation describes what is actually in the source today, and clearly m
 | [Architecture](architecture.md) | The capture → protocol → session → UI pipeline, repository map, boundaries |
 | [Protocol support](protocol-support.md) | The accurate, per-layer decode matrix and its limits |
 | [Privacy & security](privacy-and-security.md) | Local-first posture, the privileged helper, and the trust boundary |
+| [Competitor comparison](comparison.md) | Source-backed comparison with packet-analysis alternatives |
 
 ## Status at a glance
 
@@ -25,9 +26,9 @@ protected session export, terminal-summary SQLite History, and a native SwiftUI/
 workspace with typed queries and explicit bounded Follow Stream.
 
 **Partial:** application-layer decode remains metadata-focused — DNS records, TLS handshake and record
-metadata, HTTP/1 headers, QUIC long-header metadata, and STUN attributes. TCP prefix recovery is
-bounded to initial TLS/HTTP/DNS metadata; the connection table does not provide a general always-on
-stream/record analyzer.
+metadata, HTTP/1 request-line and Host header recognition, QUIC long-header metadata, and STUN
+attributes. TCP prefix recovery is bounded to initial TLS/HTTP/DNS metadata; the connection table
+does not provide a general always-on stream/record analyzer.
 Protected `.tracexysession` export enforces the Privacy settings by omitting raw frames and sensitive
 decoded metadata. Raw pcap/pcapng remains evidence-preserving and is never presented as redacted.
 

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -1,0 +1,104 @@
+# Tracexy Competitor Comparison
+
+Last reviewed: 2026-08-30. Source release: Tracexy 0.5.0, build 10.
+
+This matrix is the repository-owned comparison for Tracexy as a native,
+session-first macOS Network Intelligence Platform. It mirrors the public
+Tracexy website positioning and keeps current source facts separate from
+roadmap work.
+
+A requested TCP connection viewer is intentionally excluded. It is not part of
+the current public Tracexy competitor set, and adding it here would create an
+unsupported comparison claim.
+
+## Method
+
+- Tracexy claims come from this repository's README, documentation, and current
+  version configuration.
+- The competitor set comes from the public Tracexy alternatives matrix:
+  Wireshark, tcpdump, TShark, Packet, and Cocoa Packet Analyzer.
+- Closed products are not reverse engineered. If a claim is not public or not
+  verified, the cell says `closed source or no public information`.
+- This document does not include outbound competitor links. The public website
+  intentionally avoids competitor links on comparison pages and treats
+  unverified closed-source claims conservatively.
+- Tracexy is not described as a Wireshark clone or replacement. It is a
+  different workflow: app-aware Mac sessions and support-ready evidence first,
+  packet detail underneath.
+
+## Product Boundary
+
+Tracexy is passive packet capture and local analysis. It can expose TLS
+metadata and identify QUIC long headers, but it does not intercept TLS, decrypt
+TLS or QUIC, or expose encrypted HTTP payloads. HTTPS request inspection,
+modification, replay, and redaction belong to
+[Rockxy](https://github.com/RockxyApp/Rockxy), not Tracexy.
+
+App and process attribution is also conditional: it is a core Tracexy workflow
+when macOS reports `pktap` process context or when local socket fallback can
+resolve ownership. Missing ownership is shown as unknown rather than invented.
+
+## Maintained Feature Matrix
+
+| Decision point | Tracexy | Wireshark | tcpdump | TShark | Packet | Cocoa Packet Analyzer |
+|---|---|---|---|---|---|---|
+| Primary workflow | Native macOS, session-first packet evidence with app/process context | Deep protocol dissection and broad packet-analysis workflow | Small command-line capture primitive | Wireshark dissection and field output in a terminal | Friendly native Mac traffic view | Native Mac packet/trace analyzer |
+| Platform posture | macOS 14+ native app | Multi-platform desktop app | Multi-platform CLI | Multi-platform CLI | macOS; current public requirements need vendor verification | macOS; current public requirements need vendor verification |
+| Source/license posture | Public source under AGPL-3.0-or-later; separate commercial terms may exist for official distributions | Public open-source project | Public open-source command-line tool | Public open-source Wireshark command-line tool | closed source or no public information | closed source or no public information |
+| Live capture | Live libpcap capture through a narrow privileged helper | Live interface capture | Live interface capture from terminal | Live capture from terminal | Native Mac live traffic workflow, depth requires vendor verification | Capture workflow requires vendor verification |
+| Saved capture files | Opens and writes PCAP and PCAPNG; sniffs capture-file type | Broad capture-file open support | Reads and writes pcap-style captures | Reads capture files through Wireshark tooling | closed source or no public information | PCAP/trace workflow publicly positioned, exact format scope requires vendor verification |
+| App/process attribution | Core workflow when macOS context is available; unknown stays unknown | Possible through capture context and platform metadata, not the central workflow | Depends on capture context and surrounding tools | Available only if fields/capture context expose it | Per-app usage is publicly positioned, implementation depth requires vendor verification | Not a central verified claim |
+| Session grouping | Canonical five-tuple sessions, timing, byte counts, lifecycle and bounded evidence | Conversation analysis exists, but workflow begins from packets/protocol trees | Not a native session UI | Terminal output can be shaped by fields and filters | closed source or no public information | closed source or no public information |
+| Current protocol coverage | Ethernet, loopback/tunnel, ARP, IPv4/IPv6, ICMP, TCP/UDP, DNS, TLS metadata, HTTP/1 recognition, STUN, conservative QUIC long-header metadata | Broad dissector ecosystem | Capture-oriented; analysis usually handled elsewhere | Wireshark dissectors in terminal form | Readable protocol breakdown is publicly positioned, exact depth requires vendor verification | Plugin-oriented protocol dissection is publicly positioned, exact depth requires vendor verification |
+| Bounds and malformed input posture | Bounds-checked decoder; truncated/malformed frames must produce partial decode or controlled errors | Public project has mature dissector hardening, exact behavior varies by dissector | Capture tool boundary | Wireshark dissector boundary in CLI form | closed source or no public information | closed source or no public information |
+| Filtering | Interface/source selection, BPF, protocol/app/domain filters, search, typed Investigation queries | Capture filters, display filters, field expressions | libpcap/tcpdump capture-filter syntax | Capture filters, display filters, field extraction | UI-driven filters require vendor verification | Trace filters require vendor verification |
+| TLS and HTTPS payloads | TLS metadata only; no TLS interception, no decryption, no encrypted HTTP body visibility | Packet visibility depends on keys, capture point, and protocol conditions | Captures bytes; no HTTP interception workflow | Same packet-analysis boundary as Wireshark | Not positioned as an HTTPS interception proxy | Packet-analyzer boundary; no verified HTTPS interception claim |
+| Follow stream / reassembly | Explicit bounded Follow Stream for saved or fully stopped sources; no active-live growing-spool reads; no general always-on stream analyzer | Mature stream-follow workflow | Not a native GUI workflow | Terminal-oriented stream/field analysis depends on command usage | closed source or no public information | closed source or no public information |
+| Evidence handoff | Decoded fields, raw hex, capture exports, protected `.tracexysession` export, local History summaries | Packet/protocol artifacts and export formats | Capture artifacts for scripts and incident collection | Machine-readable terminal output | Visual/export scope requires vendor verification | Trace/export scope requires vendor verification |
+| Privacy model | Local-first; no automatic upload of capture payloads; protected session export omits raw frames and sensitive decoded metadata | Local analysis by default unless the user chooses external flows | Local CLI capture by default | Local CLI analysis by default | closed source or no public information | closed source or no public information |
+| Automation fit | Native desktop investigation plus a bounded read-only History automation core; no executable target or network transport today | GUI with supporting command-line tools | Strong for scripts and remote hosts | Strong for shell pipelines and CI-style output | Desktop-first; automation requires vendor verification | Desktop-first; automation requires vendor verification |
+| Best aligned user | Mac developer/support/security workflow that needs app-aware packet evidence without decrypting traffic | Protocol engineer or analyst needing maximum dissector depth | Operator collecting traffic quickly on a terminal or remote system | Analyst automating Wireshark-style dissection | Mac user wanting a friendly traffic view | Mac user wanting a native packet/trace analyzer |
+
+## Tracexy Current Features
+
+These are current source claims:
+
+| Area | Current capability |
+|---|---|
+| Capture | Live interface capture through the helper; interface discovery; snap length, promiscuous mode, and BPF settings; PCAP and PCAPNG read/write |
+| Protocol | Bounds-checked packet buffer and direct decoder for current L2-L4 and selected application metadata |
+| Sessions | Canonical five-tuple grouping, endpoint projections, timing/byte summaries, bounded connection evidence |
+| Findings | Selected evidence-linked TCP and datagram findings; no general durable security-analysis engine |
+| Follow Stream | On-demand bounded TCP follow for identity-checked saved or fully stopped sources |
+| History | Local terminal capture/session summaries in SQLite; no raw packet persistence |
+| Automation | Read-only bounded History projection to deterministic JSON or spreadsheet-safe CSV; no listener, provider, executable target, or MCP server |
+| Exports | Raw PCAP/PCAPNG stays byte-preserving; protected `.tracexysession` export omits raw frames and sensitive decoded metadata |
+
+## Not Current Claims
+
+Do not present these as shipped:
+
+- deep HTTP/2 decoding;
+- deep HTTP/3 or QUIC frame/payload decoding;
+- WebSocket decoding;
+- TLS analysis or decrypted HTTPS payload visibility;
+- general always-on TCP stream or record reassembly;
+- user-visible connection/TLS evidence navigation beyond current views;
+- automatic History retention cleanup;
+- production replay UI/runner;
+- CLI transport, TracexyMCP, or AI data transport; and
+- packet-rewriting redaction for raw PCAP or PCAPNG.
+
+## Source Ledger
+
+- Tracexy source truth: `README.md`, `docs/README.md`,
+  `docs/protocol-support.md`, `docs/privacy-and-security.md`,
+  `Configuration/Versions.xcconfig`.
+- Public website source truth reviewed:
+  `tracexy/alternatives.html`, `tracexy/compare.html`,
+  `wireshark-alternative.html`, `tracexy.html`,
+  `scripts/check-tracexy-feature-truth.mjs`.
+- Public pages that carry the same positioning:
+  `https://rockxy.io/tracexy/alternatives`,
+  `https://rockxy.io/tracexy/compare`,
+  `https://rockxy.io/wireshark-alternative`.

--- a/legal/BINARY-EULA-v1.0.md
+++ b/legal/BINARY-EULA-v1.0.md
@@ -1,0 +1,183 @@
+# Tracexy Binary End User License Agreement
+
+Version 1.0 - effective 2026-08-30
+
+This agreement applies prospectively to an official Tracexy binary
+distribution that includes or presents Binary EULA v1.0 on or after its
+effective date. It does not retroactively change the license of an earlier
+distribution. It does not replace or restrict the GNU AGPL rights that apply to
+a separate copy of the public Tracexy source edition.
+
+This document is a project-maintained legal draft and should be reviewed before
+use for a material transaction.
+
+## 1. Parties and acceptance
+
+This agreement is between you and Rockxy LLC (**Licensor**). "Licensor" also
+includes a permitted successor or assignee under Section 12.
+
+By installing, copying, or using an Official Binary that presents this
+agreement, you accept it. If you do not accept it, do not install or use that
+Official Binary; you may instead obtain the separately licensed public source
+edition.
+
+## 2. Definitions
+
+**Official Binary** means a Tracexy macOS application distributed by or on
+behalf of Licensor and identified by a Tracexy version, build number,
+signature, notarized distribution artifact, or official release channel.
+
+**Community Mode** means the capabilities available in an Official Binary
+without a commercial entitlement.
+
+**Commercial Capabilities** means capabilities, capacity, support, update
+rights, enterprise features, or distribution rights made available by an
+eligible commercial license or entitlement.
+
+**Public Source Edition** means source published at
+`https://github.com/RockxyApp/Tracexy` under the GNU Affero General Public
+License, version 3 or later, except identified third-party material.
+
+## 3. Binary license
+
+Subject to this agreement, Licensor grants you a limited, non-exclusive,
+non-transferable license to install and use the Official Binary on compatible
+Apple-branded computers that you own or control. Community Mode may be used
+free of charge. Commercial Capabilities may be used only while and to the
+extent authorized by a valid commercial entitlement and its applicable purchase
+or order terms.
+
+The Official Binary is licensed, not sold. No title or ownership is
+transferred except for ownership of the physical or downloaded copy as required
+by law.
+
+## 4. Public source edition
+
+The Public Source Edition is a separate licensing artifact. Builds made solely
+from that public repository are governed by its AGPL license. An Official
+Binary may be built from a separate downstream distribution and may contain
+non-public components; the public repository is not represented as its complete
+or exact build source unless the relevant release says so.
+
+Nothing in this agreement limits rights expressly granted to you under an
+open-source license for a separate copy of the relevant open-source material.
+Where a third-party license grants rights that conflict with this agreement,
+that third-party license controls for its component.
+
+## 5. Commercial entitlements and updates
+
+A purchase or commercial grant provides only the device scope, capabilities,
+support, update period, and distribution rights described in the applicable
+checkout, order, invoice, or written agreement. A perpetual entitlement, if
+offered, permits continued use of covered Commercial Capabilities in eligible
+builds; it does not promise all future versions, services, or updates.
+
+Tracexy may contact a licensing service to activate, restore, deactivate, or
+validate an entitlement and determine build eligibility. Community Mode remains
+available when no commercial entitlement is active, subject to this agreement.
+
+## 6. Restrictions
+
+Except as permitted by this agreement, a component's open-source license, or
+mandatory law, you may not:
+
+- copy, redistribute, rent, lease, sublicense, or commercially host the Official
+  Binary;
+- bypass or falsify license, entitlement, update-eligibility, signature, or
+  security controls;
+- reverse engineer, decompile, or disassemble non-public portions of the
+  Official Binary; or
+- remove proprietary, copyright, license, or attribution notices.
+
+These restrictions do not prohibit interoperability, security research, or
+other activity that applicable law expressly permits despite a contract, and
+they do not restrict rights granted for separately licensed open-source code.
+
+## 7. Captured data and acceptable use
+
+You are responsible for having authority to capture, inspect, export, or share
+network traffic and credentials. Do not use Tracexy to access systems or data
+without authorization, violate privacy or communications laws, deploy malware,
+or interfere with services. Tracexy's technical ability to capture traffic does
+not provide legal permission to do so.
+
+Data handling by the Official Binary and related services is described in the
+current Tracexy privacy notice. Third-party export, publishing, sharing, AI, or
+hosted services process data under their own terms when you explicitly use
+them.
+
+## 8. Updates, services, and support
+
+Licensor may change or discontinue update, activation, or hosted-service
+functionality, subject to purchase commitments and mandatory law. Unless a
+separate written support agreement applies, no support level or response time
+is guaranteed.
+
+Updates may be subject to a newer agreement. Material changes will be presented
+with reasonable notice before they govern a newly installed update; continued
+use of an already licensed eligible build remains subject to the version
+accepted for that build unless mandatory law provides otherwise.
+
+## 9. Ownership and trademarks
+
+Licensor and applicable contributors retain all rights not expressly granted.
+This agreement does not grant permission to use Tracexy or Rockxy LLC names,
+logos, icons, domains, or trade dress to identify a modified or redistributed
+product, except for truthful nominative reference permitted by law.
+
+## 10. Warranty disclaimer
+
+TO THE MAXIMUM EXTENT PERMITTED BY APPLICABLE LAW, THE OFFICIAL BINARY AND
+RELATED SERVICES ARE PROVIDED "AS IS" AND "AS AVAILABLE," WITHOUT WARRANTIES OF
+ANY KIND, EXPRESS, IMPLIED, OR STATUTORY, INCLUDING MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE, TITLE, NON-INFRINGEMENT, ACCURACY, OR UNINTERRUPTED
+OPERATION. TRACEXY IS A NETWORK-CAPTURE AND ANALYSIS TOOL; CAPTURED DATA,
+PRIVILEGED HELPER INSTALLATION, EXPORTS, AND SYSTEM CAPTURE PERMISSIONS REQUIRE
+CAREFUL USER REVIEW.
+
+Nothing in this agreement excludes warranties or remedies that cannot lawfully
+be excluded, including mandatory consumer rights.
+
+## 11. Limitation of liability
+
+TO THE MAXIMUM EXTENT PERMITTED BY APPLICABLE LAW, LICENSOR WILL NOT BE LIABLE
+FOR INDIRECT, INCIDENTAL, SPECIAL, CONSEQUENTIAL, EXEMPLARY, OR PUNITIVE
+DAMAGES, OR FOR LOST PROFITS, REVENUE, DATA, GOODWILL, OR BUSINESS
+INTERRUPTION, ARISING FROM THE OFFICIAL BINARY OR RELATED SERVICES, EVEN IF
+ADVISED OF THE POSSIBILITY.
+
+LICENSOR'S TOTAL LIABILITY ARISING FROM COMMERCIAL CAPABILITIES WILL NOT
+EXCEED THE AMOUNT YOU PAID FOR THE RELEVANT TRACEXY LICENSE DURING THE TWELVE
+MONTHS BEFORE THE EVENT GIVING RISE TO THE CLAIM. FOR COMMUNITY MODE, TOTAL
+LIABILITY WILL NOT EXCEED USD 10. These limits do not apply where liability
+cannot lawfully be limited.
+
+## 12. Termination and assignment
+
+Your binary license terminates if you materially breach this agreement and do
+not cure a curable breach after reasonable notice. On termination, you must
+stop using and delete the Official Binary, but termination does not affect
+rights granted under a separate open-source license.
+
+Licensor may assign this agreement to an entity that acquires, succeeds to, or
+operates the Tracexy project or business, provided that entity assumes existing
+customer-license obligations in writing. You may not assign a commercial
+entitlement except as its purchase terms or mandatory law permit.
+
+## 13. Trade controls
+
+You must comply with export-control and sanctions laws that apply to you and
+your use of the Official Binary. You represent that you are not prohibited from
+receiving the Official Binary under those laws. This section does not require
+conduct prohibited by applicable law.
+
+## 14. General
+
+This agreement, applicable purchase or order terms, privacy notices, and
+incorporated third-party notices form the agreement for the Official Binary. If
+purchase or order terms conflict with this agreement, the more specific term
+controls for that transaction.
+
+If a provision is unenforceable, it will be limited to the minimum extent
+necessary and the remainder continues. Failure to enforce a provision is not a
+waiver.

--- a/legal/COMMERCIAL-LICENSING.md
+++ b/legal/COMMERCIAL-LICENSING.md
@@ -1,0 +1,73 @@
+# Tracexy Commercial Licensing Policy
+
+Version 1.0 - effective 2026-08-30
+
+Tracexy uses a dual-license-friendly contribution model. The public source
+edition remains available under the GNU Affero General Public License, version
+3 or later (`AGPL-3.0-or-later`). Rockxy LLC may also offer official binaries,
+support, enterprise rights, hosted services, private distribution rights, or
+other downstream Tracexy distributions under separate commercial terms.
+
+This document is a project policy summary, not legal advice.
+
+## Public source edition
+
+The source published in this repository is licensed under
+`AGPL-3.0-or-later`, except for third-party material identified under its own
+license. You may run, study, modify, and redistribute the public source edition,
+including commercially, if you comply with AGPL terms.
+
+Important practical obligations include:
+
+- keep the AGPL license and required notices with redistributed copies;
+- mark meaningful modified versions as modified;
+- provide Corresponding Source for covered object-code distributions; and
+- if a modified version offers remote network interaction, offer the
+  Corresponding Source to users who interact with it over that network.
+
+The AGPL grant does not include trademark rights in Tracexy, Rockxy LLC,
+logos, icons, domains, or trade dress.
+
+## Separate commercial terms
+
+Rockxy LLC may sell or grant a separate commercial license for use cases that
+need terms different from AGPL. Examples include proprietary redistribution,
+private forks that cannot satisfy AGPL source-sharing obligations, internal
+enterprise deployment terms, warranty or support commitments, white-label
+distribution, or separately licensed official binaries.
+
+A commercial license applies only when Rockxy LLC grants it in writing or when
+an official distribution presents the applicable agreement. Owning or using a
+commercially licensed copy does not cancel the AGPL rights you have for a
+separate copy of the public source edition.
+
+## Contributor rights model
+
+Contributors retain copyright in their contributions. To keep Tracexy usable in
+both the public AGPL edition and separately licensed Rockxy LLC distributions,
+external contributors must accept the current Tracexy Individual Contributor
+License Agreement before a pull request can be merged. Organization-owned
+contributions also require a Corporate Contributor License Agreement.
+
+See:
+
+- [Tracexy ICLA v1.0](cla/ICLA-v1.0.md)
+- [Tracexy CCLA v1.0](cla/CCLA-v1.0.md)
+- [Contributor agreement policy](cla/README.md)
+
+## Official binaries
+
+An official binary may be an AGPL build, a separately licensed binary, or a
+distribution that combines open-source and non-public downstream material,
+depending on the release channel and agreement presented with that binary.
+
+Nothing in a binary agreement limits rights expressly granted for a separate
+copy of AGPL-licensed source. Third-party components remain under their own
+licenses.
+
+## Trademarks and product identity
+
+The Tracexy and Rockxy LLC names, product icons, domains, and visual identity
+are reserved. You may use them for truthful nominative reference, such as
+saying that your fork is based on Tracexy, but you may not present a modified
+build as an official Tracexy or Rockxy LLC product without written permission.

--- a/legal/cla/CCLA-v1.0.md
+++ b/legal/cla/CCLA-v1.0.md
@@ -1,0 +1,115 @@
+# Tracexy Corporate Contributor License Agreement
+
+Version 1.0 - effective 2026-08-30
+
+This agreement must be completed by an authorized representative of an entity
+that owns or controls Contributions submitted to Tracexy.
+
+## 1. Parties
+
+This agreement is between the legal entity identified in the signature block
+(**Entity**) and **Rockxy LLC** (the **Project Owner**). "Project Owner"
+includes a permitted successor or assignee under Section 7.
+
+## 2. Covered Contributions and contributors
+
+**Contribution**, **Tracexy Material**, and **Submission Date** have the
+meanings in the [Tracexy ICLA v1.0](ICLA-v1.0.md). This agreement covers
+Contributions owned or controlled by Entity and intentionally submitted by
+people whom Entity has identified in writing as authorized contributors. It
+does not cover a parent, subsidiary, or other affiliate merely because of
+common ownership or voting control. Each affiliate whose Contributions are to
+be covered must execute its own CCLA or a written joinder accepted by the
+Project Owner that expressly grants the copyright and patent rights in those
+Contributions.
+
+Each individual contributor must also accept the current Tracexy ICLA. An
+individual's acceptance does not replace this agreement for rights owned or
+controlled by Entity.
+
+## 3. Copyright license
+
+Entity grants the Project Owner a perpetual, worldwide, non-exclusive,
+no-charge, royalty-free, irrevocable and transferable copyright license, with
+the right to sublicense through multiple tiers, to reproduce, modify, prepare
+derivative works of, publicly display, publicly perform, distribute,
+communicate, make available, and otherwise use or exploit each covered
+Contribution, alone or as part of Tracexy Material, in source or object form.
+
+This grant includes licensing under open-source, source-available, commercial,
+or proprietary terms, including Community, Professional, Enterprise, embedded,
+hosted, and white-label Tracexy distributions.
+
+## 4. Patent license
+
+Entity grants the Project Owner and its sublicensees a perpetual, worldwide,
+non-exclusive, no-charge, royalty-free, irrevocable and transferable patent
+license, with the right to sublicense through multiple tiers, to make, have
+made, use, offer to sell, sell, import, and otherwise transfer each covered
+Contribution and its combination with the Tracexy Material to which it was
+submitted. This applies only to patent claims Entity owns or controls that are
+necessarily infringed by the Contribution alone or by that combination.
+
+## 5. Public source commitment
+
+If the Project Owner includes a covered Contribution in any Tracexy Material or
+distribution, the Project Owner will also license that Contribution under the
+license used for the public Tracexy source edition on the Submission Date,
+currently `AGPL-3.0-or-later`. This does not require publication of separate
+downstream material that is not the covered Contribution.
+
+## 6. Entity representations
+
+Entity represents that it is authorized to enter this agreement; it has the
+rights needed to grant these licenses; its authorized-contributor list is
+accurate; and covered Contributions do not knowingly violate third-party rights
+or confidentiality duties. Entity will identify third-party material and its
+license and will promptly report a material error in these representations.
+
+Covered Contributions are provided "as is," without warranties or support
+obligations, to the maximum extent permitted by law.
+
+## 7. Assignment
+
+The Project Owner may assign this agreement and its rights to an entity that
+acquires, succeeds to, or operates the Tracexy project or business, provided
+that entity assumes in writing the Project Owner's obligations, including
+Section 5. The agreement may not be transferred separately from the Tracexy
+project or business.
+
+Entity may assign this agreement to a successor acquiring substantially all of
+the relevant business or contribution rights if the successor assumes this
+agreement in writing and Entity notifies the Project Owner.
+
+## 8. General
+
+This agreement is the entire agreement about its subject. Amendments must be in
+writing and accepted by both parties. If a provision is unenforceable, it will
+be limited to the minimum extent necessary and the remainder continues.
+
+Nothing in this agreement grants rights to Tracexy or Rockxy LLC names, logos,
+icons, domains, or trademarks.
+
+## Execution
+
+This agreement may be signed in counterparts and by an electronic-signature
+service. The Project Owner assigns the final executed copy a unique agreement
+ID and retains it privately with the authorized-contributor schedule and any
+accepted affiliate joinder.
+
+### Entity
+
+- Agreement ID:
+- Entity legal name:
+- Jurisdiction and registration number:
+- Registered address:
+- Authorized representative name and title:
+- Signature:
+- Date:
+
+### Project Owner
+
+- Legal name: Rockxy LLC
+- Authorized representative:
+- Signature:
+- Date:

--- a/legal/cla/ICLA-v1.0.md
+++ b/legal/cla/ICLA-v1.0.md
@@ -1,0 +1,138 @@
+# Tracexy Individual Contributor License Agreement
+
+Version 1.0 - effective 2026-08-30
+
+Thank you for contributing to Tracexy. This agreement defines the rights needed
+to accept and use your Contributions while you retain ownership of them.
+
+## 1. Parties and definitions
+
+This agreement is between you and **Rockxy LLC** (the **Project Owner**).
+"Project Owner" also includes a permitted successor or assignee under Section
+8.
+
+**Contribution** means any original work of authorship that you intentionally
+submit to the Project Owner for inclusion in Tracexy, including code, tests,
+documentation, translations, designs, and other materials submitted through a
+pull request, commit, patch, or another contribution channel designated by the
+Project Owner. A communication conspicuously marked "Not a Contribution" is
+excluded.
+
+**Tracexy Material** means the Tracexy software, documentation, and related
+materials to which the Contribution is submitted.
+
+**Submission Date** means, for a given Contribution, the date on which you
+first submit that Contribution to the Project Owner. For a Contribution
+submitted through a pull request, the Submission Date is the date that pull
+request is opened.
+
+## 2. Ownership
+
+You retain ownership of the copyright in your Contribution and reserve all
+rights not expressly granted by this agreement. This agreement is a license,
+not a copyright assignment.
+
+## 3. Copyright license
+
+You grant the Project Owner a perpetual, worldwide, non-exclusive, no-charge,
+royalty-free, irrevocable, transferable copyright license, with the right to
+sublicense through multiple tiers, to reproduce, modify, prepare derivative
+works of, publicly display, publicly perform, distribute, communicate, make
+available, and otherwise use or exploit your Contribution, alone or as part of
+Tracexy Material, in source or object form.
+
+This grant includes the right to license the Contribution under open-source,
+source-available, commercial, or proprietary terms, including Community,
+Professional, Enterprise, embedded, hosted, and white-label distributions of
+Tracexy.
+
+## 4. Patent license
+
+You grant the Project Owner and its sublicensees a perpetual, worldwide,
+non-exclusive, no-charge, royalty-free, irrevocable and transferable patent
+license, with the right to sublicense through multiple tiers, to make, have
+made, use, offer to sell, sell, import, and otherwise transfer your
+Contribution and your Contribution in combination with the Tracexy Material to
+which it was submitted. This license applies only to patent claims that you own
+or control and that are necessarily infringed by your Contribution alone or by
+that combination.
+
+## 5. Public source commitment
+
+If the Project Owner includes your Contribution in any Tracexy Material or
+distribution, the Project Owner will also license that Contribution under the
+license used for the public Tracexy source edition on the Submission Date. As
+of this agreement's effective date, that license is the GNU Affero General
+Public License, version 3 or any later version (`AGPL-3.0-or-later`). This
+commitment does not require publication of separate downstream material that
+is not your Contribution.
+
+## 6. Your representations
+
+You represent that:
+
+- you are legally entitled to grant the rights in this agreement;
+- each Contribution is your original creation, except for third-party material
+  that you clearly identify together with its source and license;
+- your Contribution does not knowingly violate another person's copyright,
+  patent, trade secret, confidentiality obligation, or other right;
+- if an employer or another organization owns or controls rights in your
+  Contribution, you have obtained permission to contribute it and that
+  organization has executed any Corporate Contributor License Agreement
+  required by the Project Owner; and
+- you will promptly notify the Project Owner if you learn that any of these
+  representations was materially inaccurate when made.
+
+You are not expected to provide support for your Contribution unless you agree
+to do so separately in writing.
+
+## 7. Moral rights
+
+To the maximum extent permitted by applicable law, you waive and agree not to
+assert moral rights or similar rights that would prevent the Project Owner or a
+licensee from exercising the rights granted by this agreement. Where waiver is
+not permitted, you consent to those acts to the maximum extent permitted.
+
+## 8. Assignment and future entity
+
+The Project Owner may assign this agreement and the rights granted under it to
+an entity that acquires, succeeds to, or operates the Tracexy project or
+business, provided that the entity assumes in writing the Project Owner's
+obligations under this agreement, including Section 5. The Project Owner may
+not transfer this agreement separately from the Tracexy project or business.
+
+You may not assign this agreement without the Project Owner's written consent,
+except to a successor that acquires substantially all rights in your
+Contribution and agrees in writing to be bound by this agreement.
+
+## 9. Disclaimer and no obligation
+
+Your Contribution is provided "as is," without warranties or conditions of any
+kind, to the maximum extent permitted by law. This agreement does not require
+the Project Owner to accept, use, distribute, or continue distributing any
+Contribution.
+
+## 10. Electronic acceptance and records
+
+You accept this agreement by posting the exact assent statement specified by
+the Tracexy contribution workflow from the GitHub account associated with your
+Contribution. The Project Owner may retain the account identifier, comment and
+pull-request identifiers, timestamp, and agreement version needed to document
+acceptance.
+
+Acceptance of this version applies to the Contribution or Contributions in the
+pull request in which you post the assent statement and to each Contribution
+you submit afterward while this version is in effect. A material amendment
+requires a new version and new acceptance; it will not be applied
+retroactively merely by editing this document.
+
+## 11. General
+
+This agreement is the entire agreement about its subject and supersedes prior
+discussions about future Contributions, but it does not revoke licenses already
+granted for earlier Contributions. If a provision is unenforceable, it will be
+limited to the minimum extent necessary and the remaining provisions will
+continue. Failure to enforce a provision is not a waiver.
+
+Nothing in this agreement grants rights to Tracexy or Rockxy LLC names, logos,
+icons, domains, or trademarks.

--- a/legal/cla/ICLA-v1.0.sha256
+++ b/legal/cla/ICLA-v1.0.sha256
@@ -1,0 +1,1 @@
+a1c24d57492ec051e27991c094364c669aad0f710d9c3113b6a898bbeebab3e5  legal/cla/ICLA-v1.0.md

--- a/legal/cla/README.md
+++ b/legal/cla/README.md
@@ -1,0 +1,50 @@
+# Tracexy Contributor Agreement Policy
+
+## Current agreements
+
+- Individual contributors: [ICLA v1.0](ICLA-v1.0.md)
+- Organizations that own or control Contributions:
+  [CCLA v1.0](CCLA-v1.0.md) plus an ICLA from each contributor
+
+The ICLA is a broad license, not a copyright assignment. Contributors retain
+their copyright. The Project Owner receives transferable and sublicensable
+rights needed for the public AGPL source edition and separately licensed
+Tracexy distributions. Contributions incorporated into the public source
+edition remain available there under its public source license.
+
+## Version and acceptance policy
+
+The ICLA v1.0 document path is immutable. A material change requires a new
+versioned document and a new signature store. Acceptance of one version never
+counts as acceptance of a later version.
+
+For ICLA v1.0, the exact GitHub acceptance statement is:
+
+> I have read and agree to the Tracexy ICLA v1.0
+
+The version-specific signature store path is `signatures/icla-v1.0.json`. On
+the default branch it should be an empty example store; live acceptance records
+belong on a dedicated `cla-signatures` branch, never on protected `main` or
+`develop`.
+
+Each record should be read together with the versioned document, the signature
+comment, the recorded document SHA-256, and the immutable Git commit containing
+those exact document bytes. The current document digest is recorded in
+[ICLA-v1.0.sha256](ICLA-v1.0.sha256). A CLA gate should fail closed for any
+contributor whose acceptance cannot be resolved to the exact agreement version.
+
+## Organizational contributions
+
+An employee must determine whether an employer owns or controls the proposed
+Contribution. When it does, an authorized representative must execute the CCLA
+and identify the authorized contributors. The executed CCLA and its changes are
+kept privately by the Project Owner; the public repository should record only a
+non-sensitive reference needed for merge review.
+
+## Legal review note
+
+These agreements are project-maintained legal drafts based on established CLA
+structures. They have not been represented as advice from Tracexy's attorney.
+Before relying on them for a material transaction, company formation, or a
+disputed contribution, the Project Owner should obtain advice for the relevant
+jurisdiction and confirm the public contracting identity.


### PR DESCRIPTION
## Summary

- Add AGPL/commercial licensing guidance, Binary EULA draft, and contributor agreement policy for Tracexy.
- Add security, contribution, issue, and pull request guidance for public collaboration.
- Add source-backed Tracexy competitor comparison in the README and documentation.

## Validation

- `bash .github/scripts/check-public-safety.sh`
- `shasum -a 256 -c legal/cla/ICLA-v1.0.sha256`
- YAML issue template parsing
- Targeted Markdown link check
- `git diff --check`
- `swiftformat --lint .`
- `swiftlint lint --strict`
- `xcodebuild -project Tracexy.xcodeproj -scheme Tracexy -destination 'platform=macOS' build`