### PR TITLE
fix(history): enforce automatic retention policy

### DIFF
--- a/Tracexy/Core/Storage/HistoryDemoFixture.swift
+++ b/Tracexy/Core/Storage/HistoryDemoFixture.swift
@@ -1,0 +1,289 @@
+import Foundation
+
+// MARK: - HistoryDemoFixture
+
+/// A bounded, deterministic synthetic History seed for development/demo use only.
+///
+/// It exists so an operator can populate an *injected* ``SessionStore`` with a
+/// credible, varied History table and exercise the Auto-clear retention tiers
+/// immediately, without a live capture. It is deliberately:
+///
+/// - **Path-agnostic** — it never resolves or opens the production History file. The
+///   caller injects whatever store it wants seeded (the app composes it only with an
+///   in-memory store behind `--dum-data`).
+/// - **Settings-agnostic** — it reads no `UserDefaults` and applies no policy; it
+///   only clears and rewrites the injected store.
+/// - **Clock-injected & deterministic** — every capture/session timestamp derives
+///   from the injected `now`, and every identity is a fixed UUID, so the same clock
+///   always yields byte-identical records.
+/// - **Privacy-safe** — every hostname is under `example.com`/`example.net`/
+///   `example.org` and every literal address is in an IPv4 documentation range
+///   (`192.0.2.0/24`, `198.51.100.0/24`, `203.0.113.0/24`) or IPv6 `2001:db8::/32`.
+///   It carries no credentials, payloads, user paths, live endpoints or raw bytes.
+enum HistoryDemoFixture {
+    // MARK: Internal
+
+    /// A fixed synthetic UUID string could not be parsed. This fails the reset
+    /// deterministically rather than silently substituting a random identity, so a
+    /// typo in a fixed ID can never produce nondeterministic demo data.
+    enum FixtureError: Error, Equatable {
+        case malformedFixedID(String)
+    }
+
+    /// Clear `store` and reseed it with the deterministic demo set anchored to `now`.
+    ///
+    /// This *replaces* whatever the injected store held: it first deletes every
+    /// existing capture (the zero-retention clear primitive), then writes the four
+    /// fixed-ID synthetic captures. Reseeding with the same `now` is idempotent —
+    /// the store converges to the identical rows regardless of prior contents.
+    static func reset(into store: SessionStore, now: Date) async throws {
+        // Clear only the injected store — never a resolved production path.
+        _ = try await store.applyRetention(HistoryRetentionPolicy(maxCaptureCount: 0))
+        for demo in try demoCaptures(now: now) {
+            try await store.replaceCapture(demo.record, sessions: demo.sessions)
+        }
+    }
+
+    // MARK: Private
+
+    /// One synthetic capture and its ordered sessions, ready to write.
+    private struct DemoCapture {
+        let record: HistoryCaptureRecord
+        let sessions: [HistorySessionRecord]
+    }
+
+    /// The neutral content of one synthetic session, independent of timing (start
+    /// time and duration are derived from the enclosing capture window).
+    private struct SessionSpec {
+        let id: String
+        let processName: String?
+        let host: String
+        let source: String
+        let destination: String
+        let protocols: [String]
+        let status: HistorySessionStatus
+        let latencyMilliseconds: Double?
+        let bytesUp: Int64
+        let bytesDown: Int64
+    }
+
+    /// One synthetic capture: its identity, age before the injected clock, kind,
+    /// fidelity, and ordered session content.
+    private struct CaptureSpec {
+        let id: String
+        /// Seconds before the injected clock at which this capture ended. Every value
+        /// is comfortably clear of the shipped Auto-clear cutoffs (900 / 3_600 /
+        /// 86_400 s), so strict retention comparisons never land on a boundary.
+        let age: TimeInterval
+        let sourceKind: HistorySourceKind
+        let completeness: HistoryCompleteness
+        let sessions: [SessionSpec]
+    }
+
+    /// Every capture spans this many seconds; sessions are spaced inside the window
+    /// so their timestamps stay internally coherent with the capture lifetime.
+    private static let captureSpan: TimeInterval = 120
+
+    /// The four fixed captures, newest-first by age. The ages map each capture to a
+    /// distinct retention tier: ~5 min survives every interval; ~30 min survives 1h
+    /// and 24h; ~3 h survives only 24h; ~30 h never survives an enabled interval.
+    private static let captureSpecs: [CaptureSpec] = [
+        CaptureSpec(
+            id: "0A000000-0000-4000-8000-0000000000C1",
+            age: 5 * 60,
+            sourceKind: .live,
+            completeness: .complete,
+            sessions: [
+                SessionSpec(
+                    id: "0B000000-0000-4000-8000-000000000001",
+                    processName: "Safari",
+                    host: "example.com",
+                    source: "192.0.2.10:52344",
+                    destination: "198.51.100.20:443",
+                    protocols: ["tcp", "tls", "http"],
+                    status: .ok,
+                    latencyMilliseconds: 18.4,
+                    bytesUp: 2_048, bytesDown: 40_960
+                ),
+                SessionSpec(
+                    id: "0B000000-0000-4000-8000-000000000002",
+                    processName: "Mail",
+                    host: "example.net",
+                    source: "[2001:db8::10]:51000",
+                    destination: "[2001:db8:1::20]:443",
+                    protocols: ["tcp", "tls"],
+                    status: .warning,
+                    latencyMilliseconds: 240.0,
+                    bytesUp: 512, bytesDown: 1_024
+                ),
+                SessionSpec(
+                    id: "0B000000-0000-4000-8000-000000000003",
+                    processName: nil,
+                    host: "example.org",
+                    source: "203.0.113.5:49200",
+                    destination: "203.0.113.80:80",
+                    protocols: ["tcp", "http"],
+                    status: .error,
+                    latencyMilliseconds: nil,
+                    bytesUp: 0, bytesDown: 0
+                ),
+            ]
+        ),
+        CaptureSpec(
+            id: "0A000000-0000-4000-8000-0000000000C2",
+            age: 30 * 60,
+            sourceKind: .saved,
+            completeness: .complete,
+            sessions: [
+                SessionSpec(
+                    id: "0B000000-0000-4000-8000-000000000004",
+                    processName: "curl",
+                    host: "api.example.com",
+                    source: "192.0.2.30:53000",
+                    destination: "198.51.100.40:443",
+                    protocols: ["tcp", "tls", "http"],
+                    status: .ok,
+                    latencyMilliseconds: 33.2,
+                    bytesUp: 8_192, bytesDown: 131_072
+                ),
+                SessionSpec(
+                    id: "0B000000-0000-4000-8000-000000000005",
+                    processName: "Music",
+                    host: "cdn.example.net",
+                    source: "192.0.2.31:53100",
+                    destination: "198.51.100.41:443",
+                    protocols: ["tcp", "tls", "http"],
+                    status: .ok,
+                    latencyMilliseconds: 12.0,
+                    bytesUp: 1_024, bytesDown: 262_144
+                ),
+            ]
+        ),
+        CaptureSpec(
+            id: "0A000000-0000-4000-8000-0000000000C3",
+            age: 3 * 60 * 60,
+            sourceKind: .live,
+            completeness: .incomplete,
+            sessions: [
+                SessionSpec(
+                    id: "0B000000-0000-4000-8000-000000000006",
+                    processName: "Safari",
+                    host: "example.com",
+                    source: "192.0.2.50:60000",
+                    destination: "198.51.100.50:443",
+                    protocols: ["udp", "quic"],
+                    status: .ok,
+                    latencyMilliseconds: 22.5,
+                    bytesUp: 4_096, bytesDown: 20_480
+                ),
+                SessionSpec(
+                    id: "0B000000-0000-4000-8000-000000000007",
+                    processName: "mDNSResponder",
+                    host: "dns.example.net",
+                    source: "192.0.2.51:5353",
+                    destination: "198.51.100.51:53",
+                    protocols: ["udp", "dns"],
+                    status: .ok,
+                    latencyMilliseconds: 8.7,
+                    bytesUp: 128, bytesDown: 256
+                ),
+                SessionSpec(
+                    id: "0B000000-0000-4000-8000-000000000008",
+                    processName: "ssh",
+                    host: "example.org",
+                    source: "203.0.113.10:49000",
+                    destination: "203.0.113.90:22",
+                    protocols: ["tcp"],
+                    status: .warning,
+                    latencyMilliseconds: 95.0,
+                    bytesUp: 3_072, bytesDown: 4_096
+                ),
+                SessionSpec(
+                    id: "0B000000-0000-4000-8000-000000000009",
+                    processName: nil,
+                    host: "mail.example.org",
+                    source: "192.0.2.52:50500",
+                    destination: "198.51.100.52:587",
+                    protocols: ["tcp", "tls"],
+                    status: .error,
+                    latencyMilliseconds: nil,
+                    bytesUp: 256, bytesDown: 0
+                ),
+            ]
+        ),
+        CaptureSpec(
+            id: "0A000000-0000-4000-8000-0000000000C4",
+            age: 30 * 60 * 60,
+            sourceKind: .saved,
+            completeness: .complete,
+            sessions: [
+                SessionSpec(
+                    id: "0B000000-0000-4000-8000-00000000000A",
+                    processName: "com.example.sync",
+                    host: "example.net",
+                    source: "[2001:db8::100]:52000",
+                    destination: "[2001:db8:2::200]:443",
+                    protocols: ["tcp", "tls", "http"],
+                    status: .ok,
+                    latencyMilliseconds: 45.1,
+                    bytesUp: 16_384, bytesDown: 524_288
+                ),
+                SessionSpec(
+                    id: "0B000000-0000-4000-8000-00000000000B",
+                    processName: "wget",
+                    host: "legacy.example.org",
+                    source: "203.0.113.20:48000",
+                    destination: "203.0.113.200:8080",
+                    protocols: ["tcp", "http"],
+                    status: .warning,
+                    latencyMilliseconds: 310.5,
+                    bytesUp: 640, bytesDown: 2_048
+                ),
+            ]
+        ),
+    ]
+
+    /// Realize the fixed capture specs against the injected clock, deriving coherent
+    /// capture windows and per-session timestamps.
+    private static func demoCaptures(now: Date) throws -> [DemoCapture] {
+        let clock = now.timeIntervalSince1970
+        return try captureSpecs.map { spec in
+            let end = clock - spec.age
+            let start = end - captureSpan
+            let record = try HistoryCaptureRecord(
+                captureID: fixedID(spec.id),
+                startedAt: start,
+                endedAt: end,
+                sourceKind: spec.sourceKind,
+                completeness: spec.completeness
+            )
+            let sessions = try spec.sessions.enumerated().map { slot, session in
+                try HistorySessionRecord(
+                    sessionID: fixedID(session.id),
+                    // Space sessions inside the window so start + duration <= end.
+                    startTime: start + 1 + Double(slot) * 10,
+                    duration: 6.5,
+                    processName: session.processName,
+                    host: session.host,
+                    sourceEndpoint: session.source,
+                    destinationEndpoint: session.destination,
+                    protocols: session.protocols,
+                    status: session.status,
+                    latencyMilliseconds: session.latencyMilliseconds,
+                    bytesUp: session.bytesUp,
+                    bytesDown: session.bytesDown
+                )
+            }
+            return DemoCapture(record: record, sessions: sessions)
+        }
+    }
+
+    /// Parse a fixed synthetic UUID, failing closed on a malformed literal so a demo
+    /// identity is never silently randomized.
+    private static func fixedID(_ string: String) throws -> UUID {
+        guard let uuid = UUID(uuidString: string) else {
+            throw FixtureError.malformedFixedID(string)
+        }
+        return uuid
+    }
+}

--- a/Tracexy/Core/Storage/SessionStore.swift
+++ b/Tracexy/Core/Storage/SessionStore.swift
@@ -562,6 +562,10 @@ extension SessionStore {
     /// deterministic oldest-first order and the exact deleted session count summed
     /// from each selected capture's stored `session_count` — never from
     /// `sqlite3_changes()`, which omits foreign-key cascade deletes.
+    ///
+    /// Cancellation is honored before begin and before each delete, so a
+    /// mid-retention cancellation rolls the transaction back and preserves every
+    /// capture untouched.
     func applyRetention(_ policy: HistoryRetentionPolicy) throws -> HistoryRetentionOutcome {
         guard !configuration.readOnly else {
             throw HistoryStoreError.readOnly
@@ -605,6 +609,9 @@ extension SessionStore {
         var deletedIDs: [UUID] = []
         var deletedSessions = 0
         for index in 0 ..< prefix {
+            // Honor cancellation between deletes: a mid-retention cancellation
+            // throws and the surrounding transaction rolls back every prior delete.
+            try checkCancellation()
             try Self.checkFault(faultHook, .retentionDelete(index: index))
             let candidate = candidates[index]
             delete.reset()

--- a/Tracexy/Models/UI/AppSettings.swift
+++ b/Tracexy/Models/UI/AppSettings.swift
@@ -332,6 +332,34 @@ enum AutoClear: String, CaseIterable, Identifiable {
         case .hours24: String(localized: "After 24 hours")
         }
     }
+
+    /// The retention window this choice represents, or `nil` for `.never` (no
+    /// automatic clearing). The coordinator — never this type or the store — turns
+    /// a non-`nil` interval into a `HistoryRetentionPolicy`.
+    var retentionInterval: TimeInterval? {
+        switch self {
+        case .never: nil
+        case .minutes15: 900
+        case .hour1: 3_600
+        case .hours24: 86_400
+        }
+    }
+}
+
+// MARK: - HistoryRetentionSettingsResolver
+
+/// Resolves the persisted History Auto-clear choice from injected `UserDefaults`.
+/// An absent key (fresh install, before the picker has been touched) or an unknown
+/// persisted value fails closed to `.never`, so corrupt or stale defaults can never
+/// trigger deletion. Pure and deterministic, so the mapping is unit-testable without
+/// the shared store.
+enum HistoryRetentionSettingsResolver {
+    static func autoClear(defaults: UserDefaults = .standard) -> AutoClear {
+        guard let raw = defaults.string(forKey: SettingsKeys.autoClear) else {
+            return .never
+        }
+        return AutoClear(rawValue: raw) ?? .never
+    }
 }
 
 // MARK: - AppInfo

--- a/Tracexy/Models/UI/HistoryDemoLaunchMode.swift
+++ b/Tracexy/Models/UI/HistoryDemoLaunchMode.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+// MARK: - HistoryDemoLaunchMode
+
+/// Development-only composition policy for the synthetic History walkthrough.
+///
+/// The launch flag never grants access to production History. The app composes an
+/// in-memory ``SessionStore`` separately and this type supplies a dedicated defaults
+/// suite so changing Auto-clear during a demo cannot mutate the user's real settings.
+enum HistoryDemoLaunchMode {
+    /// Keep the user-requested spelling as the canonical script contract. The
+    /// clearer alias is accepted for discoverability without breaking that contract.
+    static let launchArguments = ["--dum-data", "--demo-data"]
+
+    static func isEnabled(arguments: [String] = CommandLine.arguments) -> Bool {
+        launchArguments.contains { arguments.contains($0) }
+    }
+
+    static func settingsSuiteName(identity: TracexyIdentity = .current) -> String {
+        "\(identity.defaultsPrefix).history-demo"
+    }
+
+    /// Reset only the isolated demo suite. Never fall back to `.standard`: callers
+    /// must fail the demo composition closed if this suite cannot be created.
+    static func freshSettingsDefaults(identity: TracexyIdentity = .current) -> UserDefaults? {
+        let suiteName = settingsSuiteName(identity: identity)
+        guard let defaults = UserDefaults(suiteName: suiteName) else {
+            return nil
+        }
+        defaults.removePersistentDomain(forName: suiteName)
+        defaults.set(AutoClear.never.rawValue, forKey: SettingsKeys.autoClear)
+        defaults.set(SettingsTab.privacy.rawValue, forKey: SettingsKeys.selectedSettingsTab)
+        return defaults
+    }
+}

--- a/Tracexy/TracexyApp.swift
+++ b/Tracexy/TracexyApp.swift
@@ -90,8 +90,14 @@ struct TracexyApp: App {
         .windowToolbarStyle(.unifiedCompact)
 
         Window("Settings", id: "settings") {
-            SettingsView(updater: updater)
-                .preferredColorScheme(colorScheme)
+            SettingsView(
+                updater: updater,
+                historyRetentionError: coordinator.historyRetentionError,
+                isHistoryDemoMode: coordinator.isHistoryDemoMode,
+                onAutoClearChange: { coordinator.configureHistoryAutoClear($0) }
+            )
+            .defaultAppStorage(Self.settingsDefaults)
+            .preferredColorScheme(colorScheme)
         }
         .defaultSize(width: 900, height: 640)
         .windowResizability(.contentMinSize)
@@ -99,6 +105,18 @@ struct TracexyApp: App {
     }
 
     // MARK: Private
+
+    /// Demo settings never share the production defaults domain. If Foundation
+    /// cannot create the dedicated suite, demo composition fails closed instead
+    /// of silently writing through `.standard`.
+    private static let isHistoryDemoMode = HistoryDemoLaunchMode.isEnabled()
+    private static let historyDemoDefaults: UserDefaults? = isHistoryDemoMode
+        ? HistoryDemoLaunchMode.freshSettingsDefaults()
+        : nil
+
+    private static var settingsDefaults: UserDefaults {
+        historyDemoDefaults ?? .standard
+    }
 
     /// The single shared coordinator, owned by the app so every scene (main
     /// window + editor/manager windows) reads and mutates the same state.
@@ -121,12 +139,34 @@ struct TracexyApp: App {
     /// failure is isolated here: the app and capture engine start regardless, and
     /// History simply reports itself unavailable.
     private static func composeCoordinator() -> MainContentCoordinator {
+        if isHistoryDemoMode {
+            guard historyDemoDefaults != nil else {
+                let coordinator = MainContentCoordinator(policy: AppPolicyProvider.current)
+                coordinator.historyError = "Synthetic History couldn’t start because its isolated settings store is unavailable."
+                return coordinator
+            }
+            do {
+                return try MainContentCoordinator(
+                    policy: AppPolicyProvider.current,
+                    sessionStore: SessionStore(),
+                    isHistoryDemoMode: true
+                )
+            } catch {
+                let coordinator = MainContentCoordinator(policy: AppPolicyProvider.current)
+                coordinator.historyError = "Synthetic History couldn’t start — \(error.localizedDescription)"
+                return coordinator
+            }
+        }
+
         switch HistoryStoreFactory.production() {
         case let .ready(store):
-            return MainContentCoordinator(policy: AppPolicyProvider.current, sessionStore: store)
+            let coordinator = MainContentCoordinator(policy: AppPolicyProvider.current, sessionStore: store)
+            coordinator.configureHistoryAutoClear(HistoryRetentionSettingsResolver.autoClear())
+            return coordinator
         case let .unavailable(reason):
             let coordinator = MainContentCoordinator(policy: AppPolicyProvider.current)
             coordinator.historyError = reason
+            coordinator.configureHistoryAutoClear(HistoryRetentionSettingsResolver.autoClear())
             return coordinator
         }
     }

--- a/Tracexy/ViewModels/MainContentCoordinator+History.swift
+++ b/Tracexy/ViewModels/MainContentCoordinator+History.swift
@@ -66,6 +66,85 @@ extension MainContentCoordinator {
     /// One ordinal-ascending session page size; well within the store's bound.
     static let historySessionPageSize = 200
 
+    /// The most relevant recoverable History notice. Retention has precedence so
+    /// the Privacy pane and History surface can explain the action the user most
+    /// recently requested without overwriting unrelated read/write diagnostics.
+    var historyNotice: String? {
+        historyRetentionError ?? historyError
+    }
+
+    /// Dismiss the currently visible History notice wherever it is presented.
+    func dismissHistoryNotice() {
+        if historyRetentionError != nil {
+            historyRetentionError = nil
+        } else {
+            historyError = nil
+        }
+    }
+
+    // MARK: Synthetic demo preparation
+
+    /// Reset the explicitly injected in-memory demo store, then navigate to the
+    /// populated History surface. Production composition never enables this path.
+    /// The launch guard makes a SwiftUI task remount inert instead of replacing a
+    /// demo state the operator is actively testing.
+    func prepareHistoryDemo() async {
+        guard isHistoryDemoMode, !hasPreparedHistoryDemo else {
+            return
+        }
+        hasPreparedHistoryDemo = true
+        guard let store = sessionStore else {
+            historyError = "Synthetic History is unavailable because no isolated store was composed."
+            historyAvailability = .unavailable
+            return
+        }
+
+        do {
+            try await HistoryDemoFixture.reset(into: store, now: historyNow())
+            historyError = nil
+            historyRetentionError = nil
+            activeWorkspace.sidebarSelection = .history
+            refreshHistory()
+        } catch {
+            let message = "Couldn’t prepare synthetic History — \(Self.describe(error))"
+            historyError = message
+            historyAvailability = .failed(message)
+            activeWorkspace.sidebarSelection = .history
+        }
+    }
+
+    // MARK: Automatic retention policy
+
+    /// Adopt the persisted/user-selected policy and immediately evaluate it at a
+    /// documented lifecycle boundary. `.never` invalidates queued automatic work
+    /// but never attempts to undo a retention transaction that already began.
+    func configureHistoryAutoClear(_ selection: AutoClear) {
+        historyAutoClear = selection
+        historyRetentionError = nil
+        historyRetentionRequestID &+= 1
+        guard selection.retentionInterval != nil else {
+            return
+        }
+        scheduleAutomaticHistoryRetention(expectedRetentionRequestID: historyRetentionRequestID)
+    }
+
+    /// Map the UI preference to the store's settings-agnostic age policy. The
+    /// store deletes records strictly older than this cutoff, so a capture whose
+    /// end timestamp equals the cutoff remains retained.
+    static func historyRetentionPolicy(
+        autoClear: AutoClear,
+        now: Date
+    )
+        -> HistoryRetentionPolicy?
+    {
+        guard let interval = autoClear.retentionInterval else {
+            return nil
+        }
+        return HistoryRetentionPolicy(
+            oldestAllowedEndDate: now.timeIntervalSince1970 - interval
+        )
+    }
+
     // MARK: Lifetime tracking
 
     /// Mint one durable History identity for a confirmed live start. Any prior
@@ -196,24 +275,105 @@ extension MainContentCoordinator {
     /// read model; failure sets a distinct recoverable History error and never
     /// mutates sessions, capture state or ``captureError``, nor claims success.
     func scheduleHistoryWrite(store: SessionStore, input: HistoryRecordProjection.Input) {
-        let previous = historyWriteTask
-        historyWriteRequestID &+= 1
-        let requestID = historyWriteRequestID
-        historyWriteTask = Task.detached(priority: .utility) { [weak self] in
+        let previous = historyMutationTask
+        let retentionRequestID = historyRetentionRequestID
+        historyMutationRequestID &+= 1
+        let requestID = historyMutationRequestID
+        historyMutationTask = Task.detached(priority: .utility) { [weak self] in
             await previous?.value
             let output = HistoryRecordProjection.project(input)
             do {
                 try await store.replaceCapture(output.capture, sessions: output.sessions)
-                await self?.finishHistoryWrite(errorMessage: nil, requestID: requestID)
             } catch is CancellationError {
-                // A boundary superseded this write; leave read-model state intact.
+                await self?.finishHistoryMutation(requestID: requestID, refreshesHistory: true)
+                return
             } catch {
-                await self?.finishHistoryWrite(
-                    errorMessage: "Couldn’t save this capture to History — \(Self.describe(error))",
-                    requestID: requestID
+                await self?.finishHistoryMutation(
+                    requestID: requestID,
+                    historyError: "Couldn’t save this capture to History — \(Self.describe(error))",
+                    refreshesHistory: true
+                )
+                return
+            }
+
+            // If Settings changed while the write was pending, that change has
+            // already enqueued its own pass behind this task. Skip the stale policy
+            // here so a longer interval or `.never` cannot be overruled.
+            guard let policy = await self?.automaticHistoryRetentionPolicy(
+                expectedRetentionRequestID: retentionRequestID
+            ) else {
+                await self?.finishHistoryMutation(requestID: requestID, refreshesHistory: true)
+                return
+            }
+
+            do {
+                _ = try await store.applyRetention(policy)
+                await self?.finishHistoryMutation(
+                    requestID: requestID,
+                    clearsRetentionError: true,
+                    refreshesHistory: true
+                )
+            } catch is CancellationError {
+                await self?.finishHistoryMutation(requestID: requestID, refreshesHistory: true)
+            } catch {
+                await self?.finishHistoryMutation(
+                    requestID: requestID,
+                    retentionError: Self.retentionFailureMessage(error),
+                    refreshesHistory: true
                 )
             }
         }
+    }
+
+    /// Enqueue one age-policy pass behind every already scheduled History
+    /// mutation. The request guard is checked only after the queue reaches this
+    /// operation, so a later Settings change can make stale queued work inert.
+    private func scheduleAutomaticHistoryRetention(expectedRetentionRequestID: Int) {
+        guard let store = sessionStore else {
+            return
+        }
+        let previous = historyMutationTask
+        historyMutationRequestID &+= 1
+        let requestID = historyMutationRequestID
+        historyMutationTask = Task.detached(priority: .utility) { [weak self] in
+            await previous?.value
+            guard let policy = await self?.automaticHistoryRetentionPolicy(
+                expectedRetentionRequestID: expectedRetentionRequestID
+            ) else {
+                await self?.finishHistoryMutation(requestID: requestID, refreshesHistory: true)
+                return
+            }
+            do {
+                _ = try await store.applyRetention(policy)
+                await self?.finishHistoryMutation(
+                    requestID: requestID,
+                    clearsRetentionError: true,
+                    refreshesHistory: true
+                )
+            } catch is CancellationError {
+                await self?.finishHistoryMutation(requestID: requestID, refreshesHistory: true)
+            } catch {
+                await self?.finishHistoryMutation(
+                    requestID: requestID,
+                    retentionError: Self.retentionFailureMessage(error),
+                    refreshesHistory: true
+                )
+            }
+        }
+    }
+
+    /// Resolve policy only when the queued request still represents the current
+    /// preference. The clock is read at execution time, not enqueue time, so a
+    /// long pending write cannot make the cutoff stale.
+    private func automaticHistoryRetentionPolicy(
+        expectedRetentionRequestID: Int
+    )
+        -> HistoryRetentionPolicy?
+    {
+        guard historyRetentionRequestID == expectedRetentionRequestID else {
+            return nil
+        }
+        return Self.historyRetentionPolicy(autoClear: historyAutoClear, now: historyNow())
     }
 
     // MARK: Read model
@@ -390,23 +550,24 @@ extension MainContentCoordinator {
         selectHistoryCapture(nil)
         historyRequestID &+= 1
         historySessionRequestID &+= 1
-        let requestID = historyRequestID
         historyAvailability = .loading
-        historyTask = Task { @MainActor [weak self] in
+        let previous = historyMutationTask
+        historyMutationRequestID &+= 1
+        let requestID = historyMutationRequestID
+        historyMutationTask = Task.detached(priority: .utility) { [weak self] in
+            await previous?.value
             do {
                 _ = try await store.applyRetention(HistoryRetentionPolicy(maxCaptureCount: 0))
-                guard let self, self.historyRequestID == requestID else {
-                    return
-                }
-                self.historyTask = nil
-                self.refreshHistory()
+                await self?.finishHistoryMutation(requestID: requestID, refreshesHistory: true)
             } catch is CancellationError {
+                await self?.finishHistoryMutation(requestID: requestID, refreshesHistory: true)
             } catch {
-                guard let self, self.historyRequestID == requestID else {
-                    return
-                }
-                self.historyAvailability = .failed("Couldn’t clear History — \(Self.describe(error))")
-                self.historyTask = nil
+                await self?.finishHistoryMutation(
+                    requestID: requestID,
+                    historyError: "Couldn’t clear History — \(Self.describe(error))",
+                    refreshesHistory: false,
+                    failedAvailability: true
+                )
             }
         }
     }
@@ -417,7 +578,7 @@ extension MainContentCoordinator {
         // A terminal write may schedule a refresh, and a clear task schedules a
         // second refresh task when deletion commits. Re-read each handle until
         // the chain is actually idle rather than awaiting only the first snapshot.
-        while let task = historyWriteTask {
+        while let task = historyMutationTask {
             await task.value
         }
         while let task = historyTask {
@@ -430,17 +591,36 @@ extension MainContentCoordinator {
 
     // MARK: Private
 
-    private func finishHistoryWrite(errorMessage: String?, requestID: Int) {
-        if let errorMessage {
-            historyError = errorMessage
+    private func finishHistoryMutation(
+        requestID: Int,
+        historyError: String? = nil,
+        retentionError: String? = nil,
+        clearsRetentionError: Bool = false,
+        refreshesHistory: Bool,
+        failedAvailability: Bool = false
+    ) {
+        if let historyError {
+            self.historyError = historyError
         }
-        guard historyWriteRequestID == requestID else {
+        if let retentionError {
+            historyRetentionError = retentionError
+        } else if clearsRetentionError {
+            historyRetentionError = nil
+        }
+        guard historyMutationRequestID == requestID else {
             return
         }
-        historyWriteTask = nil
-        if errorMessage == nil {
+        historyMutationTask = nil
+        if failedAvailability {
+            historyAvailability = .failed(historyError ?? "Couldn’t update History.")
+        } else if refreshesHistory {
             refreshHistory()
         }
+    }
+
+    nonisolated private static func retentionFailureMessage(_ error: Error) -> String {
+        "Auto-clear couldn’t update local History — \(describe(error)). "
+            + "Your preference is still saved; cleanup will retry at the next History boundary."
     }
 
     nonisolated private static func describe(_ error: Error) -> String {

--- a/Tracexy/ViewModels/MainContentCoordinator+SessionVisibility.swift
+++ b/Tracexy/ViewModels/MainContentCoordinator+SessionVisibility.swift
@@ -18,6 +18,27 @@ extension MainContentCoordinator {
         removedSessionIDs.intersection(Set(sessions.map(\.id))).count
     }
 
+    /// Top talkers by total bytes, for the dashboard.
+    func topHosts(limit: Int = 5) -> [(host: String, bytes: Int)] {
+        var totals: [String: Int] = [:]
+        for session in visibleSessions {
+            totals[session.host, default: 0] += session.totalBytes
+        }
+        return totals.sorted { $0.value > $1.value }
+            .prefix(limit)
+            .map { (host: $0.key, bytes: $0.value) }
+    }
+
+    func count(for proto: ProtocolKind) -> Int {
+        visibleSessions.filter { $0.protocolStack.contains(proto) }.count
+    }
+
+    /// Whether a session matches a single quick-filter chip. Finding membership
+    /// comes from the already-published Core snapshots, not summary heuristics.
+    func matches(_ session: SessionSummary, category: SessionFilterCategory) -> Bool {
+        Self.categoryMatches(session, category: category, findingSessionIDs: findingSessionIDs)
+    }
+
     /// Sessions visible in an arbitrary workspace. Live following uses this seam
     /// for inactive workspaces too, so a batch never applies the active tab's
     /// filters to another tab's selection.

--- a/Tracexy/ViewModels/MainContentCoordinator.swift
+++ b/Tracexy/ViewModels/MainContentCoordinator.swift
@@ -21,9 +21,13 @@ final class MainContentCoordinator {
     init(
         policy: (any AppPolicy)? = nil,
         layoutPreferences: WorkspaceLayoutPreferences? = nil,
-        sessionStore: SessionStore? = nil
+        sessionStore: SessionStore? = nil,
+        isHistoryDemoMode: Bool = false,
+        historyNow: @escaping @Sendable () -> Date = { Date() }
     ) {
         self.sessionStore = sessionStore
+        self.isHistoryDemoMode = isHistoryDemoMode
+        self.historyNow = historyNow
         let resolvedPolicy = policy ?? DefaultAppPolicy()
         self.policy = resolvedPolicy
         focusGate = FocusPolicyGate(
@@ -236,6 +240,26 @@ final class MainContentCoordinator {
     /// opened saved capture; it is never on the live 0.8-second publication path.
     let sessionStore: SessionStore?
 
+    /// True only for the explicit synthetic History launch path. Production
+    /// composition always leaves this false and never sees the demo fixture.
+    let isHistoryDemoMode: Bool
+
+    /// Guards the root launch task from reseeding if SwiftUI remounts the view.
+    var hasPreparedHistoryDemo = false
+
+    /// Injectable wall clock for History age policy. Production uses `Date()`;
+    /// integration tests freeze it so cutoff behavior never depends on timing.
+    let historyNow: @Sendable () -> Date
+
+    /// The currently effective Auto-clear preference. The composition root sets
+    /// it from persisted defaults at launch; Settings updates it synchronously
+    /// before requesting another bounded retention pass.
+    var historyAutoClear: AutoClear = .never
+
+    /// A retention-specific recoverable failure. It is separate from general
+    /// History read/write errors so Settings can explain the exact failed action.
+    var historyRetentionError: String?
+
     /// Durable identity of the *running* live capture, minted once on confirmed
     /// backend start. It is never keyed on the capture generation (which repeats
     /// across launches). Cleared/retired at every clear/new/start boundary and
@@ -281,12 +305,16 @@ final class MainContentCoordinator {
     /// so selecting a capture never cancels capture-list paging and vice versa.
     var historySessionRequestID = 0
     var historySessionTask: Task<Void, Never>?
-    /// At most one terminal write may be scheduled per capture; this handle lets
-    /// tests await the exact write without timing sleeps.
-    var historyWriteTask: Task<Void, Never>?
-    /// Identifies the tail of the serialized terminal-write chain. Only the tail
-    /// may clear the handle and refresh the read model.
-    var historyWriteRequestID = 0
+    /// Serialized tail for every History mutation: terminal writes, automatic
+    /// retention and explicit clear. Keeping one queue prevents a late write from
+    /// reviving rows after a clear or racing a preference-triggered cleanup.
+    var historyMutationTask: Task<Void, Never>?
+    /// Identifies the current mutation tail. Only the tail clears the handle and
+    /// refreshes the read model after all earlier mutations have settled.
+    var historyMutationRequestID = 0
+    /// Invalidates a queued automatic retention pass when the user changes the
+    /// preference again before that pass reaches the store actor.
+    var historyRetentionRequestID = 0
 
     // MARK: Focus Sets
 
@@ -1155,27 +1183,6 @@ final class MainContentCoordinator {
             return
         }
         performStopCapture()
-    }
-
-    /// Top talkers by total bytes, for the dashboard.
-    func topHosts(limit: Int = 5) -> [(host: String, bytes: Int)] {
-        var totals: [String: Int] = [:]
-        for session in visibleSessions {
-            totals[session.host, default: 0] += session.totalBytes
-        }
-        return totals.sorted { $0.value > $1.value }
-            .prefix(limit)
-            .map { (host: $0.key, bytes: $0.value) }
-    }
-
-    func count(for proto: ProtocolKind) -> Int {
-        visibleSessions.filter { $0.protocolStack.contains(proto) }.count
-    }
-
-    /// Whether a session matches a single quick-filter chip. Finding membership
-    /// comes from the already-published Core snapshots, not summary heuristics.
-    func matches(_ session: SessionSummary, category: SessionFilterCategory) -> Bool {
-        Self.categoryMatches(session, category: category, findingSessionIDs: findingSessionIDs)
     }
 
     // MARK: Private

--- a/Tracexy/Views/History/HistoryView.swift
+++ b/Tracexy/Views/History/HistoryView.swift
@@ -83,8 +83,8 @@ struct HistoryView: View {
 
     var body: some View {
         Group {
-            if let historyError = coordinator.historyError,
-               captureState == .content
+            if let historyError = coordinator.historyNotice,
+               presentsHistoryNotice
             {
                 VStack(spacing: 0) {
                     recoverableNotice(historyError)
@@ -136,6 +136,13 @@ struct HistoryView: View {
         )
     }
 
+    /// A recoverable mutation notice belongs above both populated and empty
+    /// History. Loading/failure/unavailable states already own their whole-surface
+    /// explanation and must not duplicate it in a banner.
+    private var presentsHistoryNotice: Bool {
+        captureState == .content || captureState == .empty
+    }
+
     private var sessionState: HistorySessionSurfaceState {
         HistorySessionSurfaceState.resolve(
             selectedCaptureID: coordinator.selectedHistoryCaptureID,
@@ -159,6 +166,12 @@ struct HistoryView: View {
                 Text("Terminal capture summaries stored locally")
                     .font(Theme.Typography.caption)
                     .foregroundStyle(.secondary)
+            }
+            if coordinator.isHistoryDemoMode {
+                Label("Synthetic demo data", systemImage: "testtube.2")
+                    .font(Theme.Typography.caption)
+                    .foregroundStyle(.secondary)
+                    .help("Isolated in-memory data created by the --dum-data launch mode")
             }
             Spacer()
             Button("Refresh", systemImage: "arrow.clockwise") {
@@ -389,7 +402,7 @@ struct HistoryView: View {
             Image(systemName: "exclamationmark.triangle.fill").foregroundStyle(.orange)
             Text(message).font(Theme.Typography.caption).lineLimit(2)
             Spacer()
-            Button("Dismiss") { coordinator.historyError = nil }
+            Button("Dismiss") { coordinator.dismissHistoryNotice() }
                 .buttonStyle(.plain)
         }
         .padding(.horizontal, Theme.Metrics.spacingM)

--- a/Tracexy/Views/Main/RootView.swift
+++ b/Tracexy/Views/Main/RootView.swift
@@ -109,6 +109,11 @@ struct RootView: View {
     /// setting is the single source of truth for auto-start in both development
     /// and normal launches.
     private func launchSetup() async {
+        if coordinator.isHistoryDemoMode {
+            await coordinator.prepareHistoryDemo()
+            return
+        }
+
         let shouldAutoStart = UserDefaults.standard.bool(
             forKey: SettingsKeys.autoStartCapture
         )

--- a/Tracexy/Views/Settings/PrivacySettingsView.swift
+++ b/Tracexy/Views/Settings/PrivacySettingsView.swift
@@ -6,6 +6,18 @@ import SwiftUI
 /// preserve packet evidence and therefore require explicit acknowledgement when
 /// any protection is active. Local-first remains the default posture.
 struct PrivacySettingsView: View {
+    // MARK: Lifecycle
+
+    init(
+        historyRetentionError: String? = nil,
+        isHistoryDemoMode: Bool = false,
+        onAutoClearChange: @escaping (AutoClear) -> Void = { _ in }
+    ) {
+        self.historyRetentionError = historyRetentionError
+        self.isHistoryDemoMode = isHistoryDemoMode
+        self.onAutoClearChange = onAutoClearChange
+    }
+
     // MARK: Internal
 
     var body: some View {
@@ -55,12 +67,34 @@ struct PrivacySettingsView: View {
                 SettingsDivider()
 
                 SettingsRow(label: "Auto-clear:") {
-                    Picker("", selection: $autoClear) {
+                    Picker("", selection: autoClearSelection) {
                         ForEach(AutoClear.allCases) { Text($0.title).tag($0.rawValue) }
                     }
                     .labelsHidden()
                     .frame(width: metrics.menuWidth(200))
                     .frame(minHeight: metrics.controlHeight)
+                }
+
+                SettingsIndented {
+                    SettingsFootnote(
+                        "Removes only local History summaries at launch, after a capture is added, "
+                            + "and when this setting changes. Current capture data and saved files stay untouched."
+                    )
+                }
+
+                if isHistoryDemoMode {
+                    SettingsIndented {
+                        SettingsInlineMessage(
+                            "Demo mode uses isolated synthetic History. Re-launch with --dum-data to restore all four age tiers.",
+                            tone: .info
+                        )
+                    }
+                }
+
+                if let historyRetentionError {
+                    SettingsIndented {
+                        SettingsInlineMessage(historyRetentionError, tone: .failure)
+                    }
                 }
             }
 
@@ -83,7 +117,23 @@ struct PrivacySettingsView: View {
     @AppStorage(SettingsKeys.autoClear) private var autoClear = AutoClear.never.rawValue
     @AppStorage(SettingsKeys.shareAnalytics) private var shareAnalytics = false
 
+    private let historyRetentionError: String?
+    private let isHistoryDemoMode: Bool
+    private let onAutoClearChange: (AutoClear) -> Void
     private let metrics = SettingsDisplayMetrics.standard
+
+    private var autoClearSelection: Binding<String> {
+        Binding(
+            get: {
+                AutoClear(rawValue: autoClear)?.rawValue ?? AutoClear.never.rawValue
+            },
+            set: { rawValue in
+                let selection = AutoClear(rawValue: rawValue) ?? .never
+                autoClear = selection.rawValue
+                onAutoClearChange(selection)
+            }
+        )
+    }
 }
 
 #Preview {

--- a/Tracexy/Views/Settings/SettingsStyle.swift
+++ b/Tracexy/Views/Settings/SettingsStyle.swift
@@ -501,6 +501,7 @@ struct SettingsDetailRow: View {
 // MARK: - SettingsMessageTone
 
 enum SettingsMessageTone {
+    case info
     case success
     case warning
     case failure
@@ -509,6 +510,7 @@ enum SettingsMessageTone {
 
     var symbol: String {
         switch self {
+        case .info: "info.circle.fill"
         case .success: "checkmark.circle.fill"
         case .warning: "exclamationmark.triangle.fill"
         case .failure: "xmark.octagon.fill"
@@ -517,6 +519,7 @@ enum SettingsMessageTone {
 
     var tint: Color {
         switch self {
+        case .info: .blue
         case .success: .green
         case .warning: .orange
         case .failure: .red

--- a/Tracexy/Views/Settings/SettingsView.swift
+++ b/Tracexy/Views/Settings/SettingsView.swift
@@ -7,8 +7,16 @@ import SwiftUI
 struct SettingsView: View {
     // MARK: Lifecycle
 
-    init(updater: AppUpdater) {
+    init(
+        updater: AppUpdater,
+        historyRetentionError: String? = nil,
+        isHistoryDemoMode: Bool = false,
+        onAutoClearChange: @escaping (AutoClear) -> Void = { _ in }
+    ) {
         self.updater = updater
+        self.historyRetentionError = historyRetentionError
+        self.isHistoryDemoMode = isHistoryDemoMode
+        self.onAutoClearChange = onAutoClearChange
     }
 
     // MARK: Internal
@@ -50,6 +58,9 @@ struct SettingsView: View {
     @AppStorage(SettingsKeys.selectedSettingsTab) private var selectedTab = SettingsTab.general.rawValue
 
     private let updater: AppUpdater
+    private let historyRetentionError: String?
+    private let isHistoryDemoMode: Bool
+    private let onAutoClearChange: (AutoClear) -> Void
     private let metrics = SettingsDisplayMetrics.standard
 
     private var selection: Binding<SettingsTab> {
@@ -64,7 +75,11 @@ struct SettingsView: View {
         case .general: GeneralSettingsView()
         case .capture: CaptureSettingsView()
         case .helper: HelperSettingsView()
-        case .privacy: PrivacySettingsView()
+        case .privacy: PrivacySettingsView(
+                historyRetentionError: historyRetentionError,
+                isHistoryDemoMode: isHistoryDemoMode,
+                onAutoClearChange: onAutoClearChange
+            )
         case .mcp: MCPSettingsView()
         case .updates: UpdatesSettingsView(updater: updater)
         }

--- a/TracexyTests/Core/Storage/HistoryDemoFixtureTests.swift
+++ b/TracexyTests/Core/Storage/HistoryDemoFixtureTests.swift
@@ -1,0 +1,186 @@
+import Foundation
+import Testing
+@testable import Tracexy
+
+// MARK: - HistoryDemoFixtureTests
+
+@Suite("HistoryDemoFixture deterministic demo seed and retention tiers")
+struct HistoryDemoFixtureTests {
+    // MARK: Internal
+
+    // MARK: Shape
+
+    @Test("Reset seeds four captures with the expected session counts and kinds")
+    func fixtureShape() async throws {
+        let store = try SessionStore()
+        try await HistoryDemoFixture.reset(into: store, now: Self.clock)
+
+        let captures = try await store.captures(after: nil, limit: 500).captures
+        #expect(captures.count == 4)
+        // Newest-first paging.
+        #expect(captures.map(\.sessionCount) == [3, 2, 4, 2])
+        #expect(captures.map(\.record.sourceKind) == [.live, .saved, .live, .saved])
+        #expect(captures.map(\.record.completeness) == [.complete, .complete, .incomplete, .complete])
+
+        let statuses = try await Set(Self.allSessions(store).map(\.status))
+        #expect(statuses == [.ok, .warning, .error])
+        #expect(try await Self.allSessions(store).count == 11)
+    }
+
+    // MARK: Fixed identity and content
+
+    @Test("A fixed clock yields fixed capture IDs and byte-identical session content")
+    func fixedIdentityAndContent() async throws {
+        let store = try SessionStore()
+        try await HistoryDemoFixture.reset(into: store, now: Self.clock)
+
+        let captures = try await store.captures(after: nil, limit: 500).captures
+        #expect(captures.map(\.record.captureID) == Self.expectedCaptureIDsNewestFirst)
+
+        // A specific recent session round-trips with the exact fixed content.
+        let recentID = try #require(UUID(uuidString: "0A000000-0000-4000-8000-0000000000C1"))
+        let sessions = try await store.sessions(captureID: recentID, after: nil, limit: 500).sessions
+        let first = try #require(sessions.first)
+        #expect(first.sessionID == UUID(uuidString: "0B000000-0000-4000-8000-000000000001"))
+        #expect(first.host == "example.com")
+        #expect(first.processName == "Safari")
+        #expect(first.protocols == ["tcp", "tls", "http"])
+        #expect(first.status == .ok)
+        #expect(first.latencyMilliseconds == 18.4)
+        #expect(first.bytesUp == 2_048)
+        #expect(first.bytesDown == 40_960)
+
+        // Two independent seeds with the same clock produce identical stores.
+        let other = try SessionStore()
+        try await HistoryDemoFixture.reset(into: other, now: Self.clock)
+        try await Self.expectStoresEqual(store, other)
+    }
+
+    // MARK: Privacy-safe reserved values
+
+    @Test("Every host is under example.* and every literal endpoint is documentation-only")
+    func privacySafeReservedValues() async throws {
+        let store = try SessionStore()
+        try await HistoryDemoFixture.reset(into: store, now: Self.clock)
+
+        for session in try await Self.allSessions(store) {
+            #expect(Self.isExampleHost(session.host), "unexpected host \(session.host)")
+            #expect(Self.isDocumentationEndpoint(session.sourceEndpoint), "unexpected source \(session.sourceEndpoint)")
+            #expect(
+                Self.isDocumentationEndpoint(session.destinationEndpoint),
+                "unexpected destination \(session.destinationEndpoint)"
+            )
+            if let processName = session.processName {
+                // No user paths leak through a process label.
+                #expect(!processName.contains("/"))
+            }
+        }
+    }
+
+    // MARK: Reset replaces and reseeds idempotently
+
+    @Test("Reset clears pre-existing unrelated rows before seeding")
+    func resetReplacesPreExistingRows() async throws {
+        let store = try SessionStore()
+        // A pre-existing, unrelated capture with an ID outside the fixture set.
+        let stale = HistoryCaptureRecord(
+            captureID: UUID(),
+            startedAt: 1_000,
+            endedAt: 2_000,
+            sourceKind: .saved,
+            completeness: .complete
+        )
+        try await store.replaceCapture(stale, sessions: [])
+
+        try await HistoryDemoFixture.reset(into: store, now: Self.clock)
+
+        let captures = try await store.captures(after: nil, limit: 500).captures
+        #expect(captures.count == 4)
+        #expect(!captures.map(\.record.captureID).contains(stale.captureID))
+    }
+
+    @Test("Reseeding with the same clock is idempotent")
+    func idempotentReseed() async throws {
+        let store = try SessionStore()
+        try await HistoryDemoFixture.reset(into: store, now: Self.clock)
+        let firstPass = try await store.captures(after: nil, limit: 500).captures
+
+        try await HistoryDemoFixture.reset(into: store, now: Self.clock)
+        let secondPass = try await store.captures(after: nil, limit: 500).captures
+
+        #expect(firstPass == secondPass)
+        #expect(secondPass.count == 4)
+    }
+
+    // MARK: Retention tiers
+
+    @Test("Auto-clear tiers retain Never=4, 24h=3, 1h=2, 15m=1")
+    func retentionTierCounts() async throws {
+        #expect(try await Self.remaining(after: .never) == 4)
+        #expect(try await Self.remaining(after: .hours24) == 3)
+        #expect(try await Self.remaining(after: .hour1) == 2)
+        #expect(try await Self.remaining(after: .minutes15) == 1)
+    }
+
+    // MARK: Private
+
+    /// A fixed injected clock; every timestamp derives from it.
+    private static let clock = Date(timeIntervalSince1970: 1_700_000_000)
+
+    private static let expectedCaptureIDsNewestFirst: [UUID] = [
+        UUID(uuidString: "0A000000-0000-4000-8000-0000000000C1"),
+        UUID(uuidString: "0A000000-0000-4000-8000-0000000000C2"),
+        UUID(uuidString: "0A000000-0000-4000-8000-0000000000C3"),
+        UUID(uuidString: "0A000000-0000-4000-8000-0000000000C4"),
+    ].compactMap { $0 }
+
+    /// Seed a fresh store, apply the tier's interval as a strict end-date cutoff, and
+    /// return how many captures survive. `.never` applies no retention.
+    private static func remaining(after autoClear: AutoClear) async throws -> Int {
+        let store = try SessionStore()
+        try await HistoryDemoFixture.reset(into: store, now: clock)
+        if let interval = autoClear.retentionInterval {
+            let cutoff = clock.addingTimeInterval(-interval).timeIntervalSince1970
+            _ = try await store.applyRetention(HistoryRetentionPolicy(oldestAllowedEndDate: cutoff))
+        }
+        return try await store.captures(after: nil, limit: 500).captures.count
+    }
+
+    /// Every stored session across every capture, in paging order.
+    private static func allSessions(_ store: SessionStore) async throws -> [HistorySessionRecord] {
+        let captures = try await store.captures(after: nil, limit: 500).captures
+        var sessions: [HistorySessionRecord] = []
+        for capture in captures {
+            let page = try await store.sessions(captureID: capture.record.captureID, after: nil, limit: 500)
+            sessions.append(contentsOf: page.sessions)
+        }
+        return sessions
+    }
+
+    private static func expectStoresEqual(_ lhs: SessionStore, _ rhs: SessionStore) async throws {
+        let lhsCaptures = try await lhs.captures(after: nil, limit: 500).captures
+        let rhsCaptures = try await rhs.captures(after: nil, limit: 500).captures
+        #expect(lhsCaptures == rhsCaptures)
+        for capture in lhsCaptures {
+            let id = capture.record.captureID
+            let lhsSessions = try await lhs.sessions(captureID: id, after: nil, limit: 500).sessions
+            let rhsSessions = try await rhs.sessions(captureID: id, after: nil, limit: 500).sessions
+            #expect(lhsSessions == rhsSessions)
+        }
+    }
+
+    private static func isExampleHost(_ host: String) -> Bool {
+        let roots = ["example.com", "example.net", "example.org"]
+        return roots.contains { host == $0 || host.hasSuffix("." + $0) }
+    }
+
+    /// True when the endpoint's address is in an IPv4 documentation range or IPv6
+    /// `2001:db8::/32`. Bracketed IPv6 endpoints look like `[2001:db8::10]:443`.
+    private static func isDocumentationEndpoint(_ endpoint: String) -> Bool {
+        if endpoint.hasPrefix("[") {
+            return endpoint.hasPrefix("[2001:db8:")
+        }
+        let ipv4DocumentationPrefixes = ["192.0.2.", "198.51.100.", "203.0.113."]
+        return ipv4DocumentationPrefixes.contains { endpoint.hasPrefix($0) }
+    }
+}

--- a/TracexyTests/Core/Storage/SessionStoreTests.swift
+++ b/TracexyTests/Core/Storage/SessionStoreTests.swift
@@ -497,6 +497,55 @@ struct SessionStoreTests {
         #expect(try await store.captures(after: nil, limit: 500).captures.count == 2)
     }
 
+    @Test("Cancellation mid-retention rolls back every prior delete")
+    func retentionCancellationRollsBack() async throws {
+        let url = Self.temporaryURL()
+        defer { Self.removeDatabaseFiles(url) }
+        // Fire on the third armed gate call: pre-begin, the index-0 check (after
+        // which capture 0 is deleted), then the index-1 check cancels.
+        let gate = CancellationGate(cancelOnCall: 3)
+        let store = try SessionStore(configuration: .init(
+            location: .file(url),
+            isCancelled: { gate.shouldCancel() }
+        ))
+        let captures = try await Self.seedCaptures(store, endedAtSessionCounts: [
+            (1_000, 2), (1_001, 3), (1_002, 1),
+        ])
+        gate.arm()
+
+        await #expect(throws: CancellationError.self) {
+            _ = try await store.applyRetention(HistoryRetentionPolicy(maxCaptureCount: 0))
+        }
+
+        // At least one delete ran before cancellation, but the transaction rolled
+        // back, so every capture survives untouched.
+        let remaining = try await store.captures(after: nil, limit: 500)
+        #expect(Set(remaining.captures.map(\.record.captureID)) == Set(captures))
+    }
+
+    @Test("A retention fault after at least one delete rolls back the whole batch")
+    func retentionFaultRollsBack() async throws {
+        let url = Self.temporaryURL()
+        defer { Self.removeDatabaseFiles(url) }
+        let faulting = FaultBox()
+        let store = try SessionStore(configuration: .init(
+            location: .file(url),
+            faultInjection: { faulting.code(for: $0) }
+        ))
+        let captures = try await Self.seedCaptures(store, endedAtSessionCounts: [
+            (1_000, 2), (1_001, 3), (1_002, 1),
+        ])
+
+        // Delete index 0 succeeds; the fault fires at index 1, mid-transaction.
+        faulting.arm(stage: .retentionDelete(index: 1), code: 13)
+        await #expect(throws: HistoryStoreError.diskFull) {
+            _ = try await store.applyRetention(HistoryRetentionPolicy(maxCaptureCount: 0))
+        }
+
+        let remaining = try await store.captures(after: nil, limit: 500)
+        #expect(Set(remaining.captures.map(\.record.captureID)) == Set(captures))
+    }
+
     // MARK: Internal — handle cleanup
 
     @Test("Data persists across store instances, proving the handle is released")

--- a/TracexyTests/Models/UI/HistoryDemoLaunchModeTests.swift
+++ b/TracexyTests/Models/UI/HistoryDemoLaunchModeTests.swift
@@ -1,0 +1,31 @@
+import Foundation
+import Testing
+@testable import Tracexy
+
+@MainActor
+@Suite("Synthetic History launch mode")
+struct HistoryDemoLaunchModeTests {
+    @Test("The requested flag and descriptive alias enable demo mode")
+    func launchArguments() {
+        #expect(HistoryDemoLaunchMode.isEnabled(arguments: ["Tracexy", "--dum-data"]))
+        #expect(HistoryDemoLaunchMode.isEnabled(arguments: ["Tracexy", "--demo-data"]))
+        #expect(!HistoryDemoLaunchMode.isEnabled(arguments: ["Tracexy", "--direct-capture"]))
+    }
+
+    @Test("Fresh demo settings are isolated and start on Privacy with Auto-clear Never")
+    func settingsIsolation() throws {
+        let prefix = "HistoryDemoLaunchModeTests.\(UUID().uuidString)"
+        let identity = TracexyIdentity(infoDictionary: ["TracexyDefaultsPrefix": prefix])
+        let suiteName = HistoryDemoLaunchMode.settingsSuiteName(identity: identity)
+        let existing = try #require(UserDefaults(suiteName: suiteName))
+        defer { existing.removePersistentDomain(forName: suiteName) }
+        existing.set(AutoClear.hours24.rawValue, forKey: SettingsKeys.autoClear)
+        existing.set(SettingsTab.general.rawValue, forKey: SettingsKeys.selectedSettingsTab)
+
+        let defaults = try #require(HistoryDemoLaunchMode.freshSettingsDefaults(identity: identity))
+
+        #expect(HistoryRetentionSettingsResolver.autoClear(defaults: defaults) == .never)
+        #expect(defaults.string(forKey: SettingsKeys.selectedSettingsTab) == SettingsTab.privacy.rawValue)
+        #expect(suiteName.hasSuffix(".history-demo"))
+    }
+}

--- a/TracexyTests/Models/UI/PrivacySettingsTests.swift
+++ b/TracexyTests/Models/UI/PrivacySettingsTests.swift
@@ -31,6 +31,41 @@ struct PrivacySettingsTests {
         #expect(policy.maskIPAddresses)
     }
 
+    // MARK: Internal — History Auto-clear resolution
+
+    @Test("Absent Auto-clear key resolves to Never so stale defaults cannot delete")
+    func autoClearDefaultsToNever() throws {
+        let defaults = try scratchDefaults()
+
+        #expect(HistoryRetentionSettingsResolver.autoClear(defaults: defaults) == .never)
+    }
+
+    @Test("Every persisted Auto-clear choice resolves to its own case")
+    func autoClearValidChoicesResolve() throws {
+        for choice in AutoClear.allCases {
+            let defaults = try scratchDefaults()
+            defaults.set(choice.rawValue, forKey: SettingsKeys.autoClear)
+
+            #expect(HistoryRetentionSettingsResolver.autoClear(defaults: defaults) == choice)
+        }
+    }
+
+    @Test("An unknown persisted Auto-clear value fails closed to Never")
+    func autoClearUnknownValueFailsClosed() throws {
+        let defaults = try scratchDefaults()
+        defaults.set("after-3-fortnights", forKey: SettingsKeys.autoClear)
+
+        #expect(HistoryRetentionSettingsResolver.autoClear(defaults: defaults) == .never)
+    }
+
+    @Test("Auto-clear choices map to their retention intervals in seconds")
+    func autoClearRetentionIntervals() {
+        #expect(AutoClear.never.retentionInterval == nil)
+        #expect(AutoClear.minutes15.retentionInterval == 900)
+        #expect(AutoClear.hour1.retentionInterval == 3_600)
+        #expect(AutoClear.hours24.retentionInterval == 86_400)
+    }
+
     // MARK: Private
 
     private func scratchDefaults() throws -> UserDefaults {

--- a/TracexyTests/ViewModels/HistoryIntegrationTests.swift
+++ b/TracexyTests/ViewModels/HistoryIntegrationTests.swift
@@ -50,6 +50,138 @@ struct HistoryIntegrationTests {
         #expect(coordinator.historyCaptureCursor == nil)
     }
 
+    // MARK: Synthetic demo composition
+
+    @Test("Demo preparation seeds the injected store and opens History")
+    func demoPreparationSeedsAndNavigates() async throws {
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        let store = try SessionStore()
+        let coordinator = MainContentCoordinator(
+            sessionStore: store,
+            isHistoryDemoMode: true,
+            historyNow: { now }
+        )
+
+        await coordinator.prepareHistoryDemo()
+        await coordinator.waitForHistory()
+
+        #expect(coordinator.hasPreparedHistoryDemo)
+        #expect(coordinator.activeWorkspace.sidebarSelection == .history)
+        #expect(coordinator.historyAvailability == .loaded)
+        #expect(coordinator.historyCaptures.count == 4)
+        #expect(coordinator.historyCaptures.map(\.sessionCount) == [3, 2, 4, 2])
+        #expect(coordinator.historyAutoClear == .never)
+    }
+
+    @Test("Demo preparation is inert outside the explicit launch mode")
+    func demoPreparationCannotTouchProductionComposition() async throws {
+        let store = try SessionStore()
+        let existing = Self.historyCapture(startedAt: 1_000, endedAt: 2_000)
+        try await store.replaceCapture(existing, sessions: [])
+        let coordinator = MainContentCoordinator(sessionStore: store)
+
+        await coordinator.prepareHistoryDemo()
+
+        #expect(!coordinator.hasPreparedHistoryDemo)
+        #expect(coordinator.activeWorkspace.sidebarSelection == .sessions)
+        #expect(try await store.capture(id: existing.captureID) != nil)
+    }
+
+    // MARK: Automatic retention lifecycle
+
+    @Test("Launch retention deletes only captures strictly older than the deterministic cutoff")
+    func launchRetentionUsesStrictCutoff() async throws {
+        let now = Date(timeIntervalSince1970: 2_000)
+        let store = try SessionStore()
+        let old = Self.historyCapture(startedAt: 1_098, endedAt: 1_099)
+        let exact = Self.historyCapture(startedAt: 1_099, endedAt: 1_100)
+        let recent = Self.historyCapture(startedAt: 1_100, endedAt: 1_101)
+        for capture in [old, exact, recent] {
+            try await store.replaceCapture(capture, sessions: [])
+        }
+
+        let coordinator = MainContentCoordinator(sessionStore: store, historyNow: { now })
+        coordinator.configureHistoryAutoClear(.minutes15)
+        await coordinator.waitForHistory()
+
+        #expect(try await store.capture(id: old.captureID) == nil)
+        #expect(try await store.capture(id: exact.captureID) != nil)
+        #expect(try await store.capture(id: recent.captureID) != nil)
+        #expect(coordinator.historyCaptures.map(\.id) == [recent.captureID, exact.captureID])
+    }
+
+    @Test("Changing Auto-clear applies immediately while Never invalidates queued cleanup")
+    func preferenceChangeAppliesAndNeverInvalidatesQueuedWork() async throws {
+        let now = Date(timeIntervalSince1970: 5_000)
+        let store = try SessionStore()
+        let first = Self.historyCapture(startedAt: 999, endedAt: 1_000)
+        try await store.replaceCapture(first, sessions: [])
+        let coordinator = MainContentCoordinator(sessionStore: store, historyNow: { now })
+
+        // Both calls occur on MainActor before the queued task can resolve its
+        // guarded policy. `.never` therefore makes the stale 15-minute pass inert.
+        coordinator.configureHistoryAutoClear(.minutes15)
+        coordinator.configureHistoryAutoClear(.never)
+        await coordinator.waitForHistory()
+        #expect(try await store.capture(id: first.captureID) != nil)
+
+        coordinator.configureHistoryAutoClear(.hour1)
+        await coordinator.waitForHistory()
+        #expect(try await store.capture(id: first.captureID) == nil)
+    }
+
+    @Test("A terminal write commits before the current Auto-clear policy prunes History")
+    func terminalWriteThenRetentionOrdering() async throws {
+        let now = Date(timeIntervalSince1970: 2_000)
+        let store = try SessionStore()
+        let coordinator = MainContentCoordinator(sessionStore: store, historyNow: { now })
+        coordinator.configureHistoryAutoClear(.minutes15)
+        await coordinator.waitForHistory()
+
+        let old = Self.historyCapture(startedAt: 999, endedAt: 1_000)
+        try await store.replaceCapture(old, sessions: [])
+        let recentID = UUID()
+        coordinator.scheduleHistoryWrite(
+            store: store,
+            input: HistoryRecordProjection.Input(
+                captureID: recentID,
+                startedAt: 1_499,
+                endedAt: 1_500,
+                sourceKind: .live,
+                completeness: .complete,
+                sessions: [Self.summary()],
+                maskIPAddresses: false
+            )
+        )
+        await coordinator.waitForHistory()
+
+        #expect(try await store.capture(id: old.captureID) == nil)
+        #expect(try await store.capture(id: recentID) != nil)
+        #expect(coordinator.historyCaptures.map(\.id) == [recentID])
+    }
+
+    @Test("Retention failure stays History-specific and preserves the selected preference")
+    func retentionFailureIsVisibleAndIsolated() async throws {
+        let url = Self.temporaryURL()
+        defer { Self.removeDatabaseFiles(url) }
+        let writer = try SessionStore(configuration: .init(location: .file(url)))
+        let reader = try SessionStore(configuration: .init(location: .file(url), readOnly: true))
+        let coordinator = MainContentCoordinator(
+            sessionStore: reader,
+            historyNow: { Date(timeIntervalSince1970: 2_000) }
+        )
+
+        coordinator.configureHistoryAutoClear(.minutes15)
+        await coordinator.waitForHistory()
+
+        #expect(coordinator.historyAutoClear == .minutes15)
+        #expect(coordinator.historyRetentionError?.contains("Auto-clear couldn’t update") == true)
+        #expect(coordinator.historyNotice == coordinator.historyRetentionError)
+        #expect(coordinator.captureError == nil)
+        #expect(coordinator.sessions.isEmpty)
+        withExtendedLifetime(writer) {}
+    }
+
     // MARK: Live terminal mapping
 
     @Test("A terminal live publication persists exactly one live capture and refreshes the read model")
@@ -200,7 +332,7 @@ struct HistoryIntegrationTests {
 
         #expect(try await store.capture(id: firstID) != nil)
         #expect(try await store.capture(id: secondID) != nil)
-        #expect(coordinator.historyWriteTask == nil)
+        #expect(coordinator.historyMutationTask == nil)
         #expect(coordinator.historyCaptures.count == 2)
     }
 
@@ -365,6 +497,30 @@ struct HistoryIntegrationTests {
         #expect(try await store.captures(after: nil, limit: 500).captures.isEmpty)
     }
 
+    @Test("Explicit clear waits for a pending terminal write and removes its committed row")
+    func clearSerializesAfterPendingWrite() async throws {
+        let store = try SessionStore()
+        let coordinator = MainContentCoordinator(sessionStore: store)
+        coordinator.scheduleHistoryWrite(
+            store: store,
+            input: HistoryRecordProjection.Input(
+                captureID: UUID(),
+                startedAt: 1,
+                endedAt: 2,
+                sourceKind: .live,
+                completeness: .complete,
+                sessions: [Self.summary()],
+                maskIPAddresses: false
+            )
+        )
+        coordinator.clearAllHistory()
+        await coordinator.waitForHistory()
+
+        #expect(try await store.captures(after: nil, limit: 500).captures.isEmpty)
+        #expect(coordinator.historyCaptures.isEmpty)
+        #expect(coordinator.historyAvailability == .loaded)
+    }
+
     @Test("Selecting a capture loads its bounded ordinal session page")
     func selectionLoadsSessions() async throws {
         let store = try SessionStore()
@@ -511,6 +667,22 @@ struct HistoryIntegrationTests {
             latencyMilliseconds: 12.5,
             bytesUp: 100,
             bytesDown: 200
+        )
+    }
+
+    private static func historyCapture(
+        captureID: UUID = UUID(),
+        startedAt: Double,
+        endedAt: Double
+    )
+        -> HistoryCaptureRecord
+    {
+        HistoryCaptureRecord(
+            captureID: captureID,
+            startedAt: startedAt,
+            endedAt: endedAt,
+            sourceKind: .live,
+            completeness: .complete
         )
     }
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -22,8 +22,9 @@ This documentation describes what is actually in the source today, and clearly m
 **Implemented:** live libpcap capture through a signed helper, PCAP/PCAPNG read/write and disk-backed
 live-save, interface discovery, a bounds-checked packet decoder, incremental five-tuple sessions, a
 bounded TCP connection/evidence table, selected evidence-linked findings, deterministic replay,
-protected session export, terminal-summary SQLite History, and a native SwiftUI/AppKit investigation
-workspace with typed queries and explicit bounded Follow Stream.
+protected session export, terminal-summary SQLite History with boundary-triggered automatic retention,
+and a native SwiftUI/AppKit investigation workspace with typed queries and explicit bounded Follow
+Stream.
 
 **Partial:** application-layer decode remains metadata-focused — DNS records, TLS handshake and record
 metadata, HTTP/1 request-line and Host header recognition, QUIC long-header metadata, and STUN
@@ -33,8 +34,8 @@ Protected `.tracexysession` export enforces the Privacy settings by omitting raw
 decoded metadata. Raw pcap/pcapng remains evidence-preserving and is never presented as redacted.
 
 **Planned / not yet implemented:** a decoder registry with dispatch-table handoff, general TCP
-stream/record reassembly, deeper protocol/security policy, raw capture persistence, automatic History
-retention, an MCP/AI bridge, and packet-rewriting redaction for raw capture formats. The existing
+stream/record reassembly, deeper protocol/security policy, raw capture persistence, an MCP/AI bridge,
+and packet-rewriting redaction for raw capture formats. The existing
 read-only automation core has no executable or network transport. Do not treat these as present.
 
 When the source and these docs disagree, the source is correct — please open an issue or a fix.

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -70,7 +70,7 @@ These are current source claims:
 | Sessions | Canonical five-tuple grouping, endpoint projections, timing/byte summaries, bounded connection evidence |
 | Findings | Selected evidence-linked TCP and datagram findings; no general durable security-analysis engine |
 | Follow Stream | On-demand bounded TCP follow for identity-checked saved or fully stopped sources |
-| History | Local terminal capture/session summaries in SQLite; no raw packet persistence |
+| History | Local terminal capture/session summaries in SQLite with boundary-triggered Auto-clear; no raw packet persistence |
 | Automation | Read-only bounded History projection to deterministic JSON or spreadsheet-safe CSV; no listener, provider, executable target, or MCP server |
 | Exports | Raw PCAP/PCAPNG stays byte-preserving; protected `.tracexysession` export omits raw frames and sensitive decoded metadata |
 
@@ -84,7 +84,7 @@ Do not present these as shipped:
 - TLS analysis or decrypted HTTPS payload visibility;
 - general always-on TCP stream or record reassembly;
 - user-visible connection/TLS evidence navigation beyond current views;
-- automatic History retention cleanup;
+- a periodic background History retention scheduler;
 - production replay UI/runner;
 - CLI transport, TracexyMCP, or AI data transport; and
 - packet-rewriting redaction for raw PCAP or PCAPNG.

--- a/docs/privacy-and-security.md
+++ b/docs/privacy-and-security.md
@@ -27,8 +27,10 @@ fields with a fixed placeholder. The document records the applied protections as
 metadata. A version-1 document with packet bytes is produced only when every protection is disabled.
 
 These controls do not sanitize raw pcap/pcapng files. Use the warning as a hard trust boundary: export
-those formats only when you intend to handle the result as sensitive evidence. Automatic retention
-cleanup remains planned; the Auto-clear choice currently records intent only.
+those formats only when you intend to handle the result as sensitive evidence. The **Auto-clear**
+choice applies only to bounded summaries in the local History database. Tracexy enforces it at launch,
+after accepting a terminal capture into History, and when the choice changes; it never deletes raw
+pcap/pcapng files, the live spool, exports, or the current workspace.
 
 ## The privileged helper and trust boundary
 
@@ -40,7 +42,7 @@ with the app over XPC. This boundary is the highest-value part of the codebase t
   command execution, shell, or file access. Frames are drained as typed `NSSecureCoding` objects
   (`FrameBatchMessage`/`CapturedFrameMessage`) with the secure-coding class allow-list configured on
   both endpoints; the app validates every field defensively and rejects malformed metadata rather than
-  trusting it. This is protocol **v2** — an older v1 helper is classified incompatible and Start is
+  trusting it. This is protocol **v4** — an older helper is classified incompatible and Start is
   gated with an update prompt, never silently downgraded to an untyped drain.
 - **Bidirectional code-sign validation.** The helper validates every connecting caller (signing-team
   match with a certificate-chain fallback, plus a bundle-identity allowlist checked against the

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -75,6 +75,13 @@ Privacy setting at write time.
 Use **Refresh** to reload the newest summaries. **Clear…** requires confirmation and removes only the
 local History database rows; it does not clear the current capture or delete saved capture files.
 
+**Settings → Privacy → Auto-clear** can keep History forever or remove entries whose capture end time
+is older than 15 minutes, 1 hour, or 24 hours. Cleanup runs at launch, after a completed live or saved
+capture is accepted into History, and immediately when the setting changes; there is no background
+timer. An entry ending exactly at the cutoff is retained. This policy affects only local History rows,
+so an older saved capture can disappear from History while remaining open in the current workspace and
+unchanged on disk.
+
 ## Sidebar sources
 
 The **Sources** groups in Browse are derived from the current capture. Secondary-click an app,


### PR DESCRIPTION
## Summary

- Enforce the persisted History Auto-clear policy at app launch, after accepted terminal capture writes, and immediately when the preference changes.
- Serialize History writes, retention, and explicit clearing off the main actor with strict cutoff semantics, rollback-safe cancellation, and isolated failure reporting.
- Add a privacy-safe `--dum-data` launch mode backed by in-memory History and isolated settings for deterministic retention testing and product demos.
- Update Privacy and usage documentation to describe timing, scope, and raw-capture exclusions.

## Validation

- [x] `swiftformat --lint .`
- [x] `swiftlint lint --strict`
- [x] `xcodebuild -project Tracexy.xcodeproj -scheme Tracexy -destination "platform=macOS" build`
- [x] `xcodebuild -quiet -project Tracexy.xcodeproj -scheme Tracexy -destination "platform=macOS" test -only-testing:TracexyTests`
- [x] Manual `--dum-data` walkthrough: Never = 4 captures, 24 hours = 3, 1 hour = 2, 15 minutes = 1.

## Safety Checklist

- [x] Targets `develop`.
- [x] Includes focused storage, coordinator, settings, and demo-fixture tests.
- [x] Updates docs for user-facing behavior changes.
- [x] Preserves capture/helper/XPC/privacy boundaries.
- [x] Contains no credentials, signing files, local paths, raw captures, or private config.
- [x] Does not use agent, model, vendor, or local tool identity in public metadata.
- [ ] I have read and agree to the Tracexy ICLA v1.0.

## Notes

- Closes #20.
- Auto-clear affects only bounded rows in the local History database; it never deletes raw capture files, exports, the live spool, or current workspace state.
- The public-safety gate reports one pre-existing personal-webmail metadata finding on base commit `bfdaa23`; the staged/current diff adds no such finding.