### PR TITLE
feat(evidence): add cited frame navigation

### DIFF
--- a/Tracexy/Core/Analysis/SessionEvidenceSelection.swift
+++ b/Tracexy/Core/Analysis/SessionEvidenceSelection.swift
@@ -1,0 +1,139 @@
+import Foundation
+
+// This file declares the frozen, presentation-neutral value for one selected
+// session's retained connection and TLS evidence. Like the tables it reads, it is
+// observation-only: it carries the exact retained ``ConnectionSummary`` and
+// ``TLSEvidenceSummary`` values a fold already produced, plus the relevant
+// capture-level coverage counters — never a rendered label, severity, policy, raw
+// bytes, URL, path, SNI or certificate. It adds no analysis; it is a filtered,
+// deterministic projection of one immutable ``InvestigationSnapshot``.
+
+// MARK: - ConnectionSelectionCoverage
+
+/// The capture-level connection-table coverage a selected session's presentation
+/// needs, carried verbatim from ``ConnectionTable/Snapshot``. These are *global*
+/// facts: `omittedSummaryCount` and the counts describe the whole capture, never
+/// this one session, so a caller must label them as capture-level and never claim
+/// they prove this selected session was omitted.
+nonisolated struct ConnectionSelectionCoverage: Hashable, Sendable {
+    static let empty = ConnectionSelectionCoverage(
+        omittedSummaryCount: 0,
+        activeConnectionCount: 0,
+        publishedSummaryCount: 0,
+        retainedEventCount: 0,
+        countersOverflowed: false
+    )
+
+    let omittedSummaryCount: UInt64
+    let activeConnectionCount: Int
+    let publishedSummaryCount: Int
+    let retainedEventCount: Int
+    let countersOverflowed: Bool
+}
+
+// MARK: - TLSSelectionCoverage
+
+/// The capture-level TLS-evidence coverage a selected session's presentation needs,
+/// carried verbatim from ``TLSEvidenceTable/Snapshot``. As with the connection
+/// coverage these are global capture facts; absence of a retained summary for this
+/// session is unknown coverage, never evidence of absence.
+nonisolated struct TLSSelectionCoverage: Hashable, Sendable {
+    static let empty = TLSSelectionCoverage(
+        omittedObservationCount: 0,
+        retainedObservationCount: 0,
+        excludedReassembledRecordCount: 0,
+        recoveredTruncationIndicatorCount: 0,
+        decoderTruncatedFrameCount: 0,
+        capacityReached: false,
+        countersOverflowed: false
+    )
+
+    let omittedObservationCount: UInt64
+    let retainedObservationCount: Int
+    let excludedReassembledRecordCount: UInt64
+    let recoveredTruncationIndicatorCount: UInt64
+    let decoderTruncatedFrameCount: UInt64
+    let capacityReached: Bool
+    let countersOverflowed: Bool
+}
+
+// MARK: - SessionEvidenceSelection
+
+/// The immutable, presentation-neutral view of one selected session's retained
+/// connection and TLS evidence.
+///
+/// A session is tuple-derived, so one session can hold multiple sequential TCP
+/// connection incarnations when its tuple is reused. `connections` lists *every*
+/// retained incarnation whose tuple-derived session id matches, in the snapshot's
+/// existing deterministic (first-observed) order — this value never chooses one as
+/// "the connection." `tls` is the zero-or-one retained tuple/session-scoped TLS
+/// summary; because current evidence cannot prove which incarnation a tuple-scoped
+/// TLS record belongs to, it is shared at session scope and never paired to a
+/// specific connection.
+///
+/// Every per-summary omission, exclusion, truncation, loss, limitation and overflow
+/// fact needed by a presentation layer already lives inside the retained
+/// ``ConnectionSummary``/``TLSEvidenceSummary`` values carried here; the two
+/// coverage members add only the capture-level (global) counters.
+nonisolated struct SessionEvidenceSelection: Hashable, Sendable {
+    /// The tuple-derived session id this selection was projected for.
+    let sessionID: UUID
+    /// Every retained connection incarnation for this session in first-observed
+    /// order. Bounded by the connection table's published-summary bound.
+    let connections: [ConnectionSummary]
+    /// The zero-or-one retained tuple/session-scoped TLS summary. Never paired to a
+    /// connection incarnation.
+    let tls: TLSEvidenceSummary?
+    /// Capture-level connection coverage, carried verbatim.
+    let connectionCoverage: ConnectionSelectionCoverage
+    /// Capture-level TLS coverage, carried verbatim.
+    let tlsCoverage: TLSSelectionCoverage
+
+    /// Whether nothing was retained for this session. Capture-level coverage is
+    /// still carried so a caller can present it as global unknown coverage.
+    var isEmpty: Bool {
+        connections.isEmpty && tls == nil
+    }
+}
+
+// MARK: - InvestigationSnapshot selection
+
+extension InvestigationSnapshot {
+    /// Project the retained connection/TLS evidence for one tuple-derived session id.
+    ///
+    /// Pure and off-main-ready: it filters the wrapped fold's already-produced
+    /// connection and TLS summaries — no decode, no re-assessment, no copy of the
+    /// snapshot arrays beyond the bounded matches. The connection incarnations keep
+    /// the snapshot's deterministic order, and the single tuple-scoped TLS summary is
+    /// matched by session id, never re-attributed to an incarnation.
+    nonisolated func selectingSession(_ sessionID: UUID) -> SessionEvidenceSelection {
+        let connectionSnapshot = connections
+        let matchedConnections = connectionSnapshot.summaries.filter {
+            SessionBuilder.sessionID(for: $0.tuple) == sessionID
+        }
+        let tlsSnapshot = tlsEvidence
+        let matchedTLS = tlsSnapshot.summaries.first { $0.sessionID == sessionID }
+
+        return SessionEvidenceSelection(
+            sessionID: sessionID,
+            connections: matchedConnections,
+            tls: matchedTLS,
+            connectionCoverage: ConnectionSelectionCoverage(
+                omittedSummaryCount: connectionSnapshot.omittedSummaryCount,
+                activeConnectionCount: connectionSnapshot.activeConnectionCount,
+                publishedSummaryCount: connectionSnapshot.publishedSummaryCount,
+                retainedEventCount: connectionSnapshot.retainedEventCount,
+                countersOverflowed: connectionSnapshot.countersOverflowed
+            ),
+            tlsCoverage: TLSSelectionCoverage(
+                omittedObservationCount: tlsSnapshot.omittedObservationCount,
+                retainedObservationCount: tlsSnapshot.retainedObservationCount,
+                excludedReassembledRecordCount: tlsSnapshot.excludedReassembledRecordCount,
+                recoveredTruncationIndicatorCount: tlsSnapshot.recoveredTruncationIndicatorCount,
+                decoderTruncatedFrameCount: tlsSnapshot.decoderTruncatedFrameCount,
+                capacityReached: tlsSnapshot.capacityReached,
+                countersOverflowed: tlsSnapshot.countersOverflowed
+            )
+        )
+    }
+}

--- a/Tracexy/Core/Capture/LiveCaptureSpool.swift
+++ b/Tracexy/Core/Capture/LiveCaptureSpool.swift
@@ -161,6 +161,16 @@ actor LiveCaptureSpool {
         guard epoch == self.epoch else {
             throw Failure.staleEvidence
         }
+        return try readCurrentSource(locator, capturedLength: capturedLength)
+    }
+
+    /// Read one locator from the spool source that is current now, regardless of
+    /// the coordinator generation used to publish it. Stopping a capture advances
+    /// the coordinator generation without replacing the spool; the opaque source
+    /// token remains the authority for whether a locator still belongs here.
+    /// A reset mints a new token, so evidence from every superseded spool still
+    /// fails as stale before any offset is read.
+    func readCurrentSource(_ locator: SessionEvidenceLocator, capturedLength: Int) throws -> [UInt8] {
         guard let token = sourceToken, locator.sourceToken == token else {
             throw Failure.staleEvidence
         }

--- a/Tracexy/Core/Capture/SavedCaptureStreamLoader.swift
+++ b/Tracexy/Core/Capture/SavedCaptureStreamLoader.swift
@@ -96,6 +96,54 @@ nonisolated enum CaptureEvidenceReader {
     }
 }
 
+// MARK: - CitedFrameReferenceError
+
+/// Why an exact cited-frame reference could not be constructed for a saved source.
+/// Both cases are controlled, presentation-neutral failures: neither carries a path
+/// or the internal source token, so error text derived from them exposes neither.
+nonisolated enum CitedFrameReferenceError: Error, Equatable {
+    /// The provenance carried no locator, so there is no exact frame to cite. A
+    /// caller treats this as an explicit unavailable state, never a fallback read.
+    case missingLocator
+    /// The locator's source token was not minted from the currently adopted file
+    /// identity — a locator from a different or replaced source.
+    case sourceTokenMismatch
+}
+
+extension SavedCaptureStreamLoader {
+    /// Build the exact ``CaptureEvidenceReference`` for one cited frame, but only
+    /// after validating that the provenance locator's source token was minted from
+    /// `identity` (the currently adopted file). The frame coordinates come straight
+    /// from the provenance the fold already retained.
+    ///
+    /// This validates *source identity* only; the byte-level identity/length/overrun
+    /// checks still happen in ``CaptureEvidenceReader/read(_:from:maxCapturedLength:)``
+    /// when the reference is read, so a replaced, truncated or short file is caught
+    /// there. Constructs no reference and reads nothing on a wrong token or an
+    /// absent locator.
+    static func citedEvidenceReference(
+        for provenance: SessionFrameProvenance,
+        matching identity: PcapFileIdentity
+    )
+        throws -> CaptureEvidenceReference
+    {
+        guard let locator = provenance.locator else {
+            throw CitedFrameReferenceError.missingLocator
+        }
+        guard locator.sourceToken == sourceToken(for: identity) else {
+            throw CitedFrameReferenceError.sourceTokenMismatch
+        }
+        return CaptureEvidenceReference(
+            identity: identity,
+            payloadOffset: locator.offset,
+            capturedLength: provenance.capturedLength,
+            originalLength: provenance.originalLength,
+            timestamp: provenance.timestamp,
+            linkType: provenance.linkType
+        )
+    }
+}
+
 // MARK: - CaptureLoadCompleteness
 
 /// Whether the saved-open walk reached the file's end cleanly, or stopped on a
@@ -221,6 +269,22 @@ nonisolated final class SavedCaptureStreamLoader {
         let isCancelled: @Sendable () -> Bool
     }
 
+    /// A deterministic, opaque source token derived only from the opened file's
+    /// identity. Two loads of the same unchanged file yield the same token; a
+    /// replaced or resized file yields a different one. It carries no path and no
+    /// bytes — it only lets a consumer holding the same capture-local identity
+    /// correlate an evidence locator's offset back to this file.
+    ///
+    /// Internal so an evidence consumer holding the currently adopted file identity
+    /// can validate that a locator's source token was minted from *this* file before
+    /// resolving it (see ``citedEvidenceReference(for:matching:)``).
+    static func sourceToken(for identity: PcapFileIdentity) -> UUID {
+        SessionBuilder.stableID(
+            "savedsource|\(identity.size)|\(identity.device)|\(identity.inode)"
+                + "|\(identity.modifiedAt?.timeIntervalSince1970 ?? -1)"
+        )
+    }
+
     /// Fold the entire file into one result.
     ///
     /// - Parameter onProgress: coalesced, monotonic byte-progress callbacks. Never
@@ -297,18 +361,6 @@ nonisolated final class SavedCaptureStreamLoader {
 
     private let configuration: Configuration
     private let reader: CaptureStreamReader
-
-    /// A deterministic, opaque source token derived only from the opened file's
-    /// identity. Two loads of the same unchanged file yield the same token; a
-    /// replaced or resized file yields a different one. It carries no path and no
-    /// bytes — it only lets a consumer holding the same capture-local identity
-    /// correlate an evidence locator's offset back to this file.
-    private static func sourceToken(for identity: PcapFileIdentity) -> UUID {
-        SessionBuilder.stableID(
-            "savedsource|\(identity.size)|\(identity.device)|\(identity.inode)"
-                + "|\(identity.modifiedAt?.timeIntervalSince1970 ?? -1)"
-        )
-    }
 
     /// Drive the reader to its terminal, folding each frame exactly once. Kept
     /// separate so `load` reads as open → walk → finalize.

--- a/Tracexy/Models/UI/Finding.swift
+++ b/Tracexy/Models/UI/Finding.swift
@@ -15,6 +15,10 @@ struct Finding: Identifiable, Hashable {
     let coverage: AnalysisCoverage
     let citedObservationCount: Int
     let omittedCitationCount: UInt64
+    /// Exact bounded frame provenance copied from Core citations, in citation
+    /// order. The presentation layer keeps no bytes and invents no fallback: an
+    /// absent locator remains visibly unavailable when the user asks to inspect it.
+    let citedFrames: [SessionFrameProvenance]
 }
 
 // MARK: Finding projection
@@ -33,6 +37,7 @@ extension Finding {
         coverage = finding.coverage
         citedObservationCount = finding.citations.count
         omittedCitationCount = finding.omittedCitationCount
+        citedFrames = finding.citations.flatMap(\.provenance)
         subtitle = Self.subtitle(
             context: host,
             citedObservationCount: citedObservationCount,
@@ -51,6 +56,7 @@ extension Finding {
         coverage = finding.coverage
         citedObservationCount = finding.citations.count
         omittedCitationCount = finding.omittedCitationCount
+        citedFrames = finding.citations.map(\.provenance)
         subtitle = Self.subtitle(
             context: "TC bit observed · \(host)",
             citedObservationCount: citedObservationCount,

--- a/Tracexy/Models/UI/InspectorPresentation.swift
+++ b/Tracexy/Models/UI/InspectorPresentation.swift
@@ -11,6 +11,7 @@ enum InspectorTab: String, CaseIterable, Identifiable, Hashable {
     // analyser cannot draw, since its engine has no shared axis across
     // conversations of different protocols.
     case timeline
+    case evidence
     case stream
     case layers
     case requests
@@ -26,6 +27,7 @@ enum InspectorTab: String, CaseIterable, Identifiable, Hashable {
     nonisolated var title: String {
         switch self {
         case .timeline: "Timeline"
+        case .evidence: "Evidence"
         case .stream: "Stream"
         case .layers: "Layers"
         case .requests: "Requests"
@@ -37,6 +39,7 @@ enum InspectorTab: String, CaseIterable, Identifiable, Hashable {
     nonisolated var systemImage: String {
         switch self {
         case .timeline: "chart.bar.xaxis"
+        case .evidence: "point.3.connected.trianglepath.dotted"
         case .stream: "arrow.left.arrow.right.square"
         case .layers: "square.stack.3d.up"
         case .requests: "arrow.left.arrow.right"
@@ -52,8 +55,16 @@ enum InspectorTab: String, CaseIterable, Identifiable, Hashable {
     /// learns once — the evidence tabs describe what this session literally
     /// contains, so a facet with no bytes behind it would be a promise the
     /// decode cannot keep.
-    static func visibleTabs(for session: SessionSummary) -> [InspectorTab] {
+    static func visibleTabs(
+        for session: SessionSummary,
+        hasSessionEvidence: Bool = false
+    )
+        -> [InspectorTab]
+    {
         var tabs: [InspectorTab] = [.timeline]
+        if hasSessionEvidence {
+            tabs.append(.evidence)
+        }
         if session.protocolStack.contains(.tcp) {
             tabs.append(.stream)
         }

--- a/Tracexy/Models/UI/SessionEvidencePresentation.swift
+++ b/Tracexy/Models/UI/SessionEvidencePresentation.swift
@@ -1,0 +1,295 @@
+import Foundation
+
+// MARK: - SessionEvidenceItem
+
+/// One literal, chronologically sortable row in the bottom Evidence facet.
+///
+/// The value is deliberately presentation-only: it keeps the already-bounded
+/// Core fact and its exact provenance, but adds no finding, endpoint role, loss
+/// cause, or TLS policy. A row may cite more than one frame (the completed TCP
+/// handshake); every cited frame remains independently inspectable.
+struct SessionEvidenceItem: Identifiable, Hashable {
+    enum Kind: Hashable {
+        case connection
+        case tls
+    }
+
+    let id: String
+    let kind: Kind
+    let title: String
+    let detail: String
+    let timestamp: Date
+    let ordinal: FrameOrdinal
+    let provenance: [SessionFrameProvenance]
+
+    var systemImage: String {
+        switch kind {
+        case .connection: "point.3.connected.trianglepath.dotted"
+        case .tls: "lock.shield"
+        }
+    }
+
+    var categoryLabel: String {
+        switch kind {
+        case .connection: "TCP"
+        case .tls: "TLS"
+        }
+    }
+}
+
+extension SessionEvidenceItem {
+    /// Merge retained connection events and direct-frame TLS observations on the
+    /// capture's monotonic frame axis. Stable source-order tie breakers preserve
+    /// deterministic display when several observations cite the same frame.
+    static func timeline(
+        connections: [ConnectionSummary],
+        tls: TLSEvidenceSummary?
+    )
+        -> [SessionEvidenceItem]
+    {
+        var indexed: [(item: SessionEvidenceItem, sourceRank: Int, sourceIndex: Int)] = []
+
+        for (connectionIndex, connection) in connections.enumerated() {
+            for (eventIndex, event) in connection.events.enumerated() {
+                let occurrence = event.occurrenceOrdinal
+                indexed.append((
+                    item: SessionEvidenceItem(
+                        id: "connection-\(connection.id.rawValue.uuidString)-\(eventIndex)",
+                        kind: .connection,
+                        title: SessionEvidenceCopy.connectionEventTitle(event.kind),
+                        detail: SessionEvidenceCopy.connectionEventDetail(
+                            event,
+                            tuple: connection.tuple,
+                            incarnation: connectionIndex + 1,
+                            incarnationCount: connections.count
+                        ),
+                        timestamp: event.timestamp,
+                        ordinal: occurrence,
+                        provenance: event.provenance
+                    ),
+                    sourceRank: 0,
+                    sourceIndex: eventIndex
+                ))
+            }
+        }
+
+        if let tls {
+            for (observationIndex, observation) in tls.observations.enumerated() {
+                indexed.append((
+                    item: SessionEvidenceItem(
+                        id: "tls-\(observation.provenance.ordinal.rawValue)-"
+                            + "\(observation.recordIndex)-\(observationIndex)",
+                        kind: .tls,
+                        title: SessionEvidenceCopy.tlsRecordTitle(observation.fact),
+                        detail: SessionEvidenceCopy.tlsRecordDetail(observation),
+                        timestamp: observation.provenance.timestamp,
+                        ordinal: observation.provenance.ordinal,
+                        provenance: [observation.provenance]
+                    ),
+                    sourceRank: 1,
+                    sourceIndex: observationIndex
+                ))
+            }
+        }
+
+        return indexed.sorted { lhs, rhs in
+            if lhs.item.ordinal != rhs.item.ordinal {
+                return lhs.item.ordinal < rhs.item.ordinal
+            }
+            if lhs.sourceRank != rhs.sourceRank {
+                return lhs.sourceRank < rhs.sourceRank
+            }
+            return lhs.sourceIndex < rhs.sourceIndex
+        }.map(\.item)
+    }
+}
+
+// MARK: - SessionEvidenceCopy
+
+/// Fixed, neutral copy for the evidence UI. Keeping these mappings outside the
+/// views makes the claims directly testable and prevents slightly different TLS
+/// or coverage wording from appearing in the bottom and right inspectors.
+nonisolated enum SessionEvidenceCopy {
+    static func connectionEventTitle(_ kind: ConnectionEventKind) -> String {
+        switch kind {
+        case .firstObserved: "First frame observed"
+        case .syn: "SYN observed"
+        case .synAck: "SYN + ACK observed"
+        case .handshakeCompleted: "Three-way handshake observed"
+        case .payloadObserved: "TCP payload observed"
+        case .fin: "FIN observed"
+        case .rst: "Reset observed"
+        case .lateSegmentAfterClose: "Late segment after close"
+        case .ambiguousTupleReuse: "Ambiguous tuple reuse observed"
+        case .stateEvicted: "Connection state evicted"
+        case .sequenceAdvanced: "Sequence advanced"
+        case .retransmission: "Retransmission observed"
+        case .overlap: "Segment overlap observed"
+        case .outOfOrderBuffered: "Out-of-order segment buffered"
+        case .pendingDrained: "Buffered sequence gap drained"
+        case .pendingOverflow: "Pending sequence bound reached"
+        case .serialAmbiguous: "Sequence distance ambiguous"
+        case .applicationRecord: "Application record identified"
+        case .applicationProbeTruncated: "Application probe bound reached"
+        }
+    }
+
+    static func connectionEventDetail(
+        _ event: ConnectionEvent,
+        tuple: FiveTuple,
+        incarnation: Int,
+        incarnationCount: Int
+    )
+        -> String
+    {
+        var parts: [String] = []
+        if incarnationCount > 1 {
+            parts.append("connection \(incarnation) of \(incarnationCount)")
+        }
+        if let direction = event.direction {
+            parts.append(directionLabel(direction, tuple: tuple))
+        }
+        if event.payloadLength > 0 {
+            parts.append("\(event.payloadLength.formatted()) payload bytes")
+        }
+        if let applicationKind = event.applicationKind {
+            let completeness = event.applicationComplete == true ? "complete first record" : "partial first record"
+            parts.append("\(applicationKind.label) · \(completeness)")
+        }
+        if event.provenance.count > 1 {
+            parts.append("\(event.provenance.count) cited frames")
+        }
+        return parts.isEmpty ? "Retained connection observation" : parts.joined(separator: " · ")
+    }
+
+    static func directionLabel(_ direction: ConnectionDirection, tuple: FiveTuple) -> String {
+        switch direction {
+        case .aToB: "\(tuple.a.display) → \(tuple.b.display)"
+        case .bToA: "\(tuple.b.display) → \(tuple.a.display)"
+        }
+    }
+
+    static func phaseLabel(_ phase: ConnectionPhase) -> String {
+        switch phase {
+        case .opening: "Opening observed"
+        case .active: "Active traffic observed"
+        case .closing: "Closing observed"
+        case .closed: "Terminal observation retained"
+        }
+    }
+
+    static func handshakeLabel(_ handshake: HandshakeObservation) -> String {
+        switch handshake {
+        case .none: "Not observed"
+        case .synObserved: "SYN observed"
+        case .synAckObserved: "SYN + ACK observed"
+        case .threeWayObserved: "Three-way handshake observed"
+        }
+    }
+
+    static func lossLabel(_ loss: CaptureLossKnowledge) -> String {
+        switch loss {
+        case .unknown: "Capture loss unknown"
+        case .noLossReported: "No loss reported for retained flow frames"
+        case .lossReported: "Capture loss reported"
+        }
+    }
+
+    static func closeReasonLabel(_ reason: ConnectionCloseReason?) -> String? {
+        switch reason {
+        case .none: nil
+        case .orderly: "Bidirectional FIN observed"
+        case let .reset(direction): "Reset observed · \(direction == .aToB ? "A → B" : "B → A")"
+        case .stateEviction: "State evicted under bound"
+        }
+    }
+
+    static func limitationLabels(_ limitations: ConnectionLimitations) -> [String] {
+        var labels: [String] = []
+        let values: [(ConnectionLimitations, String)] = [
+            (.startUnobserved, "Connection start was not observed"),
+            (.handshakeIncomplete, "Handshake evidence is incomplete"),
+            (.payloadTruncated, "Snap-length truncation was observed"),
+            (.ambiguousTupleReuse, "Tuple reuse could not be split confidently"),
+            (.priorStateEvicted, "Earlier state for this tuple was evicted"),
+            (.eventHistoryTruncated, "Older connection events were omitted"),
+            (.counterOverflow, "A connection counter saturated"),
+            (.sequenceGapObserved, "A sequence-space gap was observed"),
+            (.serialDistanceAmbiguous, "A serial distance was ambiguous"),
+            (.sequenceStateTruncated, "Sequence tracking state was truncated"),
+            (.applicationProbeTruncated, "The bounded application probe was truncated"),
+        ]
+        for (flag, label) in values where limitations.contains(flag) {
+            labels.append(label)
+        }
+        return labels
+    }
+
+    static func tlsRecordTitle(_ fact: TLSRecordFact) -> String {
+        if let handshake = fact.handshake {
+            switch handshake {
+            case .clientHello: return "TLS ClientHello"
+            case let .serverHello(server):
+                return server.isHelloRetryRequest ? "TLS HelloRetryRequest" : "TLS ServerHello"
+            }
+        }
+        return switch fact.contentType {
+        case 20: "TLS ChangeCipherSpec record"
+        case 21: "TLS Alert record"
+        case 22: "TLS Handshake record"
+        case 23: "TLS Application Data record"
+        case 24: "TLS Heartbeat record"
+        default: "TLS record type \(fact.contentType)"
+        }
+    }
+
+    static func tlsRecordDetail(_ observation: TLSEvidenceObservation) -> String {
+        let fact = observation.fact
+        var parts = [
+            directionLabel(observation.direction, tuple: observation.tuple),
+            "record \(observation.recordIndex + 1)",
+            "\(fact.capturedBodyLength.formatted())/\(fact.declaredBodyLength.formatted()) body bytes",
+            fact.bodyComplete ? "body complete" : "body incomplete",
+            "legacy record version \(versionLabel(fact.legacyRecordVersion))",
+        ]
+
+        switch fact.handshake {
+        case let .clientHello(client):
+            if client.offeredVersions.isEmpty {
+                parts
+                    .append(client
+                        .extensionsComplete ? "no supported_versions values retained" : "extensions incomplete")
+            } else {
+                parts.append("offered \(client.offeredVersions.map(versionLabel).joined(separator: ", "))")
+            }
+            if client.offeredVersionsOmittedCount > 0 {
+                parts.append("\(client.offeredVersionsOmittedCount) offered versions omitted")
+            }
+        case let .serverHello(server):
+            parts.append(String(format: "cipher 0x%04X", server.selectedCipher))
+            if server.isHelloRetryRequest {
+                parts.append("retry request; no final version claimed")
+            } else if let selectedVersion = server.selectedVersion {
+                parts.append("selected \(versionLabel(selectedVersion))")
+            } else {
+                parts.append("selected version unavailable")
+            }
+        case .none:
+            break
+        }
+        return parts.joined(separator: " · ")
+    }
+
+    static func versionLabel(_ rawValue: UInt16) -> String {
+        let name: String? = switch rawValue {
+        case 0x0300: "SSL 3.0"
+        case 0x0301: "TLS 1.0"
+        case 0x0302: "TLS 1.1"
+        case 0x0303: "TLS 1.2"
+        case 0x0304: "TLS 1.3"
+        default: nil
+        }
+        let raw = String(format: "0x%04X", rawValue)
+        return name.map { "\($0) (\(raw))" } ?? raw
+    }
+}

--- a/Tracexy/ViewModels/MainContentCoordinator+EvidenceNavigation.swift
+++ b/Tracexy/ViewModels/MainContentCoordinator+EvidenceNavigation.swift
@@ -1,0 +1,395 @@
+import Foundation
+
+// MARK: - EvidenceProjectionPipeline
+
+/// The off-main projection of the selected session's retained connection/TLS
+/// evidence, with its own request/task guard. Held on the main actor; nothing here
+/// crosses actors except the pure ``SessionEvidenceSelection`` result.
+struct EvidenceProjectionPipeline {
+    /// The published projection for the current selection, or `nil` when nothing is
+    /// selected.
+    var selection: SessionEvidenceSelection?
+    /// Monotonic request id; a superseded refresh cannot publish.
+    var requestID = 0
+    var task: Task<Void, Never>?
+}
+
+// MARK: - SelectedFrameEvidence
+
+/// The one explicitly cited frame: its exact provenance, bounded captured bytes and
+/// decoded layers. Selection-scoped and local — never persisted, exported or
+/// transported. Carries no path, source token, URL or file identity.
+nonisolated struct SelectedFrameEvidence: Hashable, Sendable {
+    let sessionID: UUID
+    let provenance: SessionFrameProvenance
+    /// The exact captured bytes of this one frame, bounded by its captured length.
+    let bytes: [UInt8]
+    /// The layers decoded from `bytes` off-main under the frame's intrinsic link type.
+    let layers: [DecodedLayer]
+}
+
+// MARK: - CitedFrameState
+
+/// The coarse state of the one cited-frame inspection slot. It doubles as the load
+/// guard: a finish callback publishes only when the slot is still `.loading` the
+/// exact provenance it was started for.
+nonisolated enum CitedFrameState: Equatable, Sendable {
+    /// Nothing cited.
+    case idle
+    /// The selected citation has no locator, so there is no navigable local frame.
+    /// An explicit unavailable state that triggers no read and never falls back.
+    case unavailable
+    /// A read/decode is in flight for exactly this provenance.
+    case loading(SessionFrameProvenance)
+    /// The one cited frame's bounded bytes and decoded layers.
+    case loaded(SelectedFrameEvidence)
+    /// A controlled failure. The message exposes no path or source token.
+    case failed(String)
+}
+
+// MARK: - CitedFramePipeline
+
+/// The one explicitly cited frame plus its request/task guard.
+struct CitedFramePipeline {
+    var state: CitedFrameState = .idle
+    /// Monotonic request id; a superseded/cleared read cannot publish.
+    var requestID = 0
+    var task: Task<Void, Never>?
+}
+
+// MARK: - CitedFrameSource
+
+/// The source context a cited-frame read was started against, re-checked verbatim
+/// before publication so a late task cannot publish across a source boundary.
+nonisolated private enum CitedFrameSource: Equatable, Sendable {
+    case saved(url: URL, identity: PcapFileIdentity)
+    case live(generation: Int)
+}
+
+// MARK: - Evidence navigation
+
+@MainActor
+extension MainContentCoordinator {
+    /// The shared entry point for a direct table/workspace selection change: it retires
+    /// the previously cited frame and rebuilds the off-main projection for the newly
+    /// selected session. Existing `select(_:)` routes through it too.
+    func evidenceNavigationDidChangeSelection() {
+        cancelCitedFrame()
+        refreshSelectedSessionEvidenceProjection()
+    }
+
+    /// Rebuild the selected session's connection/TLS projection off-main and publish
+    /// it only behind request, workspace, session and capture-generation guards. A
+    /// superseding refresh cancels/retires the prior task. `adoptInvestigation` calls
+    /// this so a publication refreshes the current selection without re-assessing
+    /// evidence.
+    func refreshSelectedSessionEvidenceProjection() {
+        evidenceProjection.task?.cancel()
+        evidenceProjection.requestID &+= 1
+        let requestID = evidenceProjection.requestID
+        guard let sessionID = activeWorkspace.selectedSessionID else {
+            evidenceProjection.selection = nil
+            evidenceProjection.task = nil
+            return
+        }
+        let snapshot = investigationSnapshot
+        let workspaceID = activeWorkspace.id
+        let expectedGeneration = startGeneration
+        let task = Task.detached(priority: .userInitiated) { [weak self] in
+            let selection = snapshot.selectingSession(sessionID)
+            await self?.publishSelectedSessionEvidenceProjection(
+                selection,
+                sessionID: sessionID,
+                workspaceID: workspaceID,
+                requestID: requestID,
+                expectedGeneration: expectedGeneration
+            )
+        }
+        evidenceProjection.task = task
+    }
+
+    /// Start one guarded exact cited-frame inspection for a session id and provenance.
+    /// A nil locator is an explicit unavailable state and triggers no read. Saved and
+    /// live/stopped-live sources each resolve exactly one frame; neither copies nor
+    /// scans its source, and no fallback frame is ever read.
+    func inspectCitedFrame(sessionID: UUID, provenance: SessionFrameProvenance) {
+        cancelCitedFrame()
+        citedFrame.requestID &+= 1
+        let requestID = citedFrame.requestID
+
+        // Only inspect a frame for the currently selected session.
+        guard activeWorkspace.selectedSessionID == sessionID else {
+            return
+        }
+        // Nil locator: explicit unavailable, no read, no fallback offset.
+        guard let locator = provenance.locator else {
+            citedFrame.state = .unavailable
+            return
+        }
+
+        let workspaceID = activeWorkspace.id
+        let expectedGeneration = startGeneration
+
+        if isViewingSavedCapture {
+            startSavedCitedFrameRead(
+                sessionID: sessionID, provenance: provenance,
+                requestID: requestID, workspaceID: workspaceID, expectedGeneration: expectedGeneration
+            )
+        } else {
+            startLiveCitedFrameRead(
+                sessionID: sessionID, provenance: provenance, locator: locator,
+                requestID: requestID, workspaceID: workspaceID, expectedGeneration: expectedGeneration
+            )
+        }
+    }
+
+    /// Cancel and clear only the cited-frame slot (a selection change or explicit
+    /// clear). The projection is left to its own refresh path.
+    func cancelCitedFrame() {
+        citedFrame.task?.cancel()
+        citedFrame.task = nil
+        citedFrame.requestID &+= 1
+        citedFrame.state = .idle
+    }
+
+    /// Retire both evidence-navigation pipelines at a capture/source/clear boundary so
+    /// stale projection and cited-frame state can never outlive the source they
+    /// described.
+    func clearEvidenceNavigation() {
+        evidenceProjection.task?.cancel()
+        evidenceProjection.task = nil
+        evidenceProjection.requestID &+= 1
+        evidenceProjection.selection = nil
+        cancelCitedFrame()
+    }
+
+    /// Test/diagnostic seam for the exact projection task handle; no timing sleeps.
+    func waitForEvidenceProjection() async {
+        let task = evidenceProjection.task
+        await task?.value
+    }
+
+    /// Test/diagnostic seam for the exact cited-frame task handle; no timing sleeps.
+    func waitForCitedFrame() async {
+        let task = citedFrame.task
+        await task?.value
+    }
+
+    /// The adopted saved file's identity, derived from any retained evidence
+    /// reference (all share the one opened file's identity). `nil` for live/idle
+    /// sources, so a cited-frame source-token validation cannot pass off-source.
+    var adoptedSavedCaptureIdentity: PcapFileIdentity? {
+        savedCaptureEvidence.values.first?.identity
+    }
+
+    // MARK: Internal publication
+
+    func publishSelectedSessionEvidenceProjection(
+        _ selection: SessionEvidenceSelection,
+        sessionID: UUID,
+        workspaceID: UUID,
+        requestID: Int,
+        expectedGeneration: Int
+    ) {
+        guard requestID == evidenceProjection.requestID,
+              activeWorkspace.id == workspaceID,
+              activeWorkspace.selectedSessionID == sessionID,
+              startGeneration == expectedGeneration else
+        {
+            return
+        }
+        evidenceProjection.selection = selection
+        evidenceProjection.task = nil
+    }
+
+    // MARK: Private
+
+    private func startSavedCitedFrameRead(
+        sessionID: UUID,
+        provenance: SessionFrameProvenance,
+        requestID: Int,
+        workspaceID: UUID,
+        expectedGeneration: Int
+    ) {
+        guard let url = savedCaptureEvidenceURL, let identity = adoptedSavedCaptureIdentity else {
+            citedFrame.state = .failed(Self.citedFrameSourceUnavailableMessage)
+            return
+        }
+        // Validate the locator's source token against the adopted identity before
+        // constructing the exact reference; the byte-level identity/length/overrun
+        // checks stay in `CaptureEvidenceReader`.
+        let reference: CaptureEvidenceReference
+        do {
+            reference = try SavedCaptureStreamLoader.citedEvidenceReference(for: provenance, matching: identity)
+        } catch {
+            citedFrame.state = .failed(Self.citedFrameMessage(for: error))
+            return
+        }
+        citedFrame.state = .loading(provenance)
+        let task = Task.detached(priority: .userInitiated) { [weak self] in
+            do {
+                let bytes = try CaptureEvidenceReader.read(reference, from: url)
+                try Task.checkCancellation()
+                let evidence = Self.decodeCitedFrame(sessionID: sessionID, provenance: provenance, bytes: bytes)
+                await self?.finishCitedFrame(
+                    evidence, sessionID: sessionID, workspaceID: workspaceID,
+                    requestID: requestID, expectedGeneration: expectedGeneration,
+                    source: .saved(url: url, identity: identity)
+                )
+            } catch is CancellationError {
+                // Superseded or cleared: nothing to publish.
+            } catch {
+                await self?.failCitedFrame(
+                    Self.citedFrameMessage(for: error), sessionID: sessionID,
+                    workspaceID: workspaceID, requestID: requestID,
+                    expectedGeneration: expectedGeneration,
+                    source: .saved(url: url, identity: identity),
+                    provenance: provenance
+                )
+            }
+        }
+        citedFrame.task = task
+    }
+
+    private func startLiveCitedFrameRead(
+        sessionID: UUID,
+        provenance: SessionFrameProvenance,
+        locator: SessionEvidenceLocator,
+        requestID: Int,
+        workspaceID: UUID,
+        expectedGeneration: Int
+    ) {
+        // A finite single-frame spool read is allowed during active capture: the
+        // actor validates epoch, source token, synchronized size and exact length. It
+        // does not copy or scan the spool and does not change Follow Stream eligibility.
+        let spool = liveCaptureSpool
+        let capturedLength = provenance.capturedLength
+        citedFrame.state = .loading(provenance)
+        let task = Task.detached(priority: .userInitiated) { [weak self] in
+            do {
+                // The coordinator generation advances when a live capture stops,
+                // while the finalized spool and its locators intentionally remain
+                // the same source. Validate against that source's opaque token;
+                // publication still uses the stopped/current generation guards.
+                let bytes = try await spool.readCurrentSource(locator, capturedLength: capturedLength)
+                try Task.checkCancellation()
+                let evidence = Self.decodeCitedFrame(sessionID: sessionID, provenance: provenance, bytes: bytes)
+                await self?.finishCitedFrame(
+                    evidence, sessionID: sessionID, workspaceID: workspaceID,
+                    requestID: requestID, expectedGeneration: expectedGeneration,
+                    source: .live(generation: expectedGeneration)
+                )
+            } catch is CancellationError {
+                // Superseded or cleared: nothing to publish.
+            } catch {
+                await self?.failCitedFrame(
+                    Self.citedFrameMessage(for: error), sessionID: sessionID,
+                    workspaceID: workspaceID, requestID: requestID,
+                    expectedGeneration: expectedGeneration,
+                    source: .live(generation: expectedGeneration),
+                    provenance: provenance
+                )
+            }
+        }
+        citedFrame.task = task
+    }
+
+    private func finishCitedFrame(
+        _ evidence: SelectedFrameEvidence,
+        sessionID: UUID,
+        workspaceID: UUID,
+        requestID: Int,
+        expectedGeneration: Int,
+        source: CitedFrameSource
+    ) {
+        guard requestID == citedFrame.requestID,
+              activeWorkspace.id == workspaceID,
+              activeWorkspace.selectedSessionID == sessionID,
+              startGeneration == expectedGeneration,
+              currentSourceMatches(source),
+              case let .loading(pending) = citedFrame.state,
+              pending == evidence.provenance else
+        {
+            return
+        }
+        citedFrame.state = .loaded(evidence)
+        citedFrame.task = nil
+    }
+
+    private func failCitedFrame(
+        _ message: String,
+        sessionID: UUID,
+        workspaceID: UUID,
+        requestID: Int,
+        expectedGeneration: Int,
+        source: CitedFrameSource,
+        provenance: SessionFrameProvenance
+    ) {
+        guard requestID == citedFrame.requestID,
+              activeWorkspace.id == workspaceID,
+              activeWorkspace.selectedSessionID == sessionID,
+              startGeneration == expectedGeneration,
+              currentSourceMatches(source),
+              case let .loading(pending) = citedFrame.state,
+              pending == provenance else
+        {
+            return
+        }
+        citedFrame.state = .failed(message)
+        citedFrame.task = nil
+    }
+
+    /// Re-check the source kind/URL/identity a read was started against.
+    private func currentSourceMatches(_ source: CitedFrameSource) -> Bool {
+        switch source {
+        case let .saved(url, identity):
+            isViewingSavedCapture
+                && savedCaptureEvidenceURL == url
+                && adoptedSavedCaptureIdentity == identity
+        case .live:
+            !isViewingSavedCapture
+        }
+    }
+
+    nonisolated private static func decodeCitedFrame(
+        sessionID: UUID,
+        provenance: SessionFrameProvenance,
+        bytes: [UInt8]
+    )
+        -> SelectedFrameEvidence
+    {
+        let frame = CapturedFrame(
+            bytes: bytes,
+            timestamp: provenance.timestamp,
+            originalLength: provenance.originalLength,
+            capturedLength: provenance.capturedLength,
+            linkType: provenance.linkType
+        )
+        let packet = SessionBuilder.decodePacket(frame, linkType: provenance.linkType)
+        return SelectedFrameEvidence(
+            sessionID: sessionID, provenance: provenance, bytes: bytes, layers: packet.layers
+        )
+    }
+
+    // MARK: Neutral copy
+
+    static var citedFrameSourceUnavailableMessage: String {
+        "The capture source for this evidence is unavailable."
+    }
+
+    /// Map an error to neutral copy that reveals no path or internal source token.
+    nonisolated private static func citedFrameMessage(for error: Error) -> String {
+        if let referenceError = error as? CitedFrameReferenceError {
+            switch referenceError {
+            case .sourceTokenMismatch:
+                return "This citation belongs to a different capture source."
+            case .missingLocator:
+                return "This observation has no navigable local frame."
+            }
+        }
+        if let spoolFailure = error as? LiveCaptureSpool.Failure, case .staleEvidence = spoolFailure {
+            return "The requested capture evidence is no longer available."
+        }
+        return "The cited frame is no longer available in the current capture source."
+    }
+}

--- a/Tracexy/ViewModels/MainContentCoordinator+SavedCaptureOpening.swift
+++ b/Tracexy/ViewModels/MainContentCoordinator+SavedCaptureOpening.swift
@@ -255,6 +255,10 @@ extension MainContentCoordinator {
         isLoadingSelectedSessionEvidence = false
         selectedSessionEvidenceError = nil
 
+        // A capture/source/clear/new-open boundary also retires the evidence-navigation
+        // projection and any raw cited-frame state so neither outlives its source.
+        clearEvidenceNavigation()
+
         if clearPublishedEvidence {
             savedCaptureEvidence = [:]
             savedCaptureEvidenceURL = nil
@@ -415,6 +419,9 @@ extension MainContentCoordinator {
         selectSidebarItem(.sessions)
         followLatestVisibleSession(acceptedSessionIDs: Set(sessions.map(\.id)))
         loadSelectedSavedCaptureEvidence()
+        // The auto-followed selection was set after `adoptInvestigation` above, so
+        // rebuild the projection for whatever row Follow Live landed on.
+        refreshSelectedSessionEvidenceProjection()
 
         // The single saved History write hook: only after both the request and
         // start-generation guards above passed and the result was atomically

--- a/Tracexy/ViewModels/MainContentCoordinator.swift
+++ b/Tracexy/ViewModels/MainContentCoordinator.swift
@@ -23,11 +23,15 @@ final class MainContentCoordinator {
         layoutPreferences: WorkspaceLayoutPreferences? = nil,
         sessionStore: SessionStore? = nil,
         isHistoryDemoMode: Bool = false,
-        historyNow: @escaping @Sendable () -> Date = { Date() }
+        historyNow: @escaping @Sendable () -> Date = { Date() },
+        liveCaptureSpool: LiveCaptureSpool? = nil
     ) {
         self.sessionStore = sessionStore
         self.isHistoryDemoMode = isHistoryDemoMode
         self.historyNow = historyNow
+        self.liveCaptureSpool = liveCaptureSpool ?? LiveCaptureSpool(
+            directoryName: TracexyIdentity.current.appSupportDirectoryName
+        )
         let resolvedPolicy = policy ?? DefaultAppPolicy()
         self.policy = resolvedPolicy
         focusGate = FocusPolicyGate(
@@ -213,6 +217,16 @@ final class MainContentCoordinator {
     var selectedSessionEvidenceRequestID = 0
     var selectedSessionEvidenceTask: Task<Void, Never>?
 
+    // MARK: Evidence navigation (U2D1)
+
+    // The selected session's presentation-neutral connection/TLS projection and the
+    // one explicitly cited frame, each with its own request/task pipeline. Native
+    // inspector surfaces consume these bounded values without rescanning the immutable
+    // snapshot. Both are retired at every selection/capture/source boundary so stale
+    // evidence can never outlive the selection or source it described.
+    var evidenceProjection = EvidenceProjectionPipeline()
+    var citedFrame = CitedFramePipeline()
+
     /// Explicit, selection-scoped Follow Stream state. Raw application bytes enter
     /// coordinator memory only after the user requests this operation and are
     /// retired at every selection/capture/source boundary.
@@ -349,9 +363,7 @@ final class MainContentCoordinator {
 
     /// Complete local raw-frame retention for save/export. The in-memory frame
     /// window remains bounded independently for responsive UI.
-    let liveCaptureSpool = LiveCaptureSpool(
-        directoryName: TracexyIdentity.current.appSupportDirectoryName
-    )
+    let liveCaptureSpool: LiveCaptureSpool
     /// Serializes engine access so batches fold in arrival order even though each
     /// call hops onto the engine actor, and so a boundary reset is ordered ahead
     /// of the ingests that follow it.
@@ -369,21 +381,19 @@ final class MainContentCoordinator {
     /// The immutable passive connection-table snapshot for the current capture,
     /// published in lock-step with ``sessions`` behind the same generation guard.
     ///
-    /// Non-visual in this package: no View reads or displays it. It is additive
-    /// evidence adopted alongside the session summaries and reset to an empty
-    /// snapshot at every capture boundary so stale connection state can never
-    /// outlive the capture it described.
+    /// It is additive evidence adopted alongside the session summaries and reset
+    /// to an empty snapshot at every capture boundary so stale connection state
+    /// can never outlive the capture it described.
     private(set) var connectionSnapshot = ConnectionTable.Snapshot.empty
 
     /// The immutable passive connection *analysis* for the current capture,
     /// published in lock-step with ``connectionSnapshot`` and ``sessions`` behind
     /// the same generation guard, and only ever through ``adoptInvestigation``.
     ///
-    /// Non-visual in this package: no View reads or displays it. It is the exact
-    /// N3A2a assessment of ``connectionSnapshot`` — never re-derived on the main
-    /// actor — adopted alongside the session summaries and reset to the empty
-    /// analysis at every capture boundary so stale findings can never outlive the
-    /// capture they described.
+    /// This is the exact N3A2a assessment of ``connectionSnapshot`` — never
+    /// re-derived on the main actor — adopted alongside the session summaries and
+    /// reset to the empty analysis at every capture boundary so stale findings can
+    /// never outlive the capture they described.
     private(set) var connectionAnalysisSnapshot = ConnectionAnalysisSnapshot.empty
 
     /// The immutable passive *datagram* analysis for the current capture, published
@@ -391,11 +401,10 @@ final class MainContentCoordinator {
     /// ``sessions`` behind the same generation guard, and only ever through
     /// ``adoptInvestigation``.
     ///
-    /// Non-visual in this package: no View reads or displays it. It is the exact
-    /// N3B3a assessment of the same fold's datagram evidence — never re-derived on
-    /// the main actor — adopted alongside the connection evidence/analysis and reset
-    /// to the empty analysis at every capture boundary so stale findings can never
-    /// outlive the capture they described.
+    /// This is the exact N3B3a assessment of the same fold's datagram evidence —
+    /// never re-derived on the main actor — adopted alongside the connection
+    /// evidence/analysis and reset to the empty analysis at every capture boundary
+    /// so stale findings can never outlive the capture they described.
     private(set) var datagramAnalysisSnapshot = DatagramAnalysisSnapshot.empty
 
     /// The complete immutable query input matching the currently published sessions
@@ -782,6 +791,7 @@ final class MainContentCoordinator {
         cancelFollowStream(clearResult: true)
         activeWorkspace.selectedSessionID = session.id
         loadSelectedSavedCaptureEvidence()
+        evidenceNavigationDidChangeSelection()
         revealPanelsForSelection()
     }
 
@@ -805,6 +815,7 @@ final class MainContentCoordinator {
         connectionAnalysisSnapshot = snapshot.connectionAnalysis
         datagramAnalysisSnapshot = snapshot.datagramAnalysis
         refreshActiveInvestigationQueries()
+        refreshSelectedSessionEvidenceProjection()
     }
 
     // MARK: Search

--- a/Tracexy/Views/Inspector/ContextDockView.swift
+++ b/Tracexy/Views/Inspector/ContextDockView.swift
@@ -161,6 +161,16 @@ struct ContextDockView: View {
                             }
                         }
 
+                        if let evidence = selectedEvidence(for: session) {
+                            SessionEvidenceContextSummaryView(selection: evidence) {
+                                let workspace = coordinator.activeWorkspace
+                                workspace.inspectorTab = .evidence
+                                if workspace.inspectorLayout == .hidden {
+                                    coordinator.toggleInspectorBottom()
+                                }
+                            }
+                        }
+
                         // State B leads with how the action spent its time; state A
                         // has a single span, so its own layer's facts lead instead.
                         if let activity, activity.sessions.count > 1 {
@@ -260,6 +270,18 @@ struct ContextDockView: View {
                     detail: finding.subtitle,
                     color: finding.severity.tint
                 )
+                if !finding.citedFrames.isEmpty {
+                    ContextInspectorFullRow {
+                        Menu("Inspect Citation") {
+                            ForEach(Array(finding.citedFrames.enumerated()), id: \.offset) { _, provenance in
+                                Button("Frame \(provenance.ordinal.rawValue.formatted())") {
+                                    inspectCitation(provenance, for: session)
+                                }
+                            }
+                        }
+                        .controlSize(.small)
+                    }
+                }
             }
         }
     }
@@ -568,6 +590,24 @@ struct ContextDockView: View {
         case .tls: "TLS handshake"
         case .tcp: "TCP connect"
         default: proto.label
+        }
+    }
+
+    private func selectedEvidence(for session: SessionSummary) -> SessionEvidenceSelection? {
+        guard let selection = coordinator.evidenceProjection.selection,
+              selection.sessionID == session.id else
+        {
+            return nil
+        }
+        return selection
+    }
+
+    private func inspectCitation(_ provenance: SessionFrameProvenance, for session: SessionSummary) {
+        coordinator.inspectCitedFrame(sessionID: session.id, provenance: provenance)
+        let workspace = coordinator.activeWorkspace
+        workspace.inspectorTab = .layers
+        if workspace.inspectorLayout == .hidden {
+            coordinator.toggleInspectorBottom()
         }
     }
 

--- a/Tracexy/Views/Inspector/InspectorView.swift
+++ b/Tracexy/Views/Inspector/InspectorView.swift
@@ -14,40 +14,35 @@ struct InspectorView: View {
         // Progressive disclosure: only the facets relevant to this session are
         // shown, and the active tab falls back to Timeline if the persisted
         // selection is hidden for the newly-selected session.
-        let visibleTabs = session.map { InspectorTab.visibleTabs(for: $0) } ?? []
+        let visibleTabs = session.map { resolvedVisibleTabs(for: $0) } ?? []
         let activeTab = visibleTabs.contains(workspace.inspectorTab) ? workspace.inspectorTab : .timeline
-        Group {
+        VStack(spacing: 0) {
             if let session {
-                if activeTab == .layers {
-                    layersInspector(session)
+                inspectorChrome(
+                    workspace: workspace,
+                    visibleTabs: visibleTabs,
+                    activeTab: activeTab,
+                    session: session
+                )
+            }
+            Group {
+                if let session {
+                    if activeTab == .layers {
+                        layersInspector(session)
+                    } else {
+                        ScrollView {
+                            content(tab: activeTab, session: session)
+                                .padding(Theme.Metrics.spacingL)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                        }
+                    }
                 } else {
-                    ScrollView {
-                        content(tab: activeTab, session: session)
-                            .padding(Theme.Metrics.spacingL)
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                    }
-                }
-            } else {
-                ContentUnavailableView("No Session Selected", systemImage: "rectangle.dashed")
-                    .frame(maxWidth: .infinity, maxHeight: .infinity)
-            }
-        }
-        .tracexyDenseScrollEdge()
-        .tracexySafeAreaBar(edge: .top) {
-            if let session {
-                VStack(spacing: 0) {
-                    // Facet tabs and scope remain one compact functional row.
-                    tabStrip(
-                        workspace: workspace,
-                        visibleTabs: visibleTabs,
-                        activeTab: activeTab,
-                        session: session
-                    )
-                    if supportsFieldFilter(activeTab) {
-                        fieldFilterRow
-                    }
+                    ContentUnavailableView("No Session Selected", systemImage: "rectangle.dashed")
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
                 }
             }
+            .tracexyDenseScrollEdge()
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
         // Claim the full width here, on the pane itself.
         //
@@ -71,7 +66,7 @@ struct InspectorView: View {
             coordinator.loadSelectedSavedCaptureEvidence()
             // Reconcile the persisted tab so the picker never shows a hidden facet.
             if let session = coordinator.selectedSession,
-               !InspectorTab.visibleTabs(for: session).contains(workspace.inspectorTab)
+               !resolvedVisibleTabs(for: session).contains(workspace.inspectorTab)
             {
                 workspace.inspectorTab = .timeline
             }
@@ -84,12 +79,78 @@ struct InspectorView: View {
     @State private var selectedRange: Range<Int>?
     @State private var followStreamDisplayMode: FollowStreamDisplayMode = .text
 
-    private var fieldFilterRow: some View {
+    private var selectedEvidence: SessionEvidenceSelection? {
+        guard let selection = coordinator.evidenceProjection.selection,
+              selection.sessionID == coordinator.activeWorkspace.selectedSessionID else
+        {
+            return nil
+        }
+        return selection
+    }
+
+    private var selectedCitedFrame: SelectedFrameEvidence? {
+        guard case let .loaded(evidence) = coordinator.citedFrame.state,
+              evidence.sessionID == coordinator.activeWorkspace.selectedSessionID else
+        {
+            return nil
+        }
+        return evidence
+    }
+
+    private var citedFrameStateIsActive: Bool {
+        if case .idle = coordinator.citedFrame.state {
+            return false
+        }
+        return true
+    }
+
+    private var citedFrameScopeRow: some View {
+        HStack(spacing: Theme.Metrics.spacingS) {
+            Image(systemName: "scope")
+                .foregroundStyle(.secondary)
+            switch coordinator.citedFrame.state {
+            case .idle:
+                EmptyView()
+            case .unavailable:
+                Text("Exact cited frame unavailable")
+            case let .loading(provenance):
+                ProgressView()
+                    .controlSize(.mini)
+                Text("Loading cited frame \(provenance.ordinal.rawValue.formatted())…")
+            case let .loaded(evidence):
+                Text("Cited frame \(evidence.provenance.ordinal.rawValue.formatted())")
+                    .font(Theme.Typography.captionMedium)
+                Text("· \(evidence.bytes.count.formatted()) captured bytes")
+                    .foregroundStyle(.secondary)
+            case let .failed(message):
+                Text(message)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            }
+            Spacer(minLength: Theme.Metrics.spacingM)
+            Button("Clear Citation") {
+                coordinator.cancelCitedFrame()
+            }
+            .controlSize(.small)
+        }
+        .font(Theme.Typography.caption)
+        .padding(.horizontal, Theme.Metrics.spacingM)
+        .padding(.vertical, 5)
+        .background(.quaternary.opacity(0.35))
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("Cited frame scope")
+    }
+
+    /// Decode-tree filtering is a compact Layers utility, not another full-width
+    /// sticky row. Keeping it inside the tab chrome preserves the scarce vertical
+    /// viewport when an exact citation also needs its own visible scope row.
+    private var layerFilterControl: some View {
         HStack(spacing: 5) {
             Image(systemName: "magnifyingglass").foregroundStyle(.secondary).font(.system(size: Theme.Icon.small))
             TextField("Filter key or value", text: $fieldQuery)
                 .textFieldStyle(.plain)
                 .font(Theme.Typography.caption)
+                .accessibilityLabel("Filter decoded fields")
             if !fieldQuery.isEmpty {
                 Button { fieldQuery = "" } label: { Image(systemName: "xmark.circle.fill") }
                     .buttonStyle(.plain).foregroundStyle(.secondary)
@@ -99,7 +160,7 @@ struct InspectorView: View {
         }
         .padding(.horizontal, 8).padding(.vertical, 5)
         .tracexyContentSurface(in: Capsule(style: .continuous))
-        .padding(.horizontal, Theme.Glass.functionalBarHorizontalInset)
+        .frame(minWidth: 180, idealWidth: 240, maxWidth: 280)
     }
 
     private var followStreamLoading: some View {
@@ -136,6 +197,34 @@ struct InspectorView: View {
         .tracexyContentSurface(
             in: RoundedRectangle(cornerRadius: Theme.Metrics.cornerRadius, style: .continuous)
         )
+    }
+
+    /// The bottom inspector hosts AppKit-backed split content. Native
+    /// `safeAreaBar` allows that content to continue underneath the bar, but
+    /// nested split scroll views do not consume the propagated inset and their
+    /// scrollbars end up behind the chrome. Keep this header in normal layout so
+    /// the decode and hex panes begin strictly below it.
+    private func inspectorChrome(
+        workspace: WorkspaceState,
+        visibleTabs: [InspectorTab],
+        activeTab: InspectorTab,
+        session: SessionSummary
+    )
+        -> some View
+    {
+        VStack(spacing: 0) {
+            tabStrip(
+                workspace: workspace,
+                visibleTabs: visibleTabs,
+                activeTab: activeTab,
+                session: session
+            )
+            if activeTab != .evidence, citedFrameStateIsActive {
+                citedFrameScopeRow
+            }
+            Divider()
+        }
+        .background(Color(nsColor: .windowBackgroundColor))
     }
 
     /// What the pane is currently describing, stated at the right of the tab row.
@@ -175,8 +264,20 @@ struct InspectorView: View {
     /// the horizontal space deliberately.
     @ViewBuilder
     private func layersInspector(_ session: SessionSummary) -> some View {
-        let layers = filterLayers(session.decodedLayers, query: fieldQuery)
-        if session.decodedLayers.isEmpty {
+        let sourceLayers = selectedCitedFrame?.layers ?? session.decodedLayers
+        let layers = filterLayers(sourceLayers, query: fieldQuery)
+        if case .loading = coordinator.citedFrame.state {
+            ProgressView("Loading cited frame…")
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else if case .unavailable = coordinator.citedFrame.state {
+            placeholder("This observation has no exact source locator. No replacement frame was loaded.")
+                .padding(Theme.Metrics.spacingL)
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        } else if case let .failed(message) = coordinator.citedFrame.state {
+            placeholder(message)
+                .padding(Theme.Metrics.spacingL)
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        } else if sourceLayers.isEmpty {
             placeholder("No decode available for this session.")
                 .padding(Theme.Metrics.spacingL)
                 .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
@@ -204,7 +305,7 @@ struct InspectorView: View {
 
     @ViewBuilder
     private func hexPane(_ session: SessionSummary) -> some View {
-        let bytes = coordinator.evidenceBytes(for: session)
+        let bytes = evidenceBytes(for: session)
         if !bytes.isEmpty {
             ScrollView {
                 HexDumpView(bytes: bytes, highlight: selectedRange)
@@ -240,23 +341,22 @@ struct InspectorView: View {
     )
         -> some View
     {
-        // Wide: tabs and the scope pill share one row. Compact: the tabs scroll
-        // horizontally and the scope drops to a second row, so neither clips when
-        // the pane is narrow (e.g. while the right inspector is also open).
-        ViewThatFits(in: .horizontal) {
-            HStack(spacing: 2) {
-                tabButtons(workspace: workspace, visibleTabs: visibleTabs, activeTab: activeTab)
-                Spacer(minLength: Theme.Metrics.spacingL)
-                scopeLabel(session)
-            }
-            VStack(alignment: .leading, spacing: 6) {
-                ScrollView(.horizontal, showsIndicators: false) {
-                    HStack(spacing: 2) {
-                        tabButtons(workspace: workspace, visibleTabs: visibleTabs, activeTab: activeTab)
+        // Tabs and the optional Layers filter always share one horizontally
+        // scrollable row. The scope stays visible at the trailing edge, so even
+        // compact panes add no extra sticky row above an exact citation.
+        HStack(spacing: Theme.Metrics.spacingM) {
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: 2) {
+                    tabButtons(workspace: workspace, visibleTabs: visibleTabs, activeTab: activeTab)
+                    if activeTab == .layers {
+                        layerFilterControl
+                            .padding(.leading, Theme.Metrics.spacingS)
                     }
                 }
-                scopeLabel(session)
             }
+            .layoutPriority(1)
+            scopeLabel(session)
+                .frame(minWidth: 140, idealWidth: 240, maxWidth: 320, alignment: .trailing)
         }
         .padding(.horizontal, Theme.Metrics.spacingM)
         .padding(.vertical, 6)
@@ -291,10 +391,50 @@ struct InspectorView: View {
         switch tab {
         case .layers: EmptyView() // routed to layersInspector (linked tree + hex)
         case .timeline: timeline(session)
+        case .evidence: sessionEvidence(session)
         case .stream: followStream(session)
         case .requests: requests(session)
         case .payload: payload(session)
         case .hex: rawEvidence(session)
+        }
+    }
+
+    // MARK: Connection and TLS evidence
+
+    @ViewBuilder
+    private func sessionEvidence(_ session: SessionSummary) -> some View {
+        if let selection = selectedEvidence {
+            SessionEvidenceTimelineView(
+                selection: selection,
+                selectedFrameOrdinal: selectedCitedFrame?.provenance.ordinal,
+                isLoadingFrame: {
+                    if case .loading = coordinator.citedFrame.state {
+                        return true
+                    }
+                    return false
+                }(),
+                frameError: {
+                    if case let .failed(message) = coordinator.citedFrame.state {
+                        return message
+                    }
+                    return nil
+                }(),
+                frameUnavailable: {
+                    if case .unavailable = coordinator.citedFrame.state {
+                        return true
+                    }
+                    return false
+                }(),
+                inspectFrame: { provenance in
+                    coordinator.inspectCitedFrame(sessionID: session.id, provenance: provenance)
+                    coordinator.activeWorkspace.inspectorTab = .layers
+                    selectedRange = nil
+                }
+            )
+        } else if coordinator.evidenceProjection.task != nil {
+            ProgressView("Preparing retained evidence…")
+        } else {
+            placeholder("No retained connection or direct-frame TLS evidence is available for this session.")
         }
     }
 
@@ -510,8 +650,14 @@ struct InspectorView: View {
     /// hex, and the fastest way to confirm what a body actually was.
     @ViewBuilder
     private func payload(_ session: SessionSummary) -> some View {
-        let text = printablePayload(coordinator.evidenceBytes(for: session))
-        if coordinator.isLoadingSelectedSessionEvidence {
+        let text = printablePayload(evidenceBytes(for: session))
+        if case .loading = coordinator.citedFrame.state {
+            ProgressView("Loading cited frame…")
+        } else if case .unavailable = coordinator.citedFrame.state {
+            placeholder("This observation has no exact source locator. No replacement frame was loaded.")
+        } else if case let .failed(message) = coordinator.citedFrame.state {
+            placeholder(message)
+        } else if coordinator.isLoadingSelectedSessionEvidence {
             ProgressView("Loading selected evidence…")
         } else if let error = coordinator.selectedSessionEvidenceError {
             placeholder(error)
@@ -527,8 +673,14 @@ struct InspectorView: View {
 
     @ViewBuilder
     private func rawEvidence(_ session: SessionSummary) -> some View {
-        let bytes = coordinator.evidenceBytes(for: session)
-        if !bytes.isEmpty {
+        let bytes = evidenceBytes(for: session)
+        if case .loading = coordinator.citedFrame.state {
+            ProgressView("Loading cited frame…")
+        } else if case .unavailable = coordinator.citedFrame.state {
+            placeholder("This observation has no exact source locator. No replacement frame was loaded.")
+        } else if case let .failed(message) = coordinator.citedFrame.state {
+            placeholder(message)
+        } else if !bytes.isEmpty {
             HexDumpView(bytes: bytes, highlight: nil)
         } else if coordinator.isLoadingSelectedSessionEvidence {
             ProgressView("Loading selected evidence…")
@@ -692,9 +844,25 @@ struct InspectorView: View {
     // Plain-language verdict for the top of the Summary tab, e.g.
     // "TLS to api.example.com · 142 ms · 2 protocols · OK".
 
-    /// The "Filter key or value" field applies to the decode tree.
-    private func supportsFieldFilter(_ tab: InspectorTab) -> Bool {
-        tab == .layers
+    private func resolvedVisibleTabs(for session: SessionSummary) -> [InspectorTab] {
+        let hasEvidence = selectedEvidence.map { selection in
+            !selection.isEmpty
+                || selection.connectionCoverage.omittedSummaryCount > 0
+                || selection.connectionCoverage.countersOverflowed
+                || selection.tlsCoverage.capacityReached
+                || selection.tlsCoverage.countersOverflowed
+                || selection.tlsCoverage.omittedObservationCount > 0
+                || selection.tlsCoverage.excludedReassembledRecordCount > 0
+        } ?? false
+        var tabs = InspectorTab.visibleTabs(for: session, hasSessionEvidence: hasEvidence)
+        if citedFrameStateIsActive, !tabs.contains(.layers), let evidenceIndex = tabs.firstIndex(of: .evidence) {
+            tabs.insert(.layers, at: tabs.index(after: evidenceIndex))
+        }
+        return tabs
+    }
+
+    private func evidenceBytes(for session: SessionSummary) -> [UInt8] {
+        selectedCitedFrame?.bytes ?? coordinator.evidenceBytes(for: session)
     }
 
     /// Prunes the decode tree to layers/fields matching the field-filter query.

--- a/Tracexy/Views/Inspector/SessionEvidenceContextSummaryView.swift
+++ b/Tracexy/Views/Inspector/SessionEvidenceContextSummaryView.swift
@@ -1,0 +1,171 @@
+import SwiftUI
+
+// MARK: - SessionEvidenceContextSummaryView
+
+/// Compact right-dock explanation of the retained connection/TLS model. The
+/// complete chronological observations stay in the bottom Evidence facet; this
+/// view names the scope, coverage, and route to those literal citations.
+struct SessionEvidenceContextSummaryView: View {
+    // MARK: Internal
+
+    let selection: SessionEvidenceSelection
+    let openEvidence: () -> Void
+
+    var body: some View {
+        if !selection.connections.isEmpty {
+            ContextInspectorFieldTable(
+                title: "Connection Evidence",
+                fields: connectionFields
+            )
+        }
+
+        if let tls = selection.tls {
+            ContextInspectorFieldTable(
+                title: "TLS Evidence",
+                fields: tlsFields(tls)
+            )
+        }
+
+        if !selection.isEmpty || hasGlobalCoverageCaveat {
+            ContextInspectorTable(title: "Evidence Navigation") {
+                ContextInspectorFullRow {
+                    VStack(alignment: .leading, spacing: Theme.Metrics.spacingS) {
+                        Text(navigationExplanation)
+                            .font(Theme.Typography.caption)
+                            .foregroundStyle(.secondary)
+                            .fixedSize(horizontal: false, vertical: true)
+                        Button("Open Evidence") {
+                            openEvidence()
+                        }
+                        .controlSize(.small)
+                        .help("Show retained connection and TLS observations in capture order")
+                    }
+                }
+            }
+        }
+    }
+
+    // MARK: Private
+
+    private var connectionFields: [ContextTableField] {
+        let connections = selection.connections
+        var fields = [
+            ContextTableField(
+                label: connections.count == 1 ? "Connection" : "Incarnations",
+                value: connections.count.formatted()
+            ),
+            ContextTableField(
+                label: "Retained Events",
+                value: connections.reduce(0) { $0 + $1.events.count }.formatted()
+            ),
+        ]
+
+        if connections.count == 1, let connection = connections.first {
+            fields.append(ContextTableField(
+                label: "Phase",
+                value: SessionEvidenceCopy.phaseLabel(connection.phase),
+                monospaced: false
+            ))
+            fields.append(ContextTableField(
+                label: "Handshake",
+                value: SessionEvidenceCopy.handshakeLabel(connection.handshake),
+                monospaced: false
+            ))
+            if let close = SessionEvidenceCopy.closeReasonLabel(connection.closeReason) {
+                fields.append(ContextTableField(
+                    label: "Close",
+                    value: close,
+                    monospaced: false
+                ))
+            }
+        } else {
+            fields.append(ContextTableField(
+                label: "Scope",
+                value: "Sequential tuple reuse; TLS evidence remains shared at session scope",
+                monospaced: false
+            ))
+        }
+
+        let omitted = connections.enumerated().compactMap { index, connection -> String? in
+            guard connection.omittedEventCount > 0 else {
+                return nil
+            }
+            return connections.count == 1
+                ? connection.omittedEventCount.formatted()
+                : "#\(index + 1): \(connection.omittedEventCount.formatted())"
+        }
+        if !omitted.isEmpty {
+            fields.append(ContextTableField(
+                label: "Omitted Events",
+                value: omitted.joined(separator: " · ")
+            ))
+        }
+
+        let loss = Set(connections.map { SessionEvidenceCopy.lossLabel($0.lossKnowledge) })
+            .sorted()
+        fields.append(ContextTableField(
+            label: "Frame Coverage",
+            value: loss.joined(separator: " · "),
+            monospaced: false
+        ))
+        return fields
+    }
+
+    private var hasGlobalCoverageCaveat: Bool {
+        selection.connectionCoverage.omittedSummaryCount > 0
+            || selection.connectionCoverage.countersOverflowed
+            || selection.tlsCoverage.omittedObservationCount > 0
+            || selection.tlsCoverage.excludedReassembledRecordCount > 0
+            || selection.tlsCoverage.capacityReached
+            || selection.tlsCoverage.countersOverflowed
+    }
+
+    private var navigationExplanation: String {
+        if selection.isEmpty {
+            return "No exact session evidence was retained. Capture-level bounds still prevent treating that absence as proof."
+        }
+        return "Review retained observations in capture order, then load one cited frame from the current local source."
+    }
+
+    private func tlsFields(_ tls: TLSEvidenceSummary) -> [ContextTableField] {
+        var fields = [
+            ContextTableField(
+                label: "Direct Records",
+                value: tls.observations.count.formatted()
+            ),
+            ContextTableField(
+                label: "Frame Coverage",
+                value: SessionEvidenceCopy.lossLabel(tls.lossKnowledge),
+                monospaced: false
+            ),
+        ]
+        if tls.omittedObservationCount > 0 {
+            fields.append(ContextTableField(
+                label: "Omitted",
+                value: tls.omittedObservationCount.formatted()
+            ))
+        }
+        if tls.excludedReassembledRecordCount > 0 {
+            fields.append(ContextTableField(
+                label: "Not Citable",
+                value: "\(tls.excludedReassembledRecordCount.formatted()) reassembled records",
+                monospaced: false
+            ))
+        }
+        if tls.decoderTruncatedFrameCount > 0 {
+            fields.append(ContextTableField(
+                label: "Decode Bound",
+                value: "\(tls.decoderTruncatedFrameCount.formatted()) frames reached the record cap",
+                monospaced: false
+            ))
+        }
+        if tls.snapLengthTruncationObserved {
+            fields.append(ContextTableField(
+                label: "Snap Length",
+                value: "Truncation observed",
+                monospaced: false
+            ))
+        }
+        return fields
+    }
+}

--- a/Tracexy/Views/Inspector/SessionEvidenceTimelineView.swift
+++ b/Tracexy/Views/Inspector/SessionEvidenceTimelineView.swift
@@ -1,0 +1,300 @@
+import SwiftUI
+
+// MARK: - SessionEvidenceTimelineView
+
+/// Literal connection/TLS observations for one selected session. The list owns
+/// no IO: choosing a citation delegates the exact-frame request to the
+/// coordinator through `inspectFrame`.
+struct SessionEvidenceTimelineView: View {
+    // MARK: Internal
+
+    let selection: SessionEvidenceSelection
+    let selectedFrameOrdinal: FrameOrdinal?
+    let isLoadingFrame: Bool
+    let frameError: String?
+    let frameUnavailable: Bool
+    let inspectFrame: (SessionFrameProvenance) -> Void
+
+    var body: some View {
+        let items = SessionEvidenceItem.timeline(
+            connections: selection.connections,
+            tls: selection.tls
+        )
+        VStack(alignment: .leading, spacing: Theme.Metrics.spacingL) {
+            evidenceHeader(items: items)
+
+            if isLoadingFrame {
+                ProgressView("Loading cited frame…")
+                    .controlSize(.small)
+            } else if frameUnavailable {
+                evidenceNotice(
+                    "This observation has no exact source locator. No replacement frame was loaded.",
+                    systemImage: "location.slash"
+                )
+            } else if let frameError {
+                evidenceNotice(frameError, systemImage: "exclamationmark.triangle")
+            }
+
+            coverage
+
+            if items.isEmpty {
+                evidenceNotice(
+                    "No connection or direct-frame TLS observations were retained for this session. "
+                        + "Capture-level bounds below may still limit what can be concluded.",
+                    systemImage: "rectangle.dashed"
+                )
+            } else {
+                LazyVStack(alignment: .leading, spacing: 0) {
+                    ForEach(Array(items.enumerated()), id: \.element.id) { index, item in
+                        evidenceRow(item)
+                        if index < items.count - 1 {
+                            Divider()
+                                .padding(.leading, 34)
+                        }
+                    }
+                }
+                .padding(.horizontal, Theme.Metrics.spacingM)
+                .tracexyContentSurface(
+                    in: RoundedRectangle(
+                        cornerRadius: Theme.Metrics.cornerRadius,
+                        style: .continuous
+                    )
+                )
+            }
+        }
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("Retained session evidence")
+    }
+
+    // MARK: Private
+
+    private var tlsCoverage: [String] {
+        guard let tls = selection.tls else {
+            return []
+        }
+        var labels: [String] = []
+        if tls.omittedObservationCount > 0 {
+            labels.append("\(tls.omittedObservationCount.formatted()) direct TLS observations omitted")
+        }
+        if tls.excludedReassembledRecordCount > 0 {
+            labels.append(
+                "\(tls.excludedReassembledRecordCount.formatted()) reassembled TLS records excluded because exact frame provenance is incomplete"
+            )
+        }
+        if tls.recoveredTruncationIndicatorCount > 0 {
+            labels.append(
+                "\(tls.recoveredTruncationIndicatorCount.formatted()) recovered truncation indicators"
+            )
+        }
+        if tls.decoderTruncatedFrameCount > 0 {
+            labels.append(
+                "\(tls.decoderTruncatedFrameCount.formatted()) direct frames reached the TLS record decode bound"
+            )
+        }
+        if tls.snapLengthTruncationObserved {
+            labels.append("TLS-bearing snap-length truncation was observed")
+        }
+        if tls.lossKnowledge != .noLossReported {
+            labels.append(SessionEvidenceCopy.lossLabel(tls.lossKnowledge))
+        }
+        return labels
+    }
+
+    /// These counters describe the capture, not the selected session. The copy
+    /// keeps that scope explicit so a global omission is never attributed here.
+    private var captureCoverage: [String] {
+        var labels: [String] = []
+        let connection = selection.connectionCoverage
+        if connection.omittedSummaryCount > 0 {
+            labels.append(
+                "Capture-level: \(connection.omittedSummaryCount.formatted()) connection summaries omitted; this does not identify which sessions were affected"
+            )
+        }
+        if connection.countersOverflowed {
+            labels.append("Capture-level: a connection evidence counter saturated")
+        }
+
+        let tls = selection.tlsCoverage
+        if tls.omittedObservationCount > 0 {
+            labels.append(
+                "Capture-level: \(tls.omittedObservationCount.formatted()) direct TLS observations omitted"
+            )
+        }
+        if tls.excludedReassembledRecordCount > 0 {
+            labels.append(
+                "Capture-level: \(tls.excludedReassembledRecordCount.formatted()) reassembled TLS records excluded from exact citation"
+            )
+        }
+        if tls.decoderTruncatedFrameCount > 0 {
+            labels.append(
+                "Capture-level: \(tls.decoderTruncatedFrameCount.formatted()) TLS-bearing frames reached the record decode bound"
+            )
+        }
+        if tls.capacityReached {
+            labels.append("Capture-level: a TLS evidence retention bound was reached")
+        }
+        if tls.countersOverflowed {
+            labels.append("Capture-level: a TLS evidence counter saturated")
+        }
+        return labels
+    }
+
+    @ViewBuilder private var coverage: some View {
+        let connectionCaveats = selection.connections.enumerated().flatMap { index, connection in
+            connectionCoverage(connection, index: index)
+        }
+        let tlsCaveats = tlsCoverage
+        let globalCaveats = captureCoverage
+
+        if !connectionCaveats.isEmpty || !tlsCaveats.isEmpty || !globalCaveats.isEmpty {
+            VStack(alignment: .leading, spacing: Theme.Metrics.spacingS) {
+                Text("Coverage")
+                    .font(Theme.Typography.captionMedium)
+                    .foregroundStyle(.secondary)
+                ForEach(connectionCaveats + tlsCaveats, id: \.self) { caveat in
+                    Label(caveat, systemImage: "info.circle")
+                        .font(Theme.Typography.caption)
+                        .foregroundStyle(.secondary)
+                }
+                ForEach(globalCaveats, id: \.self) { caveat in
+                    Label(caveat, systemImage: "scope")
+                        .font(Theme.Typography.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .padding(Theme.Metrics.spacingM)
+            .tracexyContentSurface(
+                in: RoundedRectangle(
+                    cornerRadius: Theme.Metrics.cornerRadius,
+                    style: .continuous
+                )
+            )
+        }
+    }
+
+    private func evidenceHeader(items: [SessionEvidenceItem]) -> some View {
+        HStack(alignment: .firstTextBaseline, spacing: Theme.Metrics.spacingM) {
+            VStack(alignment: .leading, spacing: 3) {
+                Text("Connection & TLS Evidence")
+                    .font(Theme.Typography.bodyEmphasis)
+                Text(headerSummary(items: items))
+                    .font(Theme.Typography.caption)
+                    .foregroundStyle(.secondary)
+            }
+            Spacer(minLength: Theme.Metrics.spacingM)
+            Text("capture order")
+                .font(Theme.Typography.microMedium)
+                .padding(.horizontal, 7)
+                .padding(.vertical, 2)
+                .tracexyChipStyle(tint: .accentColor, isActive: false)
+        }
+    }
+
+    private func evidenceRow(_ item: SessionEvidenceItem) -> some View {
+        HStack(alignment: .top, spacing: Theme.Metrics.spacingM) {
+            Image(systemName: item.systemImage)
+                .font(.system(size: Theme.Icon.small))
+                .foregroundStyle(item.kind == .tls ? Theme.color(for: .tls) : Theme.color(for: .tcp))
+                .frame(width: 20, height: 20)
+
+            VStack(alignment: .leading, spacing: 3) {
+                HStack(spacing: Theme.Metrics.spacingS) {
+                    Text(item.title)
+                        .font(Theme.Typography.captionMedium)
+                    Text(item.categoryLabel)
+                        .font(Theme.Typography.microMedium)
+                        .foregroundStyle(.secondary)
+                }
+                Text(item.detail)
+                    .font(Theme.Typography.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+                HStack(spacing: Theme.Metrics.spacingS) {
+                    Text("Frame \(item.ordinal.rawValue.formatted())")
+                    Text("·")
+                    Text(item.timestamp.formatted(date: .omitted, time: .standard))
+                }
+                .font(Theme.Typography.monoSmall)
+                .foregroundStyle(.secondary)
+            }
+
+            Spacer(minLength: Theme.Metrics.spacingM)
+
+            citationButtons(item.provenance)
+        }
+        .padding(.vertical, Theme.Metrics.spacingM)
+        .accessibilityElement(children: .contain)
+    }
+
+    @ViewBuilder
+    private func citationButtons(_ citations: [SessionFrameProvenance]) -> some View {
+        if citations.count == 1, let citation = citations.first {
+            citationButton(citation, title: "Inspect Frame")
+        } else {
+            Menu("Inspect Frames") {
+                ForEach(Array(citations.enumerated()), id: \.offset) { _, citation in
+                    Button(
+                        citation.locator == nil
+                            ? "Frame \(citation.ordinal.rawValue.formatted()) — unavailable"
+                            : "Frame \(citation.ordinal.rawValue.formatted())"
+                    ) {
+                        inspectFrame(citation)
+                    }
+                }
+            }
+            .controlSize(.small)
+        }
+    }
+
+    private func citationButton(_ citation: SessionFrameProvenance, title: String) -> some View {
+        Button(title) {
+            inspectFrame(citation)
+        }
+        .controlSize(.small)
+        .disabled(isLoadingFrame)
+        .help(
+            citation.locator == nil
+                ? "This observation has no exact source locator"
+                : "Load only frame \(citation.ordinal.rawValue) from the current local capture"
+        )
+        .accessibilityValue(
+            selectedFrameOrdinal == citation.ordinal ? "Selected" : ""
+        )
+    }
+
+    private func evidenceNotice(_ text: String, systemImage: String) -> some View {
+        Label(text, systemImage: systemImage)
+            .font(Theme.Typography.caption)
+            .foregroundStyle(.secondary)
+            .fixedSize(horizontal: false, vertical: true)
+            .padding(Theme.Metrics.spacingM)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .tracexyContentSurface(
+                in: RoundedRectangle(
+                    cornerRadius: Theme.Metrics.cornerRadius,
+                    style: .continuous
+                )
+            )
+    }
+
+    private func headerSummary(items: [SessionEvidenceItem]) -> String {
+        let connectionLabel = selection.connections.count == 1
+            ? "1 connection"
+            : "\(selection.connections.count) connection incarnations"
+        let eventCount = items.count { $0.kind == .connection }
+        let tlsCount = items.count { $0.kind == .tls }
+        return "\(connectionLabel) · \(eventCount) TCP events · \(tlsCount) direct-frame TLS records"
+    }
+
+    private func connectionCoverage(_ connection: ConnectionSummary, index: Int) -> [String] {
+        let prefix = selection.connections.count > 1 ? "Connection \(index + 1): " : ""
+        var labels = SessionEvidenceCopy.limitationLabels(connection.limitations).map { prefix + $0 }
+        if connection.omittedEventCount > 0 {
+            labels.append(prefix + "\(connection.omittedEventCount.formatted()) older events omitted")
+        }
+        if connection.lossKnowledge != .noLossReported {
+            labels.append(prefix + SessionEvidenceCopy.lossLabel(connection.lossKnowledge))
+        }
+        return labels
+    }
+}

--- a/Tracexy/Views/Main/RootView.swift
+++ b/Tracexy/Views/Main/RootView.swift
@@ -47,6 +47,9 @@ struct RootView: View {
             ContextDockView(coordinator: coordinator)
         }
         .ignoresSafeArea(.container, edges: .top)
+        .onChange(of: coordinator.workspaces.activeWorkspaceID) {
+            coordinator.evidenceNavigationDidChangeSelection()
+        }
         // The unified window toolbar — sidebar toggle, interface picker, capture
         // status, and the capture/inspector actions — is installed natively by
         // `NativeWorkspaceWindowChrome`, so the sidebar toggle can sit above the
@@ -164,6 +167,7 @@ struct MainDetailView: View {
                 // bindings bypass `coordinator.select(_:)`, so this root observer is
                 // the authoritative retirement boundary for both selection paths.
                 coordinator.cancelFollowStream(clearResult: true)
+                coordinator.evidenceNavigationDidChangeSelection()
                 if newValue != nil {
                     coordinator.revealPanelsForSelection()
                 }

--- a/TracexyTests/Core/Analysis/SessionEvidenceSelectionTests.swift
+++ b/TracexyTests/Core/Analysis/SessionEvidenceSelectionTests.swift
@@ -1,0 +1,215 @@
+import Foundation
+import Testing
+@testable import Tracexy
+
+// MARK: - SessionEvidenceSelectionTests
+
+/// The pure selected-session projection must return every retained connection
+/// incarnation for a tuple-derived session in the snapshot's deterministic order,
+/// the zero-or-one shared tuple-scoped TLS summary without pairing it to an
+/// incarnation, and every per-summary and capture-level coverage fact verbatim.
+struct SessionEvidenceSelectionTests {
+    // MARK: Internal
+
+    @Test("Two reused-tuple incarnations project in order with one shared TLS summary")
+    func reusedTupleIncarnationsAndSharedTLS() {
+        let tuple = Self.tuple
+        let sessionID = SessionBuilder.sessionID(for: tuple)
+        let first = Self.connection(tuple: tuple, firstOrdinal: 1, phase: .closed)
+        let second = Self.connection(tuple: tuple, firstOrdinal: 3, phase: .opening)
+        // A different tuple/session that must never leak into this selection.
+        let other = Self.connection(tuple: Self.otherTuple, firstOrdinal: 2, phase: .active)
+
+        let snapshot = Self.snapshot(
+            connections: Self.connectionSnapshot(
+                [first, other, second], omittedSummary: 2, active: 1, published: 3, retainedEvents: 4
+            ),
+            tls: Self.tlsSnapshot(
+                [Self.tlsSummary(for: tuple)], omitted: 3, excluded: 1, recoveredTrunc: 0, decoderTrunc: 2,
+                capacity: true
+            )
+        )
+
+        let selection = snapshot.selectingSession(sessionID)
+
+        // Both incarnations, in first-observed snapshot order; the other tuple is out.
+        #expect(selection.connections == [first, second])
+        #expect(selection.connections.count == 2)
+        #expect(Set(selection.connections.map(\.id)).count == 2) // distinct incarnations
+        #expect(selection.connections.allSatisfy { $0.tuple == tuple })
+
+        // Exactly one shared tuple/session-scoped TLS summary, never paired to an id.
+        #expect(selection.tls?.sessionID == sessionID)
+        #expect(selection.tls?.tuple == tuple)
+        #expect(!selection.isEmpty)
+
+        // Per-summary coverage is carried verbatim inside the retained values.
+        #expect(selection.tls?.decoderTruncatedFrameCount == 2)
+        #expect(selection.tls?.snapLengthTruncationObserved == true)
+        #expect(selection.connections[0].lossKnowledge == first.lossKnowledge)
+
+        // Capture-level coverage is carried verbatim.
+        #expect(selection.connectionCoverage.omittedSummaryCount == 2)
+        #expect(selection.connectionCoverage.activeConnectionCount == 1)
+        #expect(selection.connectionCoverage.publishedSummaryCount == 3)
+        #expect(selection.connectionCoverage.retainedEventCount == 4)
+        #expect(selection.tlsCoverage.omittedObservationCount == 3)
+        #expect(selection.tlsCoverage.excludedReassembledRecordCount == 1)
+        #expect(selection.tlsCoverage.decoderTruncatedFrameCount == 2)
+        #expect(selection.tlsCoverage.capacityReached)
+    }
+
+    @Test("A missing selected summary keeps capture-level coverage as global unknown coverage")
+    func missingSummaryPreservesCaptureLevelCoverage() {
+        // The snapshot has evidence for `tuple`, but we select an unrelated session id.
+        let snapshot = Self.snapshot(
+            connections: Self.connectionSnapshot(
+                [Self.connection(tuple: Self.tuple, firstOrdinal: 1, phase: .closed)],
+                omittedSummary: 7, active: 2, published: 1, retainedEvents: 0
+            ),
+            tls: Self.tlsSnapshot(
+                [Self.tlsSummary(for: Self.tuple)], omitted: 9, excluded: 4, recoveredTrunc: 1, decoderTrunc: 0,
+                capacity: true
+            )
+        )
+        let unrelated = SessionBuilder.sessionID(for: Self.otherTuple)
+
+        let selection = snapshot.selectingSession(unrelated)
+
+        // No retained evidence for this session — but never evidence of absence.
+        #expect(selection.connections.isEmpty)
+        #expect(selection.tls == nil)
+        #expect(selection.isEmpty)
+
+        // The global capture-level coverage remains, as unknown coverage.
+        #expect(selection.connectionCoverage.omittedSummaryCount == 7)
+        #expect(selection.connectionCoverage.activeConnectionCount == 2)
+        #expect(selection.tlsCoverage.omittedObservationCount == 9)
+        #expect(selection.tlsCoverage.excludedReassembledRecordCount == 4)
+        #expect(selection.tlsCoverage.recoveredTruncationIndicatorCount == 1)
+        #expect(selection.tlsCoverage.capacityReached)
+    }
+
+    // MARK: Private
+
+    private static let tuple = FiveTuple(
+        proto: .tcp,
+        source: IPEndpoint(ip: "198.51.100.32", port: 50_002),
+        destination: IPEndpoint(ip: "203.0.113.62", port: 443)
+    )
+
+    private static let otherTuple = FiveTuple(
+        proto: .tcp,
+        source: IPEndpoint(ip: "198.51.100.99", port: 51_000),
+        destination: IPEndpoint(ip: "203.0.113.9", port: 443)
+    )
+
+    private static func provenance(ordinal: UInt64) -> SessionFrameProvenance {
+        SessionFrameProvenance(
+            ordinal: FrameOrdinal(ordinal),
+            timestamp: Date(timeIntervalSince1970: 1_700_000_000 + Double(ordinal)),
+            capturedLength: 60,
+            originalLength: 60,
+            linkType: LinkType.ethernet
+        )
+    }
+
+    private static func connection(
+        tuple: FiveTuple,
+        firstOrdinal: UInt64,
+        phase: ConnectionPhase
+    )
+        -> ConnectionSummary
+    {
+        let prov = provenance(ordinal: firstOrdinal)
+        return ConnectionSummary(
+            id: ConnectionID(tuple: tuple, firstOrdinal: FrameOrdinal(firstOrdinal)),
+            tuple: tuple,
+            firstProvenance: prov,
+            lastProvenance: prov,
+            initiator: .aToB,
+            phase: phase,
+            handshake: .synObserved,
+            finDirections: [],
+            closeReason: phase == .closed ? .reset(.aToB) : nil,
+            packetCount: 1,
+            capturedByteTotal: 60,
+            originalByteTotal: 60,
+            lossKnowledge: .noLossReported,
+            limitations: [.startUnobserved],
+            events: [],
+            omittedEventCount: 0
+        )
+    }
+
+    private static func tlsSummary(for tuple: FiveTuple) -> TLSEvidenceSummary {
+        TLSEvidenceSummary(
+            sessionID: SessionBuilder.sessionID(for: tuple),
+            tuple: tuple,
+            observations: [],
+            omittedObservationCount: 3,
+            excludedReassembledRecordCount: 1,
+            recoveredTruncationIndicatorCount: 0,
+            decoderTruncatedFrameCount: 2,
+            lossKnowledge: .noLossReported,
+            snapLengthTruncationObserved: true
+        )
+    }
+
+    private static func connectionSnapshot(
+        _ summaries: [ConnectionSummary],
+        omittedSummary: UInt64,
+        active: Int,
+        published: Int,
+        retainedEvents: Int
+    )
+        -> ConnectionTable.Snapshot
+    {
+        ConnectionTable.Snapshot(
+            summaries: summaries,
+            omittedSummaryCount: omittedSummary,
+            activeConnectionCount: active,
+            publishedSummaryCount: published,
+            retainedEventCount: retainedEvents,
+            countersOverflowed: false
+        )
+    }
+
+    private static func tlsSnapshot(
+        _ summaries: [TLSEvidenceSummary],
+        omitted: UInt64,
+        excluded: UInt64,
+        recoveredTrunc: UInt64,
+        decoderTrunc: UInt64,
+        capacity: Bool
+    )
+        -> TLSEvidenceTable.Snapshot
+    {
+        TLSEvidenceTable.Snapshot(
+            summaries: summaries,
+            omittedObservationCount: omitted,
+            retainedObservationCount: 0,
+            excludedReassembledRecordCount: excluded,
+            recoveredTruncationIndicatorCount: recoveredTrunc,
+            decoderTruncatedFrameCount: decoderTrunc,
+            capacityReached: capacity,
+            countersOverflowed: false
+        )
+    }
+
+    private static func snapshot(
+        connections: ConnectionTable.Snapshot,
+        tls: TLSEvidenceTable.Snapshot
+    )
+        -> InvestigationSnapshot
+    {
+        InvestigationSnapshot(
+            sessions: [],
+            connections: connections,
+            datagramEvidence: .empty,
+            tlsEvidence: tls,
+            connectionAnalysis: .empty,
+            datagramAnalysis: .empty
+        )
+    }
+}

--- a/TracexyTests/Core/Capture/CitedFrameReferenceTests.swift
+++ b/TracexyTests/Core/Capture/CitedFrameReferenceTests.swift
@@ -1,0 +1,112 @@
+import Foundation
+import Testing
+@testable import Tracexy
+
+// MARK: - CitedFrameReferenceTests
+
+/// Constructing an exact cited-frame `CaptureEvidenceReference` from a provenance
+/// must validate the locator's source token against the adopted file identity
+/// first, and the reused ``CaptureEvidenceReader`` identity/length checks must still
+/// catch a replaced or truncated file. A wrong token or an absent locator is a
+/// controlled failure that constructs no reference and reads nothing.
+struct CitedFrameReferenceTests {
+    // MARK: Internal
+
+    @Test("A current-identity token builds an exact reference that reads the cited bytes")
+    func currentTokenReadsExactBytes() throws {
+        let syn = PacketBuilder.tcpSynFrame(src: "198.51.100.5", dst: "203.0.113.9", srcPort: 44_000, dstPort: 443)
+        try Self.withSavedCapture([syn]) { url, result in
+            let identity = result.identity
+            let provenance = try #require(result.connections.summaries.first?.firstProvenance)
+            // The locator was minted from the adopted file identity at load.
+            #expect(provenance.locator?.sourceToken == SavedCaptureStreamLoader.sourceToken(for: identity))
+
+            let reference = try SavedCaptureStreamLoader.citedEvidenceReference(
+                for: provenance, matching: identity
+            )
+            let bytes = try CaptureEvidenceReader.read(reference, from: url)
+            #expect(bytes == syn)
+            #expect(bytes.count == provenance.capturedLength)
+        }
+    }
+
+    @Test("A wrong source token throws mismatch and constructs no reference")
+    func wrongTokenThrowsMismatch() throws {
+        let syn = PacketBuilder.tcpSynFrame(src: "198.51.100.6", dst: "203.0.113.10", srcPort: 44_100, dstPort: 443)
+        try Self.withSavedCapture([syn]) { _, result in
+            let provenance = try #require(result.connections.summaries.first?.firstProvenance)
+            let forged = SessionFrameProvenance(
+                ordinal: provenance.ordinal,
+                timestamp: provenance.timestamp,
+                capturedLength: provenance.capturedLength,
+                originalLength: provenance.originalLength,
+                linkType: provenance.linkType,
+                locator: SessionEvidenceLocator(sourceToken: UUID(), offset: provenance.locator?.offset ?? 0)
+            )
+            #expect(throws: CitedFrameReferenceError.sourceTokenMismatch) {
+                _ = try SavedCaptureStreamLoader.citedEvidenceReference(for: forged, matching: result.identity)
+            }
+        }
+    }
+
+    @Test("A nil locator throws the explicit missing-locator failure")
+    func missingLocatorThrows() throws {
+        let syn = PacketBuilder.tcpSynFrame(src: "198.51.100.7", dst: "203.0.113.11", srcPort: 44_200, dstPort: 443)
+        try Self.withSavedCapture([syn]) { _, result in
+            let provenance = try #require(result.connections.summaries.first?.firstProvenance)
+            let noLocator = SessionFrameProvenance(
+                ordinal: provenance.ordinal,
+                timestamp: provenance.timestamp,
+                capturedLength: provenance.capturedLength,
+                originalLength: provenance.originalLength,
+                linkType: provenance.linkType,
+                locator: nil
+            )
+            #expect(throws: CitedFrameReferenceError.missingLocator) {
+                _ = try SavedCaptureStreamLoader.citedEvidenceReference(for: noLocator, matching: result.identity)
+            }
+        }
+    }
+
+    @Test("A replaced file fails the reused identity check even with a valid reference")
+    func replacedFileFailsIdentityCheck() throws {
+        let syn = PacketBuilder.tcpSynFrame(src: "198.51.100.8", dst: "203.0.113.12", srcPort: 44_300, dstPort: 443)
+        try Self.withSavedCapture([syn]) { url, result in
+            let provenance = try #require(result.connections.summaries.first?.firstProvenance)
+            let reference = try SavedCaptureStreamLoader.citedEvidenceReference(
+                for: provenance, matching: result.identity
+            )
+            // Replace the file with different content/size: the identity/length checks
+            // in the reused reader reject the stale offset rather than return bad bytes.
+            let other = PacketBuilder.tcpSynFrame(
+                src: "198.51.100.8", dst: "203.0.113.13", srcPort: 44_301, dstPort: 8_080
+            )
+            try PcapWriter.write(linkType: LinkType.ethernet, frames: [
+                Self.frame(other), Self.frame(other),
+            ], to: url)
+            #expect(throws: PacketError.self) {
+                _ = try CaptureEvidenceReader.read(reference, from: url)
+            }
+        }
+    }
+
+    // MARK: Private
+
+    private static func frame(_ bytes: [UInt8]) -> CapturedFrame {
+        CapturedFrame(bytes: bytes, timestamp: Date(timeIntervalSince1970: 1_700_000_000), originalLength: bytes.count)
+    }
+
+    private static func withSavedCapture(
+        _ frames: [[UInt8]],
+        _ body: (URL, SavedCaptureLoadResult) throws -> Void
+    )
+        throws
+    {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cited-frame-\(UUID().uuidString).pcap")
+        try PcapWriter.write(linkType: LinkType.ethernet, frames: frames.map(frame), to: url)
+        defer { try? FileManager.default.removeItem(at: url) }
+        let result = try SavedCaptureStreamLoader(contentsOf: url).load()
+        try body(url, result)
+    }
+}

--- a/TracexyTests/Models/UI/FindingTests.swift
+++ b/TracexyTests/Models/UI/FindingTests.swift
@@ -43,6 +43,7 @@ struct FindingTests {
         #expect(finding.coverage == .omittedEvidence)
         #expect(finding.citedObservationCount == 1)
         #expect(finding.omittedCitationCount == 2)
+        #expect(finding.citedFrames == [provenance])
         #expect(finding
             .subtitle ==
             "TC bit observed · resolver.example · 1 cited observation · 2 omitted · bounded evidence omitted")

--- a/TracexyTests/Models/UI/SessionEvidencePresentationTests.swift
+++ b/TracexyTests/Models/UI/SessionEvidencePresentationTests.swift
@@ -1,0 +1,180 @@
+import Foundation
+import Testing
+@testable import Tracexy
+
+// MARK: - SessionEvidencePresentationTests
+
+@Suite("Session evidence presentation")
+struct SessionEvidencePresentationTests {
+    // MARK: Internal
+
+    @Test("Connection incarnations and shared TLS records share one stable frame timeline")
+    func timelinePreservesIncarnationsAndSharedTLS() {
+        let firstID = ConnectionID(tuple: tuple, firstOrdinal: FrameOrdinal(1))
+        let secondID = ConnectionID(tuple: tuple, firstOrdinal: FrameOrdinal(8))
+        let first = summary(
+            id: firstID,
+            firstOrdinal: 1,
+            event: event(firstID, .rst, ordinal: 5, direction: .aToB)
+        )
+        let second = summary(
+            id: secondID,
+            firstOrdinal: 8,
+            event: event(secondID, .syn, ordinal: 8, direction: .bToA)
+        )
+        let tls = TLSEvidenceSummary(
+            sessionID: SessionBuilder.sessionID(for: tuple),
+            tuple: tuple,
+            observations: [TLSEvidenceObservation(
+                sessionID: SessionBuilder.sessionID(for: tuple),
+                tuple: tuple,
+                direction: .aToB,
+                provenance: provenance(6),
+                recordIndex: 0,
+                fact: TLSRecordFact(
+                    contentType: 23,
+                    legacyRecordVersion: 0x0303,
+                    declaredBodyLength: 12,
+                    capturedBodyLength: 12,
+                    handshake: nil
+                )
+            )],
+            omittedObservationCount: 0,
+            excludedReassembledRecordCount: 0,
+            recoveredTruncationIndicatorCount: 0,
+            decoderTruncatedFrameCount: 0,
+            lossKnowledge: .unknown,
+            snapLengthTruncationObserved: false
+        )
+
+        let items = SessionEvidenceItem.timeline(connections: [first, second], tls: tls)
+
+        #expect(items.map(\.ordinal.rawValue) == [5, 6, 8])
+        #expect(items.map(\.kind) == [.connection, .tls, .connection])
+        #expect(items[0].detail.contains("connection 1 of 2"))
+        #expect(items[2].detail.contains("connection 2 of 2"))
+        #expect(items[1].title == "TLS Application Data record")
+        #expect(items[1].provenance == [provenance(6)])
+    }
+
+    @Test("TLS copy distinguishes selected version from legacy framing")
+    func tlsSelectedVersionCopyIsExplicit() {
+        let fact = TLSRecordFact(
+            contentType: 22,
+            legacyRecordVersion: 0x0303,
+            declaredBodyLength: 90,
+            capturedBodyLength: 90,
+            handshake: .serverHello(TLSServerHelloFact(
+                legacyVersion: 0x0303,
+                selectedCipher: 0x1301,
+                isHelloRetryRequest: false,
+                extensionsComplete: true,
+                selectedVersion: 0x0304
+            ))
+        )
+        let observation = TLSEvidenceObservation(
+            sessionID: SessionBuilder.sessionID(for: tuple),
+            tuple: tuple,
+            direction: .bToA,
+            provenance: provenance(11),
+            recordIndex: 0,
+            fact: fact
+        )
+
+        let detail = SessionEvidenceCopy.tlsRecordDetail(observation)
+
+        #expect(detail.contains("legacy record version TLS 1.2 (0x0303)"))
+        #expect(detail.contains("selected TLS 1.3 (0x0304)"))
+        #expect(detail.contains("cipher 0x1301"))
+    }
+
+    @Test("Coverage copy keeps unknown, omission, and overflow caveats neutral")
+    func coverageCopyIsNeutral() {
+        let labels = SessionEvidenceCopy.limitationLabels([
+            .eventHistoryTruncated,
+            .sequenceGapObserved,
+            .counterOverflow,
+        ])
+
+        #expect(SessionEvidenceCopy.lossLabel(.unknown) == "Capture loss unknown")
+        #expect(labels.contains("Older connection events were omitted"))
+        #expect(labels.contains("A sequence-space gap was observed"))
+        #expect(labels.contains("A connection counter saturated"))
+        #expect(!labels.joined(separator: " ").localizedCaseInsensitiveContains("cause"))
+    }
+
+    // MARK: Private
+
+    private var tuple: FiveTuple {
+        FiveTuple(
+            proto: .tcp,
+            source: IPEndpoint(ip: "192.0.2.10", port: 52_000),
+            destination: IPEndpoint(ip: "198.51.100.20", port: 443)
+        )
+    }
+
+    private func provenance(_ ordinal: UInt64) -> SessionFrameProvenance {
+        SessionFrameProvenance(
+            ordinal: FrameOrdinal(ordinal),
+            timestamp: Date(timeIntervalSince1970: Double(ordinal)),
+            capturedLength: 96,
+            originalLength: 96,
+            linkType: LinkType.ethernet,
+            locator: SessionEvidenceLocator(sourceToken: UUID(intValue: 9), offset: ordinal * 128)
+        )
+    }
+
+    private func event(
+        _ id: ConnectionID,
+        _ kind: ConnectionEventKind,
+        ordinal: UInt64,
+        direction: ConnectionDirection
+    )
+        -> ConnectionEvent
+    {
+        ConnectionEvent(
+            connectionID: id,
+            kind: kind,
+            timestamp: Date(timeIntervalSince1970: Double(ordinal)),
+            provenance: provenance(ordinal),
+            direction: direction
+        )
+    }
+
+    private func summary(
+        id: ConnectionID,
+        firstOrdinal: UInt64,
+        event: ConnectionEvent
+    )
+        -> ConnectionSummary
+    {
+        ConnectionSummary(
+            id: id,
+            tuple: tuple,
+            firstProvenance: provenance(firstOrdinal),
+            lastProvenance: event.provenance[0],
+            initiator: nil,
+            phase: .closed,
+            handshake: .none,
+            finDirections: [],
+            closeReason: nil,
+            packetCount: 1,
+            capturedByteTotal: 96,
+            originalByteTotal: 96,
+            lossKnowledge: .unknown,
+            limitations: [],
+            events: [event],
+            omittedEventCount: 0
+        )
+    }
+}
+
+private extension UUID {
+    init(intValue: UInt64) {
+        var bytes = [UInt8](repeating: 0, count: 16)
+        withUnsafeBytes(of: intValue.bigEndian) { raw in
+            bytes.replaceSubrange(8 ..< 16, with: raw)
+        }
+        self = bytes.withUnsafeBytes { UUID(uuid: $0.load(as: uuid_t.self)) }
+    }
+}

--- a/TracexyTests/ViewModels/EvidenceNavigationActivationTests.swift
+++ b/TracexyTests/ViewModels/EvidenceNavigationActivationTests.swift
@@ -1,0 +1,353 @@
+import Foundation
+import Testing
+@testable import Tracexy
+
+// MARK: - EvidenceNavigationActivationTests
+
+/// The coordinator's evidence-navigation package must project the selected session's
+/// connection/TLS evidence off-main behind request/workspace/session/generation
+/// guards, resolve exactly one cited frame from a saved or live source with those
+/// same guards, treat a nil locator as explicit unavailable, and retire both the
+/// projection and the raw cited frame at every selection/capture/source boundary.
+@MainActor
+@Suite("Evidence navigation coordinator activation")
+struct EvidenceNavigationActivationTests {
+    // MARK: Internal
+
+    @Test("Selecting a session publishes its projection; a new selection supersedes it")
+    func projectionPublishesAndSupersedes() async throws {
+        let environment = try makeEnvironment()
+        defer { environment.teardown() }
+        let coordinator = environment.coordinator
+        try await openConnectionCapture(coordinator, in: environment.directory)
+
+        let sessions = coordinator.sessions
+        try #require(sessions.count >= 2)
+        let first = sessions[0]
+        coordinator.select(first)
+        await coordinator.waitForEvidenceProjection()
+        #expect(coordinator.evidenceProjection.selection?.sessionID == first.id)
+
+        let second = try #require(sessions.first { $0.id != first.id })
+        coordinator.select(second)
+        await coordinator.waitForEvidenceProjection()
+        #expect(coordinator.evidenceProjection.selection?.sessionID == second.id)
+    }
+
+    @Test("A late projection cannot publish across a session/workspace/generation guard")
+    func projectionGuardsRejectStalePublication() async throws {
+        let environment = try makeEnvironment()
+        defer { environment.teardown() }
+        let coordinator = environment.coordinator
+        try await openConnectionCapture(coordinator, in: environment.directory)
+        let selected = try #require(coordinator.sessions.first)
+        coordinator.select(selected)
+        await coordinator.waitForEvidenceProjection()
+        let published = coordinator.evidenceProjection.selection
+
+        let stale = SessionEvidenceSelection(
+            sessionID: UUID(), connections: [], tls: nil,
+            connectionCoverage: .empty, tlsCoverage: .empty
+        )
+        // Stale request id — rejected.
+        coordinator.publishSelectedSessionEvidenceProjection(
+            stale, sessionID: selected.id, workspaceID: coordinator.activeWorkspace.id,
+            requestID: -1, expectedGeneration: coordinator.startGeneration
+        )
+        // Wrong workspace — rejected.
+        coordinator.publishSelectedSessionEvidenceProjection(
+            stale, sessionID: selected.id, workspaceID: UUID(),
+            requestID: coordinator.evidenceProjection.requestID, expectedGeneration: coordinator.startGeneration
+        )
+        // Wrong generation — rejected.
+        coordinator.publishSelectedSessionEvidenceProjection(
+            stale, sessionID: selected.id, workspaceID: coordinator.activeWorkspace.id,
+            requestID: coordinator.evidenceProjection.requestID, expectedGeneration: coordinator.startGeneration + 99
+        )
+        #expect(coordinator.evidenceProjection.selection == published)
+    }
+
+    @Test("A saved cited frame reads and decodes exactly the cited bytes")
+    func savedCitedFrameSucceeds() async throws {
+        let environment = try makeEnvironment()
+        defer { environment.teardown() }
+        let coordinator = environment.coordinator
+        try await openConnectionCapture(coordinator, in: environment.directory)
+        let (session, provenance) = try citedProvenance(coordinator)
+        coordinator.select(session)
+
+        coordinator.inspectCitedFrame(sessionID: session.id, provenance: provenance)
+        await coordinator.waitForCitedFrame()
+
+        guard case let .loaded(evidence) = coordinator.citedFrame.state else {
+            Issue.record("expected a loaded cited frame, got \(coordinator.citedFrame.state)")
+            return
+        }
+        #expect(evidence.sessionID == session.id)
+        #expect(evidence.provenance == provenance)
+        #expect(!evidence.bytes.isEmpty)
+        #expect(evidence.bytes.count == provenance.capturedLength)
+        #expect(!evidence.layers.isEmpty)
+    }
+
+    @Test("A forged source token fails the saved cited-frame read with neutral copy")
+    func savedCitedFrameWrongTokenFails() async throws {
+        let environment = try makeEnvironment()
+        defer { environment.teardown() }
+        let coordinator = environment.coordinator
+        try await openConnectionCapture(coordinator, in: environment.directory)
+        let (session, provenance) = try citedProvenance(coordinator)
+        coordinator.select(session)
+
+        let forged = Self.reprovenance(provenance, locator: SessionEvidenceLocator(
+            sourceToken: UUID(), offset: provenance.locator?.offset ?? 0
+        ))
+        coordinator.inspectCitedFrame(sessionID: session.id, provenance: forged)
+        await coordinator.waitForCitedFrame()
+
+        guard case let .failed(message) = coordinator.citedFrame.state else {
+            Issue.record("expected a failed cited frame, got \(coordinator.citedFrame.state)")
+            return
+        }
+        // Neutral copy: no path or source token.
+        #expect(!message.contains(environment.directory.path))
+        #expect(!message.contains(session.id.uuidString))
+    }
+
+    @Test("A nil locator is an explicit unavailable state and triggers no read")
+    func nilLocatorIsUnavailable() async throws {
+        let environment = try makeEnvironment()
+        defer { environment.teardown() }
+        let coordinator = environment.coordinator
+        try await openConnectionCapture(coordinator, in: environment.directory)
+        let (session, provenance) = try citedProvenance(coordinator)
+        coordinator.select(session)
+
+        coordinator.inspectCitedFrame(
+            sessionID: session.id,
+            provenance: Self.reprovenance(provenance, locator: nil)
+        )
+        #expect(coordinator.citedFrame.state == .unavailable)
+        #expect(coordinator.citedFrame.task == nil)
+    }
+
+    @Test("A current-epoch active-live spool read resolves exactly one frame")
+    func liveCitedFrameSucceeds() async throws {
+        let environment = try makeEnvironment()
+        defer { environment.teardown() }
+        let coordinator = environment.coordinator
+        let frames = ReplayCorpus.tcpConnectionCapturedFrames()
+        let epoch = 200
+
+        try await coordinator.liveCaptureSpool.reset(epoch: epoch)
+        let appendResult = try await coordinator.liveCaptureSpool.append(
+            frames, defaultLinkType: LinkType.ethernet, epoch: epoch
+        )
+        guard case let .appended(locators) = appendResult, let locator = locators.first else {
+            Issue.record("spool append produced no locators")
+            return
+        }
+        coordinator.startGeneration = epoch
+        coordinator.isCapturing = true
+        coordinator.sessions = SessionBuilder.build(from: frames, linkType: LinkType.ethernet)
+        let session = try #require(coordinator.sessions.first)
+        coordinator.select(session)
+
+        let provenance = Self.provenance(for: frames[0], locator: locator)
+        coordinator.inspectCitedFrame(sessionID: session.id, provenance: provenance)
+        await coordinator.waitForCitedFrame()
+
+        guard case let .loaded(evidence) = coordinator.citedFrame.state else {
+            Issue.record("expected a loaded live cited frame, got \(coordinator.citedFrame.state)")
+            return
+        }
+        #expect(evidence.bytes == frames[0].bytes)
+        #expect(!evidence.layers.isEmpty)
+    }
+
+    @Test("A stopped-live generation still resolves a citation from its finalized spool")
+    func stoppedLiveCitedFrameSucceeds() async throws {
+        let environment = try makeEnvironment()
+        defer { environment.teardown() }
+        let coordinator = environment.coordinator
+        let frames = ReplayCorpus.tcpConnectionCapturedFrames()
+        let epoch = 300
+
+        try await coordinator.liveCaptureSpool.reset(epoch: epoch)
+        let appendResult = try await coordinator.liveCaptureSpool.append(
+            frames, defaultLinkType: LinkType.ethernet, epoch: epoch
+        )
+        guard case let .appended(locators) = appendResult, let locator = locators.first else {
+            Issue.record("spool append produced no locators")
+            return
+        }
+        // Stop advances the coordinator generation, but deliberately preserves
+        // the just-finalized spool and its source token.
+        coordinator.startGeneration = epoch + 1
+        coordinator.sessions = SessionBuilder.build(from: frames, linkType: LinkType.ethernet)
+        let session = try #require(coordinator.sessions.first)
+        coordinator.select(session)
+
+        coordinator.inspectCitedFrame(
+            sessionID: session.id,
+            provenance: Self.provenance(for: frames[0], locator: locator)
+        )
+        await coordinator.waitForCitedFrame()
+
+        guard case let .loaded(evidence) = coordinator.citedFrame.state else {
+            Issue.record("expected a loaded stopped-live cited frame, got \(coordinator.citedFrame.state)")
+            return
+        }
+        #expect(evidence.bytes == frames[0].bytes)
+    }
+
+    @Test("A locator from a superseded live spool fails without reading another frame")
+    func liveCitedFrameStaleSourceFails() async throws {
+        let environment = try makeEnvironment()
+        defer { environment.teardown() }
+        let coordinator = environment.coordinator
+        let frames = ReplayCorpus.tcpConnectionCapturedFrames()
+        let oldEpoch = 400
+
+        try await coordinator.liveCaptureSpool.reset(epoch: oldEpoch)
+        let appendResult = try await coordinator.liveCaptureSpool.append(
+            frames, defaultLinkType: LinkType.ethernet, epoch: oldEpoch
+        )
+        guard case let .appended(locators) = appendResult, let staleLocator = locators.first else {
+            Issue.record("spool append produced no locators")
+            return
+        }
+
+        let currentEpoch = oldEpoch + 1
+        try await coordinator.liveCaptureSpool.reset(epoch: currentEpoch)
+        coordinator.startGeneration = currentEpoch
+        coordinator.sessions = SessionBuilder.build(from: frames, linkType: LinkType.ethernet)
+        let session = try #require(coordinator.sessions.first)
+        coordinator.select(session)
+
+        coordinator.inspectCitedFrame(
+            sessionID: session.id,
+            provenance: Self.provenance(for: frames[0], locator: staleLocator)
+        )
+        await coordinator.waitForCitedFrame()
+
+        guard case .failed = coordinator.citedFrame.state else {
+            Issue.record("expected a failed stale-source cited frame, got \(coordinator.citedFrame.state)")
+            return
+        }
+    }
+
+    @Test("Selection and capture boundaries retire the cited frame and projection")
+    func boundariesRetireEvidenceNavigation() async throws {
+        let environment = try makeEnvironment()
+        defer { environment.teardown() }
+        let coordinator = environment.coordinator
+        try await openConnectionCapture(coordinator, in: environment.directory)
+        let (session, provenance) = try citedProvenance(coordinator)
+        coordinator.select(session)
+        coordinator.inspectCitedFrame(sessionID: session.id, provenance: provenance)
+        await coordinator.waitForCitedFrame()
+        await coordinator.waitForEvidenceProjection()
+        #expect(coordinator.evidenceProjection.selection != nil)
+        guard case .loaded = coordinator.citedFrame.state else {
+            Issue.record("expected a loaded cited frame before the boundary")
+            return
+        }
+
+        // A different selection retires the previously cited frame.
+        let other = try #require(coordinator.sessions.first { $0.id != session.id })
+        coordinator.select(other)
+        #expect(coordinator.citedFrame.state == .idle)
+
+        // A capture boundary retires both pipelines.
+        coordinator.clearSessions()
+        #expect(coordinator.citedFrame.state == .idle)
+        #expect(coordinator.evidenceProjection.selection == nil)
+    }
+
+    // MARK: Private
+
+    private struct Environment {
+        let coordinator: MainContentCoordinator
+        let directory: URL
+        let teardown: () -> Void
+    }
+
+    private static func provenance(
+        for frame: CapturedFrame,
+        locator: SessionEvidenceLocator
+    )
+        -> SessionFrameProvenance
+    {
+        SessionFrameProvenance(
+            ordinal: FrameOrdinal(0),
+            timestamp: frame.timestamp,
+            capturedLength: frame.bytes.count,
+            originalLength: frame.originalLength,
+            linkType: LinkType.ethernet,
+            locator: locator
+        )
+    }
+
+    private static func reprovenance(
+        _ provenance: SessionFrameProvenance,
+        locator: SessionEvidenceLocator?
+    )
+        -> SessionFrameProvenance
+    {
+        SessionFrameProvenance(
+            ordinal: provenance.ordinal,
+            timestamp: provenance.timestamp,
+            capturedLength: provenance.capturedLength,
+            originalLength: provenance.originalLength,
+            linkType: provenance.linkType,
+            locator: locator
+        )
+    }
+
+    private func makeEnvironment(function: String = #function) throws -> Environment {
+        let suiteName = "com.amunx.tracexy.evidence-nav.\(function).\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        let directory = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("tracexy-evidence-nav-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let coordinator = MainContentCoordinator(
+            layoutPreferences: WorkspaceLayoutPreferences(defaults: defaults),
+            liveCaptureSpool: LiveCaptureSpool(directory: directory.appendingPathComponent("spool"))
+        )
+        return Environment(coordinator: coordinator, directory: directory) {
+            defaults.removePersistentDomain(forName: suiteName)
+            try? FileManager.default.removeItem(at: directory)
+        }
+    }
+
+    private func openConnectionCapture(
+        _ coordinator: MainContentCoordinator,
+        in directory: URL
+    )
+        async throws
+    {
+        let url = directory.appendingPathComponent("evidence-nav.pcap")
+        try PcapWriter.write(
+            linkType: LinkType.ethernet,
+            frames: ReplayCorpus.tcpConnectionCapturedFrames(),
+            to: url
+        )
+        let byteCount = try #require(try url.resourceValues(forKeys: [.fileSizeKey]).fileSize)
+        coordinator.openSavedCapture(SavedCapture(url: url, name: "evidence-nav", date: Date(), byteCount: byteCount))
+        await coordinator.waitForSavedCaptureOpen()
+    }
+
+    /// A selected session plus a real saved cited-frame provenance for it.
+    private func citedProvenance(
+        _ coordinator: MainContentCoordinator
+    )
+        throws -> (SessionSummary, SessionFrameProvenance)
+    {
+        let summary = try #require(coordinator.connectionSnapshot.summaries.first)
+        let sessionID = SessionBuilder.sessionID(for: summary.tuple)
+        let session = try #require(coordinator.sessions.first { $0.id == sessionID })
+        #expect(summary.firstProvenance.locator != nil)
+        return (session, summary.firstProvenance)
+    }
+}

--- a/TracexyTests/Views/Main/WorkspacePresentationContractTests.swift
+++ b/TracexyTests/Views/Main/WorkspacePresentationContractTests.swift
@@ -57,6 +57,42 @@ struct WorkspacePresentationContractTests {
         #expect(table.contains("struct ContextInspectorFullRow"))
     }
 
+    @Test("Connection and TLS navigation keeps literal evidence below and compact context at right")
+    func evidenceNavigationKeepsInspectorOwnership() throws {
+        let inspector = try readProjectFile("Tracexy/Views/Inspector/InspectorView.swift")
+        let timeline = try readProjectFile("Tracexy/Views/Inspector/SessionEvidenceTimelineView.swift")
+        let details = try readProjectFile("Tracexy/Views/Inspector/ContextDockView.swift")
+        let summary = try readProjectFile("Tracexy/Views/Inspector/SessionEvidenceContextSummaryView.swift")
+
+        #expect(inspector.contains("case .evidence: sessionEvidence(session)"))
+        #expect(inspector.contains("Cited frame"))
+        #expect(inspector.contains("coordinator.cancelCitedFrame()"))
+        #expect(timeline.contains("Capture-level:"))
+        #expect(timeline.contains("No replacement frame was loaded"))
+        #expect(details.contains("SessionEvidenceContextSummaryView"))
+        #expect(summary.contains("Button(\"Open Evidence\")"))
+        #expect(!summary.contains("SessionEvidenceItem.timeline"))
+    }
+
+    @Test("Layers keeps decode filtering compact when a cited-frame scope is visible")
+    func citedLayersKeepVerticalViewport() throws {
+        let inspector = try readProjectFile("Tracexy/Views/Inspector/InspectorView.swift")
+
+        #expect(inspector.contains("private var layerFilterControl: some View"))
+        #expect(inspector.contains("if activeTab == .layers"))
+        #expect(inspector.contains(".frame(minWidth: 180, idealWidth: 240, maxWidth: 280)"))
+        #expect(inspector.contains(".frame(minWidth: 140, idealWidth: 240, maxWidth: 320, alignment: .trailing)"))
+        #expect(inspector.contains(".accessibilityLabel(\"Filter decoded fields\")"))
+        #expect(inspector.contains("ScrollView(.horizontal, showsIndicators: false)"))
+        #expect(inspector.contains("compact panes add no extra sticky row"))
+        #expect(inspector.contains("private func inspectorChrome("))
+        #expect(inspector.contains("the decode and hex panes begin strictly below it"))
+        #expect(inspector.contains(".background(Color(nsColor: .windowBackgroundColor))"))
+        #expect(!inspector.contains(".tracexySafeAreaBar(edge: .top)"))
+        #expect(!inspector.contains("fieldFilterRow"))
+        #expect(!inspector.contains("supportsFieldFilter"))
+    }
+
     @Test("Shared workspace chrome adopts the Liquid Glass policy without replacing native data controls")
     func workspaceUsesSharedGlassPolicy() throws {
         let root = try readProjectFile("Tracexy/Views/Main/RootView.swift")
@@ -120,7 +156,8 @@ struct WorkspacePresentationContractTests {
         #expect(sidebar.contains(".tracexySafeAreaBar(edge: .bottom)"))
         #expect(details.contains(".tracexySafeAreaBar(edge: .top)"))
         #expect(details.contains(".tracexySafeAreaBar(edge: .bottom)"))
-        #expect(evidence.contains(".tracexySafeAreaBar(edge: .top)"))
+        #expect(evidence.contains("private func inspectorChrome("))
+        #expect(!evidence.contains(".tracexySafeAreaBar(edge: .top)"))
         #expect(sessions.contains(".tracexySafeAreaBar(edge: .top)"))
     }
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -238,6 +238,17 @@ opened capture, only the selected session's representative bytes are loaded; cha
 the previous read and file replacement/truncation is rejected rather than displaying bytes from a stale
 offset.
 
+When retained TCP connection or direct-frame TLS observations exist, the **Evidence** facet merges them
+on the capture's frame-order axis. Reused five-tuples remain separate connection incarnations, while TLS
+records stay explicitly shared at session scope when the retained facts cannot attribute them to one
+incarnation. Per-connection omissions, truncation, loss knowledge and bounds remain visible; global
+capture omissions are labelled capture-level and are never assigned to the selected session. Selecting
+a citation reads exactly that one frame from the current local saved file or live spool and opens its
+decoded Layers view with a visible **Cited frame** scope. A missing locator, superseded live-spool source,
+replaced or truncated file, or mismatched source fails visibly and never falls back to a representative packet.
+Changing session, workspace, capture, or source clears the cited bytes. This finite single-frame read is
+allowed during active live capture and is separate from Follow Stream's stable-source requirements.
+
 For TCP sessions, the **Stream** facet offers an explicit **Follow Stream** action. Opening the facet
 alone does not scan or retain application bytes. After activation, Tracexy locally rescans an
 identity-checked saved capture, or an immutable temporary copy of a fully stopped live capture, and
@@ -267,10 +278,11 @@ a general connection/reassembly engine. When a record remains incomplete, its ca
 lengths are labelled honestly, for example "4096 declared, 40 captured (fragment)". Encrypted TLS
 records carry no plaintext exchange, so a TLS-only session offers no requests facet.
 
-The right-hand **Details** dock uses compact two-column tables for assessment, decoded layer facts,
-host baseline, related actions, findings, and grouping evidence. Technical values are selectable and
-monospaced; related-action rows remain clickable so an investigation can move between sessions without
-leaving the dock.
+The right-hand **Details** dock uses compact two-column tables for assessment, connection/TLS evidence
+coverage, decoded layer facts, host baseline, related actions, findings, and grouping evidence. Its
+connection/TLS sections summarize scope and link to the chronological Evidence facet rather than
+duplicating the full event list. Technical values are selectable and monospaced; related-action rows
+remain clickable, and evidence-backed finding citations can open their exact local frame.
 
 The adjacent **AI Assistant** tab uses a conversation-style layout with a compact attached-session row,
 an empty transcript, and a composer pinned to the bottom. The current build does not include an assistant


### PR DESCRIPTION
## Summary

- Add a bounded, off-main projection of retained connection and direct-frame TLS evidence for the selected session, including explicit capture-level coverage and omission semantics.
- Resolve exactly one cited frame from the adopted saved capture or current/finalized live spool with source-identity, request, workspace, session, and generation guards.
- Add native Evidence timeline and context-summary navigation, exact-frame Layers/Payload/Hex inspection, and fixed inspector chrome so nested scrollbars begin below the header.
- Cover selection, stale-source, truncation, presentation, activation, layout, and documentation behavior.

## Validation

- [x] `swiftformat --lint .`
- [x] `swiftlint lint --strict`
- [x] App build completed as part of the full unit-test run.
- [x] `xcodebuild -project Tracexy.xcodeproj -scheme Tracexy -destination "platform=macOS" test -only-testing:TracexyTests`
- [x] Runtime verification: Inspect Frame loaded an exact cited frame and both Layers/Hex scrollbars remained below the inspector header.

## Safety Checklist

- [x] Targets `develop`.
- [x] Includes focused and integration test coverage.
- [x] Updates usage documentation for user-facing behavior.
- [x] Preserves capture, helper, XPC, and privacy boundaries.
- [x] Contains no credentials, signing files, local paths, raw captures, or private configuration.
- [x] Uses product-focused public metadata with no tool attribution.
- [x] I have read and agree to the Tracexy ICLA v1.0.

## Notes

- Cited-frame reads remain explicit, bounded to one local frame, and never fall back to representative bytes.
- Missing locators, replaced files, mismatched source identities, and superseded live spools fail visibly without exposing source paths or internal tokens.