### PR TITLE
feat(projects): add isolated investigations and safe project switching

### DIFF
--- a/Shared/TracexyIdentity.swift
+++ b/Shared/TracexyIdentity.swift
@@ -130,6 +130,10 @@ struct TracexyIdentity {
         "\(sharedUTTypePrefix).session"
     }
 
+    var projectUTTypeIdentifier: String {
+        "\(sharedUTTypePrefix).project"
+    }
+
     var harUTTypeIdentifier: String {
         "\(sharedUTTypePrefix).har"
     }

--- a/Tracexy/AppDelegate.swift
+++ b/Tracexy/AppDelegate.swift
@@ -1,0 +1,34 @@
+import AppKit
+
+/// Holds termination open long enough for the active Project workspace snapshot
+/// and any pending catalog write to reach durable storage.
+@MainActor
+final class AppDelegate: NSObject, NSApplicationDelegate {
+    // MARK: Internal
+
+    weak var coordinator: MainContentCoordinator?
+
+    func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
+        guard let coordinator else {
+            return .terminateNow
+        }
+        guard !isFlushingProjectState else {
+            return .terminateLater
+        }
+
+        isFlushingProjectState = true
+        Task {
+            await coordinator.flushProjectStateForTermination()
+            sender.reply(toApplicationShouldTerminate: true)
+        }
+        return .terminateLater
+    }
+
+    func applicationSupportsSecureRestorableState(_ app: NSApplication) -> Bool {
+        true
+    }
+
+    // MARK: Private
+
+    private var isFlushingProjectState = false
+}

--- a/Tracexy/Core/Storage/HistoryStoreFactory.swift
+++ b/Tracexy/Core/Storage/HistoryStoreFactory.swift
@@ -16,8 +16,9 @@ import Foundation
 enum HistoryStoreFactory {
     // MARK: Internal
 
-    /// The result of attempting to compose the production store.
-    enum Outcome: Sendable {
+    /// The result of attempting to compose the production store. `nonisolated`
+    /// because ``make(databaseURL:fileManager:)`` produces it off the main actor.
+    nonisolated enum Outcome: Sendable {
         /// A migrated, writable store is ready for terminal writes and reads.
         case ready(SessionStore)
         /// History is unavailable; the reason is suitable for a History-specific
@@ -49,7 +50,11 @@ enum HistoryStoreFactory {
 
     /// Open a writable store at `databaseURL`, isolating directory-creation and
     /// open/migration failures as ``Outcome/unavailable``.
-    static func make(databaseURL: URL, fileManager: FileManager = .default) -> Outcome {
+    ///
+    /// Deliberately `nonisolated`: creating the folder and opening/migrating the
+    /// SQLite database is real file I/O, and a Project change prepares it off the
+    /// main actor rather than blocking the UI on it.
+    nonisolated static func make(databaseURL: URL, fileManager: FileManager = .default) -> Outcome {
         let directory = databaseURL.deletingLastPathComponent()
         do {
             try fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
@@ -70,7 +75,7 @@ enum HistoryStoreFactory {
 
     // MARK: Private
 
-    private static func errorDescription(_ error: Error) -> String {
+    nonisolated private static func errorDescription(_ error: Error) -> String {
         if let error = error as? HistoryStoreError {
             return String(describing: error)
         }

--- a/Tracexy/Core/Storage/PortableProjectCodec.swift
+++ b/Tracexy/Core/Storage/PortableProjectCodec.swift
@@ -1,0 +1,229 @@
+import Darwin
+import Foundation
+
+// MARK: - PortableProjectCodecError
+
+nonisolated enum PortableProjectCodecError: Error, Equatable, Sendable {
+    case documentTooLarge(limit: Int)
+    case unsupportedSchema(Int)
+    case malformedDocument
+    case invalidProject(ProjectCatalogValidationError)
+    case directoryIsSymbolicLink
+    case directoryIsNotDirectory
+    case documentIsSymbolicLink
+    case documentIsNotRegularFile
+    case fileSystem(String)
+}
+
+// MARK: - PortableProjectDocumentIO
+
+/// Fail-closed file boundary for portable project documents. UI callers never
+/// need to perform an unbounded `Data(contentsOf:)` read or write through a
+/// symlink. Existing destinations must be regular files; writes replace them
+/// atomically from the same directory with private best-effort permissions.
+nonisolated enum PortableProjectDocumentIO {
+    // MARK: Internal
+
+    static func read(from url: URL) throws -> Project {
+        let standardizedURL = url.standardizedFileURL
+        guard let status = try fileStatus(at: standardizedURL) else {
+            throw PortableProjectCodecError.fileSystem("The project document does not exist.")
+        }
+        guard status.fileType != S_IFLNK else {
+            throw PortableProjectCodecError.documentIsSymbolicLink
+        }
+        guard status.fileType == S_IFREG else {
+            throw PortableProjectCodecError.documentIsNotRegularFile
+        }
+        guard status.size <= ProjectLimits.maximumPortableProjectBytes else {
+            throw PortableProjectCodecError.documentTooLarge(
+                limit: ProjectLimits.maximumPortableProjectBytes
+            )
+        }
+        do {
+            let data = try Data(contentsOf: standardizedURL, options: .mappedIfSafe)
+            guard data.count <= ProjectLimits.maximumPortableProjectBytes else {
+                throw PortableProjectCodecError.documentTooLarge(
+                    limit: ProjectLimits.maximumPortableProjectBytes
+                )
+            }
+            return try PortableProjectCodec.decode(data)
+        } catch let error as PortableProjectCodecError {
+            throw error
+        } catch {
+            throw PortableProjectCodecError.fileSystem(error.localizedDescription)
+        }
+    }
+
+    static func write(_ project: Project, to url: URL) throws {
+        let standardizedURL = url.standardizedFileURL
+        let directoryURL = standardizedURL.deletingLastPathComponent()
+        guard let directoryStatus = try fileStatus(at: directoryURL) else {
+            throw PortableProjectCodecError.fileSystem("The destination folder does not exist.")
+        }
+        guard directoryStatus.fileType != S_IFLNK else {
+            throw PortableProjectCodecError.directoryIsSymbolicLink
+        }
+        guard directoryStatus.fileType == S_IFDIR else {
+            throw PortableProjectCodecError.directoryIsNotDirectory
+        }
+        if let status = try fileStatus(at: standardizedURL) {
+            guard status.fileType != S_IFLNK else {
+                throw PortableProjectCodecError.documentIsSymbolicLink
+            }
+            guard status.fileType == S_IFREG else {
+                throw PortableProjectCodecError.documentIsNotRegularFile
+            }
+        }
+
+        let data = try PortableProjectCodec.encode(project)
+        let temporaryURL = directoryURL.appendingPathComponent(
+            ".tracexyproject-\(UUID().uuidString).tmp",
+            isDirectory: false
+        )
+        do {
+            try data.write(to: temporaryURL, options: .withoutOverwriting)
+            _ = chmod(temporaryURL.path, 0o600)
+            if try fileStatus(at: standardizedURL) != nil {
+                _ = try FileManager.default.replaceItemAt(standardizedURL, withItemAt: temporaryURL)
+            } else {
+                try FileManager.default.moveItem(at: temporaryURL, to: standardizedURL)
+            }
+            _ = chmod(standardizedURL.path, 0o600)
+        } catch let error as PortableProjectCodecError {
+            try? FileManager.default.removeItem(at: temporaryURL)
+            throw error
+        } catch {
+            try? FileManager.default.removeItem(at: temporaryURL)
+            throw PortableProjectCodecError.fileSystem(error.localizedDescription)
+        }
+    }
+
+    // MARK: Private
+
+    private struct FileStatus {
+        let fileType: mode_t
+        let size: Int
+    }
+
+    private static func fileStatus(at url: URL) throws -> FileStatus? {
+        var value = stat()
+        let result = url.path.withCString { lstat($0, &value) }
+        if result == 0 {
+            return FileStatus(fileType: value.st_mode & S_IFMT, size: Int(clamping: value.st_size))
+        }
+        if errno == ENOENT {
+            return nil
+        }
+        throw PortableProjectCodecError.fileSystem(String(cString: strerror(errno)))
+    }
+}
+
+// MARK: - PortableProjectCodec
+
+/// Codec for configuration-only `.tracexyproject` documents.
+///
+/// Import always issues fresh project, workspace, and filter-row identities, so
+/// a portable document can never alias an existing catalog object. The DTO has no
+/// fields for capture bytes, payload, local paths, History, or selection evidence.
+nonisolated enum PortableProjectCodec {
+    // MARK: Internal
+
+    static let fileExtension = "tracexyproject"
+    static let schemaVersion = 1
+
+    nonisolated static func encode(_ project: Project) throws -> Data {
+        let validated = try validate(project)
+        let envelope = Envelope(schemaVersion: schemaVersion, project: validated)
+        do {
+            let data = try encoder.encode(envelope)
+            guard data.count <= ProjectLimits.maximumPortableProjectBytes else {
+                throw PortableProjectCodecError.documentTooLarge(
+                    limit: ProjectLimits.maximumPortableProjectBytes
+                )
+            }
+            return data
+        } catch let error as PortableProjectCodecError {
+            throw error
+        } catch {
+            throw PortableProjectCodecError.malformedDocument
+        }
+    }
+
+    nonisolated static func decode(_ data: Data, now: Date = Date()) throws -> Project {
+        guard data.count <= ProjectLimits.maximumPortableProjectBytes else {
+            throw PortableProjectCodecError.documentTooLarge(
+                limit: ProjectLimits.maximumPortableProjectBytes
+            )
+        }
+        let envelope: Envelope
+        do {
+            envelope = try decoder.decode(Envelope.self, from: data)
+        } catch {
+            throw PortableProjectCodecError.malformedDocument
+        }
+        guard envelope.schemaVersion == schemaVersion else {
+            throw PortableProjectCodecError.unsupportedSchema(envelope.schemaVersion)
+        }
+        let validated = try validate(envelope.project)
+
+        var workspaceIDMap: [UUID: UUID] = [:]
+        let workspaces = validated.workspaces.map { workspace -> ProjectWorkspaceSnapshot in
+            let newID = UUID()
+            workspaceIDMap[workspace.id] = newID
+            var copy = workspace
+            copy.id = newID
+            copy.filterRules = workspace.filterRules.map { rule in
+                var newRule = rule
+                newRule.id = UUID()
+                return newRule
+            }
+            return copy
+        }
+        guard let activeWorkspaceID = workspaceIDMap[validated.activeWorkspaceID] else {
+            throw PortableProjectCodecError.invalidProject(
+                .activeWorkspaceMissing(
+                    projectID: validated.id,
+                    workspaceID: validated.activeWorkspaceID
+                )
+            )
+        }
+        return Project(
+            id: UUID(),
+            name: validated.name,
+            workspaces: workspaces,
+            activeWorkspaceID: activeWorkspaceID,
+            createdAt: now,
+            updatedAt: now
+        )
+    }
+
+    // MARK: Private
+
+    private struct Envelope: Codable {
+        let schemaVersion: Int
+        let project: Project
+    }
+
+    private static let encoder: JSONEncoder = {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .millisecondsSince1970
+        encoder.outputFormatting = [.sortedKeys]
+        return encoder
+    }()
+
+    private static let decoder: JSONDecoder = {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .millisecondsSince1970
+        return decoder
+    }()
+
+    nonisolated private static func validate(_ project: Project) throws -> Project {
+        let catalog = ProjectCatalog(projects: [project], activeProjectID: project.id)
+        do {
+            return try catalog.normalizedValidated().projects[0]
+        } catch let error as ProjectCatalogValidationError {
+            throw PortableProjectCodecError.invalidProject(error)
+        }
+    }
+}

--- a/Tracexy/Core/Storage/ProjectCatalogRepository.swift
+++ b/Tracexy/Core/Storage/ProjectCatalogRepository.swift
@@ -1,0 +1,289 @@
+import Darwin
+import Foundation
+
+// MARK: - ProjectCatalogPersisting
+
+nonisolated protocol ProjectCatalogPersisting: Sendable {
+    func load(seed: ProjectCatalog) async throws -> ProjectCatalog
+    func save(_ catalog: ProjectCatalog, expectedRevision: UInt64) async throws
+    func reset(to catalog: ProjectCatalog) async throws -> ProjectCatalog
+}
+
+// MARK: - ProjectCatalogRepositoryError
+
+nonisolated enum ProjectCatalogRepositoryError: Error, Equatable, Sendable {
+    case directoryIsSymbolicLink
+    case directoryIsNotDirectory
+    case catalogIsSymbolicLink
+    case catalogIsNotRegularFile
+    case catalogTooLarge(limit: Int)
+    case encodedCatalogTooLarge(limit: Int)
+    case malformedCatalog
+    case invalidCatalog(ProjectCatalogValidationError)
+    case staleRevision(expected: UInt64, actual: UInt64)
+    case invalidNextRevision(expected: UInt64, actual: UInt64)
+    case fileSystem(String)
+}
+
+// MARK: - JSONProjectCatalogRepository
+
+/// Actor-isolated JSON v1 catalog persistence rooted at an injected directory.
+///
+/// The store never persists capture data: its schema accepts only the bounded
+/// project/workspace configuration DTOs. Writes use a same-directory replacement,
+/// and every existing target must be a regular non-symlink file.
+actor JSONProjectCatalogRepository: ProjectCatalogPersisting {
+    // MARK: Lifecycle
+
+    init(
+        directoryURL: URL,
+        fileName: String = "projects.json",
+        fileManager: FileManager = .default
+    ) {
+        self.directoryURL = directoryURL.standardizedFileURL
+        self.fileURL = directoryURL.appendingPathComponent(fileName, isDirectory: false)
+            .standardizedFileURL
+        self.fileManager = fileManager
+    }
+
+    // MARK: Internal
+
+    let directoryURL: URL
+    let fileURL: URL
+
+    func load(seed: ProjectCatalog) async throws -> ProjectCatalog {
+        try prepareDirectory()
+        if let data = try readExistingData() {
+            return try decode(data)
+        }
+
+        let normalizedSeed = try validate(seed)
+        let data = try encode(normalizedSeed)
+        do {
+            try writeAtomically(data)
+        } catch {
+            // Another writer may have won the missing-file race. Adopt that
+            // complete catalog instead of overwriting it.
+            if let existing = try? readExistingData() {
+                return try decode(existing)
+            }
+            throw error
+        }
+        return normalizedSeed
+    }
+
+    func save(_ catalog: ProjectCatalog, expectedRevision: UInt64) async throws {
+        try prepareDirectory()
+        let normalized = try validate(catalog)
+        guard expectedRevision < UInt64.max,
+              normalized.revision == expectedRevision + 1 else
+        {
+            throw ProjectCatalogRepositoryError.invalidNextRevision(
+                expected: expectedRevision == UInt64.max ? UInt64.max : expectedRevision + 1,
+                actual: normalized.revision
+            )
+        }
+
+        let actualRevision: UInt64 = if let existing = try readExistingData() {
+            try decode(existing).revision
+        } else {
+            0
+        }
+        guard actualRevision == expectedRevision else {
+            throw ProjectCatalogRepositoryError.staleRevision(
+                expected: expectedRevision,
+                actual: actualRevision
+            )
+        }
+        try writeAtomically(encode(normalized))
+    }
+
+    @discardableResult
+    func reset(to catalog: ProjectCatalog) async throws -> ProjectCatalog {
+        try prepareDirectory()
+        let normalized = try validate(catalog)
+        let encoded = try encode(normalized)
+
+        var recoveryURL: URL?
+        if try existingFileStatus() != nil {
+            let backup = directoryURL.appendingPathComponent(
+                "projects.recovery-\(UUID().uuidString).json",
+                isDirectory: false
+            )
+            do {
+                try fileManager.moveItem(at: fileURL, to: backup)
+                setRestrictiveFilePermissions(backup)
+                recoveryURL = backup
+            } catch {
+                throw fileSystemError(error)
+            }
+        }
+
+        do {
+            try writeAtomically(encoded)
+        } catch {
+            if let recoveryURL, !fileManager.fileExists(atPath: fileURL.path) {
+                try? fileManager.moveItem(at: recoveryURL, to: fileURL)
+            }
+            throw error
+        }
+        return normalized
+    }
+
+    // MARK: Private
+
+    private struct FileStatus {
+        let fileType: mode_t
+        let size: Int
+    }
+
+    private static let encoder: JSONEncoder = {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .millisecondsSince1970
+        encoder.outputFormatting = [.sortedKeys]
+        return encoder
+    }()
+
+    private static let decoder: JSONDecoder = {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .millisecondsSince1970
+        return decoder
+    }()
+
+    private let fileManager: FileManager
+
+    private func prepareDirectory() throws {
+        if let status = try fileStatus(at: directoryURL) {
+            guard status.fileType != S_IFLNK else {
+                throw ProjectCatalogRepositoryError.directoryIsSymbolicLink
+            }
+            guard status.fileType == S_IFDIR else {
+                throw ProjectCatalogRepositoryError.directoryIsNotDirectory
+            }
+        } else {
+            do {
+                try fileManager.createDirectory(
+                    at: directoryURL,
+                    withIntermediateDirectories: true,
+                    attributes: [.posixPermissions: 0o700]
+                )
+            } catch {
+                throw fileSystemError(error)
+            }
+        }
+        _ = chmod(directoryURL.path, 0o700)
+    }
+
+    private func existingFileStatus() throws -> FileStatus? {
+        guard let status = try fileStatus(at: fileURL) else {
+            return nil
+        }
+        guard status.fileType != S_IFLNK else {
+            throw ProjectCatalogRepositoryError.catalogIsSymbolicLink
+        }
+        guard status.fileType == S_IFREG else {
+            throw ProjectCatalogRepositoryError.catalogIsNotRegularFile
+        }
+        return status
+    }
+
+    private func readExistingData() throws -> Data? {
+        guard let status = try existingFileStatus() else {
+            return nil
+        }
+        guard status.size <= ProjectLimits.maximumCatalogBytes else {
+            throw ProjectCatalogRepositoryError.catalogTooLarge(limit: ProjectLimits.maximumCatalogBytes)
+        }
+        do {
+            let data = try Data(contentsOf: fileURL, options: .mappedIfSafe)
+            guard data.count <= ProjectLimits.maximumCatalogBytes else {
+                throw ProjectCatalogRepositoryError.catalogTooLarge(limit: ProjectLimits.maximumCatalogBytes)
+            }
+            return data
+        } catch let error as ProjectCatalogRepositoryError {
+            throw error
+        } catch {
+            throw fileSystemError(error)
+        }
+    }
+
+    private func decode(_ data: Data) throws -> ProjectCatalog {
+        do {
+            let catalog = try Self.decoder.decode(ProjectCatalog.self, from: data)
+            return try validate(catalog)
+        } catch let error as ProjectCatalogValidationError {
+            throw ProjectCatalogRepositoryError.invalidCatalog(error)
+        } catch let error as ProjectCatalogRepositoryError {
+            throw error
+        } catch {
+            throw ProjectCatalogRepositoryError.malformedCatalog
+        }
+    }
+
+    private func encode(_ catalog: ProjectCatalog) throws -> Data {
+        do {
+            let data = try Self.encoder.encode(catalog)
+            guard data.count <= ProjectLimits.maximumCatalogBytes else {
+                throw ProjectCatalogRepositoryError.encodedCatalogTooLarge(
+                    limit: ProjectLimits.maximumCatalogBytes
+                )
+            }
+            return data
+        } catch let error as ProjectCatalogRepositoryError {
+            throw error
+        } catch {
+            throw fileSystemError(error)
+        }
+    }
+
+    private func validate(_ catalog: ProjectCatalog) throws -> ProjectCatalog {
+        do {
+            return try catalog.normalizedValidated()
+        } catch let error as ProjectCatalogValidationError {
+            throw ProjectCatalogRepositoryError.invalidCatalog(error)
+        }
+    }
+
+    private func writeAtomically(_ data: Data) throws {
+        let temporaryURL = directoryURL.appendingPathComponent(
+            ".projects-\(UUID().uuidString).tmp",
+            isDirectory: false
+        )
+        do {
+            try data.write(to: temporaryURL, options: .withoutOverwriting)
+            setRestrictiveFilePermissions(temporaryURL)
+            if try existingFileStatus() != nil {
+                _ = try fileManager.replaceItemAt(fileURL, withItemAt: temporaryURL)
+            } else {
+                try fileManager.moveItem(at: temporaryURL, to: fileURL)
+            }
+            setRestrictiveFilePermissions(fileURL)
+        } catch let error as ProjectCatalogRepositoryError {
+            try? fileManager.removeItem(at: temporaryURL)
+            throw error
+        } catch {
+            try? fileManager.removeItem(at: temporaryURL)
+            throw fileSystemError(error)
+        }
+    }
+
+    private func setRestrictiveFilePermissions(_ url: URL) {
+        _ = chmod(url.path, 0o600)
+    }
+
+    private func fileStatus(at url: URL) throws -> FileStatus? {
+        var value = stat()
+        let result = url.path.withCString { lstat($0, &value) }
+        if result == 0 {
+            return FileStatus(fileType: value.st_mode & S_IFMT, size: Int(clamping: value.st_size))
+        }
+        if errno == ENOENT {
+            return nil
+        }
+        throw ProjectCatalogRepositoryError.fileSystem(String(cString: strerror(errno)))
+    }
+
+    private func fileSystemError(_ error: Error) -> ProjectCatalogRepositoryError {
+        ProjectCatalogRepositoryError.fileSystem(error.localizedDescription)
+    }
+}

--- a/Tracexy/Core/Storage/ProjectDataFactory.swift
+++ b/Tracexy/Core/Storage/ProjectDataFactory.swift
@@ -1,0 +1,225 @@
+import Foundation
+
+// MARK: - ProjectDataLocation
+
+/// The resolved, identity-derived home of one Project's runtime data.
+///
+/// Exactly one Project — the *legacy owner* recorded in the catalog — keeps the
+/// pre-Projects locations (`History/history.sqlite`, `Captures`, the shared live
+/// spool). Every other Project is rooted under `Projects/<uuid>/`. Nothing here
+/// copies, moves, or deletes a user file: a location is only ever *resolved*.
+nonisolated struct ProjectDataLocation: Sendable, Equatable {
+    let projectID: UUID
+    /// True when this Project owns the pre-Projects data written before Project
+    /// isolation existed. Only one Project can ever be the legacy owner.
+    let isLegacyOwner: Bool
+    let historyDatabaseURL: URL
+    let capturesDirectoryURL: URL
+    let spoolDirectoryURL: URL
+    let settingsSuiteName: String
+}
+
+// MARK: - ProjectDataProviding
+
+/// Composition seam for everything a Project owns outside the JSON catalog:
+/// its terminal History database, its managed capture library folder, its live
+/// spool, and its preferences suite.
+///
+/// Tests inject a provider rooted at a temporary directory and a throwaway
+/// defaults suite prefix, so no test can reach a production path or the shared
+/// `UserDefaults` domain.
+@MainActor
+protocol ProjectDataProviding: AnyObject {
+    func location(forProject projectID: UUID, isLegacyOwner: Bool) -> ProjectDataLocation
+    /// Opening a Project's History database creates a folder and opens/migrates
+    /// SQLite. It is `async` because that work is prepared off the main actor from
+    /// the Sendable ``ProjectDataLocation`` descriptor, so changing Projects never
+    /// blocks the UI on file I/O.
+    func makeSessionStore(at location: ProjectDataLocation) async -> HistoryStoreFactory.Outcome
+    func makeLiveCaptureSpool(at location: ProjectDataLocation) -> LiveCaptureSpool
+    /// `nil` when Foundation cannot vend the suite. Callers must fail closed
+    /// rather than silently falling back to the shared domain.
+    func makeSettingsDefaults(at location: ProjectDataLocation) -> UserDefaults?
+    /// Creating the managed capture Library folder is file I/O and is prepared off
+    /// the main actor from the same Sendable descriptor.
+    func prepareCapturesDirectory(at location: ProjectDataLocation) async -> URL?
+}
+
+// MARK: - DefaultProjectDataProvider
+
+@MainActor
+final class DefaultProjectDataProvider: ProjectDataProviding {
+    // MARK: Lifecycle
+
+    /// `applicationSupportRoot`/`cacheRoot`/`settingsSuitePrefix`/`legacySettingsSource`
+    /// are injectable so tests never touch production storage or `.standard`.
+    ///
+    /// `identity` is optional rather than defaulted to `.current` so the default is
+    /// resolved *inside* this main-actor init. A default argument is evaluated in a
+    /// nonisolated context, where reading the main-actor-isolated `.current` is a
+    /// concurrency violation.
+    init(
+        identity: TracexyIdentity? = nil,
+        applicationSupportRoot: URL? = nil,
+        cacheRoot: URL? = nil,
+        settingsSuitePrefix: String? = nil,
+        legacySettingsSource: UserDefaults? = .standard,
+        fileManager: FileManager = .default
+    ) {
+        let resolvedIdentity = identity ?? .current
+        self.identity = resolvedIdentity
+        self.applicationSupportRoot = applicationSupportRoot
+            ?? resolvedIdentity.appSupportDirectory(fileManager: fileManager)
+        self.cacheRoot = cacheRoot
+            ?? Self.defaultCacheRoot(identity: resolvedIdentity, fileManager: fileManager)
+        self.settingsSuitePrefix = settingsSuitePrefix ?? "\(resolvedIdentity.defaultsPrefix).project"
+        self.legacySettingsSource = legacySettingsSource
+        self.fileManager = fileManager
+    }
+
+    // MARK: Internal
+
+    func location(forProject projectID: UUID, isLegacyOwner: Bool) -> ProjectDataLocation {
+        let root = isLegacyOwner
+            ? applicationSupportRoot
+            : applicationSupportRoot
+            .appendingPathComponent("Projects", isDirectory: true)
+            .appendingPathComponent(projectID.uuidString, isDirectory: true)
+        let spool = isLegacyOwner
+            ? cacheRoot.appendingPathComponent("LiveCaptureSpool", isDirectory: true)
+            : cacheRoot
+            .appendingPathComponent("LiveCaptureSpool", isDirectory: true)
+            .appendingPathComponent("Projects", isDirectory: true)
+            .appendingPathComponent(projectID.uuidString, isDirectory: true)
+        return ProjectDataLocation(
+            projectID: projectID,
+            isLegacyOwner: isLegacyOwner,
+            historyDatabaseURL: root.appendingPathComponent(
+                HistoryStoreFactory.relativeDatabasePath
+            ),
+            capturesDirectoryURL: root.appendingPathComponent("Captures", isDirectory: true),
+            spoolDirectoryURL: spool,
+            settingsSuiteName: "\(settingsSuitePrefix).\(projectID.uuidString)"
+        )
+    }
+
+    /// Prepared off the main actor. Only the Sendable descriptor crosses, and the
+    /// detached work uses its own `FileManager` rather than the injected one, which
+    /// stays on the main actor for path resolution.
+    func makeSessionStore(at location: ProjectDataLocation) async -> HistoryStoreFactory.Outcome {
+        let databaseURL = location.historyDatabaseURL
+        return await Task.detached(priority: .userInitiated) {
+            HistoryStoreFactory.make(databaseURL: databaseURL)
+        }.value
+    }
+
+    func makeLiveCaptureSpool(at location: ProjectDataLocation) -> LiveCaptureSpool {
+        LiveCaptureSpool(directory: location.spoolDirectoryURL)
+    }
+
+    func makeSettingsDefaults(at location: ProjectDataLocation) -> UserDefaults? {
+        guard let defaults = UserDefaults(suiteName: location.settingsSuiteName) else {
+            return nil
+        }
+        ProjectSettingsSeeding.prepare(
+            defaults,
+            suiteName: location.settingsSuiteName,
+            seedingFrom: location.isLegacyOwner ? legacySettingsSource : nil
+        )
+        return defaults
+    }
+
+    /// Prepared off the main actor, for the same reason as ``makeSessionStore(at:)``.
+    func prepareCapturesDirectory(at location: ProjectDataLocation) async -> URL? {
+        let directoryURL = location.capturesDirectoryURL
+        return await Task.detached(priority: .userInitiated) { () -> URL? in
+            do {
+                try FileManager.default.createDirectory(
+                    at: directoryURL,
+                    withIntermediateDirectories: true
+                )
+            } catch {
+                return nil
+            }
+            return directoryURL
+        }.value
+    }
+
+    // MARK: Private
+
+    private let identity: TracexyIdentity
+    private let applicationSupportRoot: URL
+    private let cacheRoot: URL
+    private let settingsSuitePrefix: String
+    private let legacySettingsSource: UserDefaults?
+    private let fileManager: FileManager
+
+    private static func defaultCacheRoot(identity: TracexyIdentity, fileManager: FileManager) -> URL {
+        let base = fileManager.urls(for: .cachesDirectory, in: .userDomainMask).first
+            ?? fileManager.temporaryDirectory
+        return base.appendingPathComponent(identity.appSupportDirectoryName, isDirectory: true)
+    }
+}
+
+// MARK: - ProjectSettingsSeeding
+
+/// Materializes the preference keys a Project owns into its own suite.
+///
+/// Two rules make this safe. First, `UserDefaults(suiteName:)` still searches the
+/// application domain, so an *absent* key would silently read the shared value —
+/// every project-scoped key is therefore written into the suite explicitly, and no
+/// project ever falls through to `.standard`. Second, the legacy owner is seeded
+/// from the pre-Projects keys and those keys are left exactly where they are: the
+/// seed reads, it never moves or deletes.
+///
+/// Every safe default below reproduces the behavior the resolvers already applied
+/// to an absent key, so materializing them changes no observable outcome.
+enum ProjectSettingsSeeding {
+    static let currentSeedVersion = 1
+
+    static var seedVersionKey: String {
+        TracexyIdentity.current.defaultsKey("project.settings.seedVersion")
+    }
+
+    /// The complete allowlist: key → the value a brand-new Project starts with.
+    static func safeDefaultValues() -> [String: Any] {
+        [
+            SettingsKeys.defaultView: DefaultView.sessions.rawValue,
+            SettingsKeys.defaultInterface: "",
+            SettingsKeys.autoStartCapture: false,
+            SettingsKeys.captureFilterMode: CaptureFilterMode.all.rawValue,
+            SettingsKeys.bpfExpression: "",
+            SettingsKeys.snapLength: CaptureConfiguration.defaultSnapLength,
+            SettingsKeys.promiscuous: false,
+            SettingsKeys.retainPackets: CaptureSettingsResolver.defaultRetainPackets,
+            SettingsKeys.redactBodies: true,
+            SettingsKeys.stripCredentials: true,
+            SettingsKeys.maskIPs: false,
+            SettingsKeys.autoClear: AutoClear.never.rawValue,
+            ProjectScopedSettingsKeys.pinnedHosts: [String](),
+            ProjectScopedSettingsKeys.focusSets: Data("[]".utf8),
+            ProjectScopedSettingsKeys.mutedHosts: [String](),
+            ProjectScopedSettingsKeys.mutedProtocols: [String](),
+            ProjectScopedSettingsKeys.hiddenSourceApps: [String](),
+            ProjectScopedSettingsKeys.hiddenSourceDomains: [String](),
+            ProjectScopedSettingsKeys.hiddenSourceIPs: [String](),
+            ProjectScopedSettingsKeys.inspectorLayout: InspectorLayout.hidden.rawValue,
+            ProjectScopedSettingsKeys.contextDockVisible: false,
+            ProjectScopedSettingsKeys.allowsAutomaticInspectorReveal: true,
+        ]
+    }
+
+    /// Write every missing project-scoped key into `defaults`' own suite domain.
+    /// `legacy` supplies the seed for the legacy owner only; a key absent there
+    /// falls back to the same safe default a new Project receives.
+    static func prepare(_ defaults: UserDefaults, suiteName: String, seedingFrom legacy: UserDefaults?) {
+        let owned = UserDefaults.standard.persistentDomain(forName: suiteName) ?? [:]
+        for (key, safeValue) in safeDefaultValues() where owned[key] == nil {
+            let seeded = legacy?.object(forKey: key)
+            defaults.set(seeded ?? safeValue, forKey: key)
+        }
+        if owned[seedVersionKey] == nil {
+            defaults.set(currentSeedVersion, forKey: seedVersionKey)
+        }
+    }
+}

--- a/Tracexy/Info.plist
+++ b/Tracexy/Info.plist
@@ -24,6 +24,28 @@
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>UTExportedTypeDeclarations</key>
+	<array>
+		<dict>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.json</string>
+			</array>
+			<key>UTTypeDescription</key>
+			<string>Tracexy Project Configuration</string>
+			<key>UTTypeIdentifier</key>
+			<string>$(TRACEXY_SHARED_UTTYPE_PREFIX).project</string>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>tracexyproject</string>
+				</array>
+				<key>public.mime-type</key>
+				<string>application/vnd.tracexy.project+json</string>
+			</dict>
+		</dict>
+	</array>
 	<key>LSMinimumSystemVersion</key>
 	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
 	<key>NSHumanReadableCopyright</key>

--- a/Tracexy/Models/Projects/ProjectModels.swift
+++ b/Tracexy/Models/Projects/ProjectModels.swift
@@ -224,22 +224,36 @@ nonisolated struct ProjectCatalog: Codable, Hashable, Sendable {
         schemaVersion: Int = ProjectCatalog.currentSchemaVersion,
         revision: UInt64 = 0,
         projects: [Project],
-        activeProjectID: UUID
+        activeProjectID: UUID,
+        legacyDataOwnerProjectID: UUID? = nil
     ) {
         self.schemaVersion = schemaVersion
         self.revision = revision
         self.projects = projects
         self.activeProjectID = activeProjectID
+        self.legacyDataOwnerProjectID = legacyDataOwnerProjectID
     }
 
     // MARK: Internal
 
     static let currentSchemaVersion = 1
 
+    /// Marks the pre-Projects History/Captures data as deliberately unowned.
+    ///
+    /// Catalog recovery uses it instead of handing existing data to a freshly
+    /// minted Project: the files stay on disk untouched, and no new Project can
+    /// silently inherit another user's capture history.
+    static let retiredLegacyDataOwnerID = UUID(uuid: (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0))
+
     var schemaVersion: Int
     var revision: UInt64
     var projects: [Project]
     var activeProjectID: UUID
+
+    /// The single Project that owns the pre-Projects `History/` database and
+    /// `Captures/` folder. Absent in a v1 catalog written before Project
+    /// isolation; assigned exactly once on first load and never reassigned.
+    var legacyDataOwnerProjectID: UUID?
 
     static func defaultCatalog(now: Date = Date()) -> ProjectCatalog {
         let workspace = ProjectWorkspaceSnapshot(title: "Live", isClosable: false)

--- a/Tracexy/Models/Projects/ProjectModels.swift
+++ b/Tracexy/Models/Projects/ProjectModels.swift
@@ -1,0 +1,415 @@
+import Foundation
+
+// MARK: - ProjectLimits
+
+nonisolated enum ProjectLimits {
+    static let minimumProjects = 1
+    static let maximumProjects = 128
+    static let minimumWorkspaces = 1
+    static let maximumWorkspacesPerProject = 32
+    static let maximumNameLength = 80
+    static let maximumStringLength = 512
+    static let maximumFilterRules = 64
+    static let maximumCatalogBytes = 2 * 1_024 * 1_024
+    static let maximumPortableProjectBytes = 1 * 1_024 * 1_024
+}
+
+// MARK: - ProjectNameNormalizationError
+
+nonisolated enum ProjectNameNormalizationError: Error, Equatable, Sendable {
+    case empty
+    case tooLong(limit: Int)
+    case containsControlCharacter
+}
+
+// MARK: - ProjectNameNormalization
+
+nonisolated enum ProjectNameNormalization {
+    nonisolated static func normalize(_ value: String) throws -> String {
+        let normalized = value
+            .precomposedStringWithCanonicalMapping
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !normalized.isEmpty else {
+            throw ProjectNameNormalizationError.empty
+        }
+        guard normalized.count <= ProjectLimits.maximumNameLength else {
+            throw ProjectNameNormalizationError.tooLong(limit: ProjectLimits.maximumNameLength)
+        }
+        guard !normalized.unicodeScalars.contains(where: { scalar in
+            if scalar.value == 0x200C || scalar.value == 0x200D {
+                return false
+            }
+            switch scalar.properties.generalCategory {
+            case .control,
+                 .format,
+                 .lineSeparator,
+                 .paragraphSeparator:
+                return true
+            default:
+                return false
+            }
+        }) else {
+            throw ProjectNameNormalizationError.containsControlCharacter
+        }
+        return normalized
+    }
+
+    nonisolated static func uniquenessKey(_ normalizedName: String) -> String {
+        normalizedName
+            .precomposedStringWithCanonicalMapping
+            .folding(
+                options: [.caseInsensitive, .diacriticInsensitive, .widthInsensitive],
+                locale: Locale(identifier: "en_US_POSIX")
+            )
+            .precomposedStringWithCanonicalMapping
+    }
+}
+
+// MARK: - ProjectFilterRuleSnapshot
+
+nonisolated struct ProjectFilterRuleSnapshot: Codable, Hashable, Sendable, Identifiable {
+    // MARK: Lifecycle
+
+    init(
+        id: UUID = UUID(),
+        isEnabled: Bool = true,
+        connector: String = "and",
+        field: String = "host",
+        filterOperator: String = "contains",
+        value: String = ""
+    ) {
+        self.id = id
+        self.isEnabled = isEnabled
+        self.connector = connector
+        self.field = field
+        self.filterOperator = filterOperator
+        self.value = value
+    }
+
+    // MARK: Internal
+
+    var id: UUID
+    var isEnabled: Bool
+    var connector: String
+    var field: String
+    var filterOperator: String
+    var value: String
+}
+
+// MARK: - ProjectWorkspaceSnapshot
+
+/// Configuration-only workspace state owned by a project.
+///
+/// Raw enum discriminators intentionally keep the persisted v1 schema independent
+/// of UI enum source changes. Hydration applies conservative fallbacks for unknown
+/// values. Selection, investigation results, capture bytes, source paths, History,
+/// and evidence locators are deliberately absent.
+nonisolated struct ProjectWorkspaceSnapshot: Codable, Hashable, Sendable, Identifiable {
+    // MARK: Lifecycle
+
+    init(
+        id: UUID = UUID(),
+        title: String,
+        isClosable: Bool = true,
+        sidebarSelection: String = "sessions",
+        navigatorMode: String = "browse",
+        isLiveChartExpanded: Bool = true,
+        inspectorTab: String = "timeline",
+        inspectorLayout: String = "hidden",
+        isContextDockVisible: Bool = false,
+        contextDockTab: String = "details",
+        allowsAutomaticInspectorReveal: Bool? = nil,
+        sessionGrouping: String = "none",
+        filterText: String = "",
+        searchField: String = "allFields",
+        isSearchEnabled: Bool = true,
+        categoryFilters: [String] = [],
+        hostFilter: String? = nil,
+        processFilter: String? = nil,
+        ipFilter: String? = nil,
+        filterRules: [ProjectFilterRuleSnapshot] = [ProjectFilterRuleSnapshot()],
+        isAdvancedFilterVisible: Bool = false,
+        isFilterBarVisible: Bool = true,
+        isFollowingLiveSessions: Bool = false
+    ) {
+        self.id = id
+        self.title = title
+        self.isClosable = isClosable
+        self.sidebarSelection = sidebarSelection
+        self.navigatorMode = navigatorMode
+        self.isLiveChartExpanded = isLiveChartExpanded
+        self.inspectorTab = inspectorTab
+        self.inspectorLayout = inspectorLayout
+        self.isContextDockVisible = isContextDockVisible
+        self.contextDockTab = contextDockTab
+        self.allowsAutomaticInspectorReveal = allowsAutomaticInspectorReveal
+        self.sessionGrouping = sessionGrouping
+        self.filterText = filterText
+        self.searchField = searchField
+        self.isSearchEnabled = isSearchEnabled
+        self.categoryFilters = categoryFilters
+        self.hostFilter = hostFilter
+        self.processFilter = processFilter
+        self.ipFilter = ipFilter
+        self.filterRules = filterRules
+        self.isAdvancedFilterVisible = isAdvancedFilterVisible
+        self.isFilterBarVisible = isFilterBarVisible
+        self.isFollowingLiveSessions = isFollowingLiveSessions
+    }
+
+    // MARK: Internal
+
+    var id: UUID
+    var title: String
+    var isClosable: Bool
+    var sidebarSelection: String
+    var navigatorMode: String
+    var isLiveChartExpanded: Bool
+    var inspectorTab: String
+    var inspectorLayout: String
+    var isContextDockVisible: Bool
+    var contextDockTab: String
+    var allowsAutomaticInspectorReveal: Bool?
+    var sessionGrouping: String
+    var filterText: String
+    var searchField: String
+    var isSearchEnabled: Bool
+    var categoryFilters: [String]
+    var hostFilter: String?
+    var processFilter: String?
+    var ipFilter: String?
+    var filterRules: [ProjectFilterRuleSnapshot]
+    var isAdvancedFilterVisible: Bool
+    var isFilterBarVisible: Bool
+    var isFollowingLiveSessions: Bool
+}
+
+// MARK: - Project
+
+nonisolated struct Project: Codable, Hashable, Sendable, Identifiable {
+    // MARK: Lifecycle
+
+    init(
+        id: UUID = UUID(),
+        name: String,
+        workspaces: [ProjectWorkspaceSnapshot],
+        activeWorkspaceID: UUID,
+        createdAt: Date = Date(),
+        updatedAt: Date = Date()
+    ) {
+        self.id = id
+        self.name = name
+        self.workspaces = workspaces
+        self.activeWorkspaceID = activeWorkspaceID
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+    }
+
+    // MARK: Internal
+
+    var id: UUID
+    var name: String
+    var workspaces: [ProjectWorkspaceSnapshot]
+    var activeWorkspaceID: UUID
+    var createdAt: Date
+    var updatedAt: Date
+}
+
+// MARK: - ProjectCatalog
+
+nonisolated struct ProjectCatalog: Codable, Hashable, Sendable {
+    // MARK: Lifecycle
+
+    init(
+        schemaVersion: Int = ProjectCatalog.currentSchemaVersion,
+        revision: UInt64 = 0,
+        projects: [Project],
+        activeProjectID: UUID
+    ) {
+        self.schemaVersion = schemaVersion
+        self.revision = revision
+        self.projects = projects
+        self.activeProjectID = activeProjectID
+    }
+
+    // MARK: Internal
+
+    static let currentSchemaVersion = 1
+
+    var schemaVersion: Int
+    var revision: UInt64
+    var projects: [Project]
+    var activeProjectID: UUID
+
+    static func defaultCatalog(now: Date = Date()) -> ProjectCatalog {
+        let workspace = ProjectWorkspaceSnapshot(title: "Live", isClosable: false)
+        let project = Project(
+            name: "My Project",
+            workspaces: [workspace],
+            activeWorkspaceID: workspace.id,
+            createdAt: now,
+            updatedAt: now
+        )
+        return ProjectCatalog(projects: [project], activeProjectID: project.id)
+    }
+}
+
+// MARK: - ProjectCatalogValidationError
+
+nonisolated enum ProjectCatalogValidationError: Error, Equatable, Sendable {
+    case unsupportedSchema(Int)
+    case projectCountOutOfBounds(count: Int, limit: Int)
+    case duplicateProjectID(UUID)
+    case activeProjectMissing(UUID)
+    case invalidProjectName(projectID: UUID, ProjectNameNormalizationError)
+    case duplicateProjectName(String)
+    case workspaceCountOutOfBounds(projectID: UUID, count: Int, limit: Int)
+    case duplicateWorkspaceID(UUID)
+    case activeWorkspaceMissing(projectID: UUID, workspaceID: UUID)
+    case invalidWorkspaceName(workspaceID: UUID, ProjectNameNormalizationError)
+    case duplicateWorkspaceName(projectID: UUID, name: String)
+    case tooManyFilterRules(workspaceID: UUID, count: Int)
+    case stringTooLong(field: String, limit: Int)
+    case invalidDate(projectID: UUID)
+}
+
+extension ProjectCatalog {
+    nonisolated func normalizedValidated(
+        maxProjects: Int = ProjectLimits.maximumProjects,
+        maxWorkspacesPerProject: Int = ProjectLimits.maximumWorkspacesPerProject
+    )
+        throws -> ProjectCatalog
+    {
+        guard schemaVersion == Self.currentSchemaVersion else {
+            throw ProjectCatalogValidationError.unsupportedSchema(schemaVersion)
+        }
+        let projectLimit = min(max(1, maxProjects), ProjectLimits.maximumProjects)
+        guard projects.count >= ProjectLimits.minimumProjects, projects.count <= projectLimit else {
+            throw ProjectCatalogValidationError.projectCountOutOfBounds(
+                count: projects.count,
+                limit: projectLimit
+            )
+        }
+
+        var result = self
+        var projectIDs = Set<UUID>()
+        var projectNames = Set<String>()
+        var workspaceIDs = Set<UUID>()
+
+        for projectIndex in result.projects.indices {
+            var project = result.projects[projectIndex]
+            guard projectIDs.insert(project.id).inserted else {
+                throw ProjectCatalogValidationError.duplicateProjectID(project.id)
+            }
+            guard project.createdAt.timeIntervalSinceReferenceDate.isFinite,
+                  project.updatedAt.timeIntervalSinceReferenceDate.isFinite else
+            {
+                throw ProjectCatalogValidationError.invalidDate(projectID: project.id)
+            }
+            do {
+                project.name = try ProjectNameNormalization.normalize(project.name)
+            } catch let error as ProjectNameNormalizationError {
+                throw ProjectCatalogValidationError.invalidProjectName(projectID: project.id, error)
+            }
+            let projectKey = ProjectNameNormalization.uniquenessKey(project.name)
+            guard projectNames.insert(projectKey).inserted else {
+                throw ProjectCatalogValidationError.duplicateProjectName(project.name)
+            }
+
+            let workspaceLimit = min(max(1, maxWorkspacesPerProject), ProjectLimits.maximumWorkspacesPerProject)
+            guard project.workspaces.count >= ProjectLimits.minimumWorkspaces,
+                  project.workspaces.count <= workspaceLimit else
+            {
+                throw ProjectCatalogValidationError.workspaceCountOutOfBounds(
+                    projectID: project.id,
+                    count: project.workspaces.count,
+                    limit: workspaceLimit
+                )
+            }
+
+            var workspaceNames = Set<String>()
+            for workspaceIndex in project.workspaces.indices {
+                var workspace = project.workspaces[workspaceIndex]
+                guard workspaceIDs.insert(workspace.id).inserted else {
+                    throw ProjectCatalogValidationError.duplicateWorkspaceID(workspace.id)
+                }
+                do {
+                    workspace.title = try ProjectNameNormalization.normalize(workspace.title)
+                } catch let error as ProjectNameNormalizationError {
+                    throw ProjectCatalogValidationError.invalidWorkspaceName(workspaceID: workspace.id, error)
+                }
+                let workspaceKey = ProjectNameNormalization.uniquenessKey(workspace.title)
+                guard workspaceNames.insert(workspaceKey).inserted else {
+                    throw ProjectCatalogValidationError.duplicateWorkspaceName(
+                        projectID: project.id,
+                        name: workspace.title
+                    )
+                }
+                guard workspace.filterRules.count <= ProjectLimits.maximumFilterRules else {
+                    throw ProjectCatalogValidationError.tooManyFilterRules(
+                        workspaceID: workspace.id,
+                        count: workspace.filterRules.count
+                    )
+                }
+                try workspace.validateStrings()
+                project.workspaces[workspaceIndex] = workspace
+            }
+            guard project.workspaces.contains(where: { $0.id == project.activeWorkspaceID }) else {
+                throw ProjectCatalogValidationError.activeWorkspaceMissing(
+                    projectID: project.id,
+                    workspaceID: project.activeWorkspaceID
+                )
+            }
+            result.projects[projectIndex] = project
+        }
+        guard result.projects.contains(where: { $0.id == result.activeProjectID }) else {
+            throw ProjectCatalogValidationError.activeProjectMissing(result.activeProjectID)
+        }
+        return result
+    }
+}
+
+private extension ProjectWorkspaceSnapshot {
+    nonisolated func validateStrings() throws {
+        let required: [(String, String)] = [
+            ("sidebarSelection", sidebarSelection),
+            ("navigatorMode", navigatorMode),
+            ("inspectorTab", inspectorTab),
+            ("inspectorLayout", inspectorLayout),
+            ("contextDockTab", contextDockTab),
+            ("sessionGrouping", sessionGrouping),
+            ("filterText", filterText),
+            ("searchField", searchField),
+        ]
+        for (field, value) in required {
+            try Self.validate(value, field: field)
+        }
+        for value in categoryFilters {
+            try Self.validate(value, field: "categoryFilters")
+        }
+        for (field, value) in [
+            ("hostFilter", hostFilter),
+            ("processFilter", processFilter),
+            ("ipFilter", ipFilter),
+        ] {
+            if let value {
+                try Self.validate(value, field: field)
+            }
+        }
+        for rule in filterRules {
+            try Self.validate(rule.connector, field: "filterRules.connector")
+            try Self.validate(rule.field, field: "filterRules.field")
+            try Self.validate(rule.filterOperator, field: "filterRules.operator")
+            try Self.validate(rule.value, field: "filterRules.value")
+        }
+    }
+
+    nonisolated static func validate(_ value: String, field: String) throws {
+        guard value.count <= ProjectLimits.maximumStringLength else {
+            throw ProjectCatalogValidationError.stringTooLong(
+                field: field,
+                limit: ProjectLimits.maximumStringLength
+            )
+        }
+    }
+}

--- a/Tracexy/Models/Projects/ProjectRuntimeState.swift
+++ b/Tracexy/Models/Projects/ProjectRuntimeState.swift
@@ -1,0 +1,184 @@
+import Foundation
+
+// MARK: - ProjectRuntimeState
+
+/// Everything one Project owns at runtime, held while that Project is parked.
+///
+/// The coordinator keeps one bucket per Project (bounded by
+/// ``ProjectStore/maxProjects``) and moves state between the bucket and its own
+/// observable properties at a Project boundary. Nothing is evicted: a parked
+/// Project keeps its real ``WorkspaceStore`` instance — with its selection,
+/// investigation drafts, query results and layout — its own ``SessionStore``,
+/// its own preferences suite, and its own ``LiveCaptureSpool`` actor, so another
+/// Project starting or resetting a capture can never destroy its evidence.
+///
+/// Deliberately absent: raw Follow Stream bytes and the derived evidence/cited
+/// frame pipelines. Those are selection-scoped raw payload and are retired at
+/// every boundary; they are rebuilt from the immutable snapshot on restore.
+@MainActor
+final class ProjectRuntimeState {
+    // MARK: Lifecycle
+
+    init(
+        projectID: UUID?,
+        location: ProjectDataLocation?,
+        settingsDefaults: UserDefaults,
+        layoutPreferences: WorkspaceLayoutPreferences,
+        workspaces: WorkspaceStore,
+        sessionStore: SessionStore?,
+        historyUnavailableReason: String? = nil,
+        liveCaptureSpool: LiveCaptureSpool,
+        capturesDirectory: URL?,
+        captureInterface: String
+    ) {
+        self.projectID = projectID
+        self.location = location
+        self.settingsDefaults = settingsDefaults
+        self.layoutPreferences = layoutPreferences
+        self.workspaces = workspaces
+        self.sessionStore = sessionStore
+        self.historyUnavailableReason = historyUnavailableReason
+        self.liveCaptureSpool = liveCaptureSpool
+        self.capturesDirectory = capturesDirectory
+        self.captureInterface = captureInterface
+        retainedFrames = RetainedFrameBuffer(capacity: MainContentCoordinator.retainedFrameLimit)
+        historyAvailability = sessionStore == nil ? .unavailable : .idle
+    }
+
+    // MARK: Internal
+
+    // MARK: Identity and resources
+
+    /// `nil` only for the pre-hydration runtime, which is bound to the hydrated
+    /// active Project instead of a provisional random identity.
+    var projectID: UUID?
+    var location: ProjectDataLocation?
+    let settingsDefaults: UserDefaults
+    let layoutPreferences: WorkspaceLayoutPreferences
+    let workspaces: WorkspaceStore
+    let liveCaptureSpool: LiveCaptureSpool
+    var sessionStore: SessionStore?
+    var historyUnavailableReason: String?
+    var capturesDirectory: URL?
+
+    // MARK: Parked capture/session state
+
+    var sessions: [SessionSummary] = []
+    var investigationSnapshot: InvestigationSnapshot = .empty
+    var retainedFrames: RetainedFrameBuffer
+    var throughputSamples: [ThroughputSample] = []
+    var pendingChartBytes = 0
+    var captureInterface: String
+    var captureError: String?
+    var captureStatistics: CaptureStatistics?
+    var helperBufferDropCount: UInt64 = 0
+    var currentLinkType: UInt32 = LinkType.ethernet
+    var removedSessionIDs: Set<UUID> = []
+
+    /// True when this Project's stopped live spool had already completed its exact
+    /// final ingest boundary. The generation token itself is never carried across a
+    /// switch — it is rebased onto a fresh, globally monotonic token on restore —
+    /// while the spool's own opaque locator identities are untouched.
+    var isStoppedCaptureReady = false
+
+    // MARK: Parked saved-capture state
+
+    var savedCaptures: [SavedCapture] = []
+    var isViewingSavedCapture = false
+    var activeSavedCapture: SavedCapture?
+    var savedCaptureActivity: CaptureActivity?
+    var savedCaptureWarning: String?
+    var savedCaptureEvidence: [UUID: CaptureEvidenceReference] = [:]
+    var savedCaptureEvidenceURL: URL?
+    var selectedSessionEvidenceID: UUID?
+    var selectedSessionEvidenceBytes: [UInt8] = []
+    var selectedSessionEvidenceError: String?
+
+    // MARK: Parked preference-backed state
+
+    var pinnedHosts: [String] = []
+    var focusSets: [FocusSet] = []
+    var mutedHosts: Set<String> = []
+    var mutedProtocols: Set<ProtocolKind> = []
+    var hiddenSourceApps: Set<String> = []
+    var hiddenSourceDomains: Set<String> = []
+    var hiddenSourceIPs: Set<String> = []
+
+    // MARK: Parked History read/write state
+
+    var historyAvailability: HistoryAvailability
+    var historyCaptures: [HistoryStoredCapture] = []
+    var historyCaptureCursor: HistoryCaptureCursor?
+    var selectedHistoryCaptureID: UUID?
+    var historySessions: [HistorySessionRecord] = []
+    var historySessionCursor: HistorySessionCursor?
+    var historySessionsAvailability: HistoryAvailability = .idle
+    var historyAutoClear: AutoClear = .never
+    var historyError: String?
+    var historyRetentionError: String?
+    var scheduledHistoryTerminals: Set<HistoryTerminalToken> = []
+
+    /// Load the preference-backed collections from this Project's own suite.
+    func loadPreferenceBackedState() {
+        pinnedHosts = settingsDefaults.stringArray(forKey: ProjectScopedSettingsKeys.pinnedHosts) ?? []
+        if let data = settingsDefaults.data(forKey: ProjectScopedSettingsKeys.focusSets),
+           let sets = try? JSONDecoder().decode([FocusSet].self, from: data)
+        {
+            focusSets = sets
+        } else {
+            focusSets = []
+        }
+        mutedHosts = Set(settingsDefaults.stringArray(forKey: ProjectScopedSettingsKeys.mutedHosts) ?? [])
+        mutedProtocols = Set(
+            (settingsDefaults.stringArray(forKey: ProjectScopedSettingsKeys.mutedProtocols) ?? [])
+                .compactMap(ProtocolKind.init(rawValue:))
+        )
+        hiddenSourceApps = SourceVisibilityPreferences.loadApps(defaults: settingsDefaults)
+        hiddenSourceDomains = SourceVisibilityPreferences.loadDomains(defaults: settingsDefaults)
+        hiddenSourceIPs = SourceVisibilityPreferences.loadIPs(defaults: settingsDefaults)
+        historyAutoClear = HistoryRetentionSettingsResolver.autoClear(defaults: settingsDefaults)
+    }
+}
+
+// MARK: - ProjectTransitionStatus
+
+/// Coarse state of the one Project lifecycle path. `pending` blocks capture start
+/// and further transitions; `failed` keeps the outgoing Project active and offers
+/// a retry rather than guessing that the outgoing capture drained.
+nonisolated enum ProjectTransitionStatus: Equatable, Sendable {
+    case idle
+    case pending
+    case failed(String)
+
+    // MARK: Internal
+
+    var isPending: Bool {
+        self == .pending
+    }
+
+    var failureMessage: String? {
+        guard case let .failed(message) = self else {
+            return nil
+        }
+        return message
+    }
+}
+
+// MARK: - ProjectSwitchConfirmationRequest
+
+/// A Project change the user must confirm because it will stop a running or
+/// starting capture first. Cancelling leaves the outgoing Project untouched.
+nonisolated struct ProjectSwitchConfirmationRequest: Identifiable, Equatable, Sendable {
+    enum Kind: Equatable, Sendable {
+        case switchProject(UUID)
+        case createProject(String)
+        case importProject(Project)
+        case deleteProject(UUID)
+    }
+
+    let id: UUID
+    let kind: Kind
+    /// The Project the capture belongs to, for the confirmation copy.
+    let outgoingProjectName: String
+    let destinationDescription: String
+}

--- a/Tracexy/Models/Projects/ProjectStore.swift
+++ b/Tracexy/Models/Projects/ProjectStore.swift
@@ -1,0 +1,462 @@
+import Foundation
+import Observation
+
+// MARK: - ProjectCatalogLoadState
+
+enum ProjectCatalogLoadState: Equatable {
+    case idle
+    case loading
+    case ready
+    case failed(String)
+}
+
+// MARK: - ProjectCatalogPersistenceState
+
+enum ProjectCatalogPersistenceState: Equatable {
+    case idle
+    case saving
+    case saved
+    case failed(String)
+}
+
+// MARK: - ProjectMutationError
+
+enum ProjectMutationError: Error, Equatable {
+    case nameInvalid(ProjectNameNormalizationError)
+    case duplicateName
+    case capacityReached(limit: Int)
+    case workspaceCapacityReached(limit: Int)
+    case projectNotFound
+    case cannotDeleteFinalProject
+    case storeNotReady
+    case revisionExhausted
+    case invalidWorkspaceSnapshot(ProjectCatalogValidationError)
+
+    // MARK: Internal
+
+    var userFacingDescription: String {
+        switch self {
+        case .nameInvalid(.empty):
+            "Enter a project name."
+        case let .nameInvalid(.tooLong(limit)):
+            "Project names can contain at most \(limit) characters."
+        case .nameInvalid(.containsControlCharacter):
+            "That project name contains unsupported characters."
+        case .duplicateName:
+            "A project with that name already exists."
+        case let .capacityReached(limit):
+            "Tracexy supports up to \(limit) projects."
+        case let .workspaceCapacityReached(limit):
+            "This project supports up to \(limit) workspaces."
+        case .projectNotFound:
+            "That project is no longer available."
+        case .cannotDeleteFinalProject:
+            "Tracexy must keep at least one project."
+        case .storeNotReady:
+            "Projects are not ready yet."
+        case .revisionExhausted:
+            "This project catalog can no longer be updated."
+        case .invalidWorkspaceSnapshot:
+            "One or more workspaces could not be saved."
+        }
+    }
+}
+
+// MARK: - ProjectStore
+
+@MainActor
+@Observable
+final class ProjectStore {
+    // MARK: Lifecycle
+
+    init(
+        maxProjects: Int,
+        maxWorkspacesPerProject: Int,
+        repository: ProjectCatalogPersisting? = nil,
+        catalog: ProjectCatalog? = nil,
+        now: @escaping () -> Date = { Date() }
+    ) {
+        self.maxProjects = min(max(1, maxProjects), ProjectLimits.maximumProjects)
+        self.maxWorkspacesPerProject = min(
+            max(1, maxWorkspacesPerProject),
+            ProjectLimits.maximumWorkspacesPerProject
+        )
+        self.repository = repository
+        self.now = now
+
+        let proposed = catalog ?? ProjectCatalog.defaultCatalog(now: now())
+        let normalized = try? proposed.normalizedValidated(
+            maxProjects: self.maxProjects,
+            maxWorkspacesPerProject: self.maxWorkspacesPerProject
+        )
+        let initial = normalized ?? ProjectCatalog.defaultCatalog(now: now())
+        self.catalog = initial
+        self.seedCatalog = initial
+        if repository == nil {
+            loadState = .ready
+            persistenceState = .saved
+        }
+    }
+
+    // MARK: Internal
+
+    private(set) var loadState: ProjectCatalogLoadState = .idle
+    private(set) var persistenceState: ProjectCatalogPersistenceState = .idle
+
+    let maxProjects: Int
+    let maxWorkspacesPerProject: Int
+
+    /// Compatibility spelling used by coordinator presentation code.
+    var persistenceStatus: ProjectCatalogPersistenceState {
+        persistenceState
+    }
+
+    var loadFailureMessage: String? {
+        guard case let .failed(message) = loadState else {
+            return nil
+        }
+        return message
+    }
+
+    var projects: [Project] {
+        catalog.projects
+    }
+
+    var activeProjectID: UUID {
+        catalog.activeProjectID
+    }
+
+    var activeProject: Project {
+        catalog.projects.first(where: { $0.id == catalog.activeProjectID }) ?? catalog.projects[0]
+    }
+
+    var isMutable: Bool {
+        guard loadState == .ready else {
+            return false
+        }
+        if case .failed = persistenceState {
+            return false
+        }
+        return true
+    }
+
+    var canCreateProject: Bool {
+        isMutable && catalog.projects.count < maxProjects
+    }
+
+    func loadPersistedCatalog() async {
+        guard let repository else {
+            loadState = .ready
+            persistenceState = .saved
+            return
+        }
+        await waitForPendingPersistence()
+        loadState = .loading
+        persistenceState = .idle
+        do {
+            let loaded = try await repository.load(seed: seedCatalog)
+            catalog = try loaded.normalizedValidated(
+                maxProjects: maxProjects,
+                maxWorkspacesPerProject: maxWorkspacesPerProject
+            )
+            loadState = .ready
+            persistenceState = .saved
+        } catch {
+            loadState = .failed(Self.errorDescription(error))
+            persistenceState = .idle
+        }
+    }
+
+    func retryLoad() async {
+        await loadPersistedCatalog()
+    }
+
+    func resetToDefaultCatalog() async {
+        await waitForPendingPersistence()
+        guard let nextRevision = try? nextRevision(after: catalog.revision) else {
+            let message = ProjectMutationError.revisionExhausted.userFacingDescription
+            loadState = .failed(message)
+            persistenceState = .failed(message)
+            return
+        }
+        var resetCatalog = ProjectCatalog.defaultCatalog(now: now())
+        resetCatalog.revision = nextRevision
+        guard let validated = try? validatedForPolicy(resetCatalog) else {
+            let message = "The default project catalog could not be prepared."
+            loadState = .failed(message)
+            persistenceState = .failed(message)
+            return
+        }
+        resetCatalog = validated
+
+        loadState = .loading
+        persistenceState = .saving
+        do {
+            if let repository {
+                resetCatalog = try await repository.reset(to: resetCatalog)
+            }
+            catalog = resetCatalog
+            seedCatalog = resetCatalog
+            loadState = .ready
+            persistenceState = .saved
+        } catch {
+            loadState = .failed(Self.errorDescription(error))
+            persistenceState = .failed(Self.errorDescription(error))
+        }
+    }
+
+    @discardableResult
+    func createProject(name: String) throws -> Project {
+        try requireMutable()
+        guard catalog.projects.count < maxProjects else {
+            throw ProjectMutationError.capacityReached(limit: maxProjects)
+        }
+        let normalizedName = try normalizeName(name)
+        guard !containsProjectName(normalizedName, excluding: nil) else {
+            throw ProjectMutationError.duplicateName
+        }
+        let timestamp = now()
+        let workspace = ProjectWorkspaceSnapshot(title: "Live", isClosable: false)
+        let project = Project(
+            name: normalizedName,
+            workspaces: [workspace],
+            activeWorkspaceID: workspace.id,
+            createdAt: timestamp,
+            updatedAt: timestamp
+        )
+        try commitMutation { catalog in
+            catalog.projects.append(project)
+            catalog.activeProjectID = project.id
+        }
+        return project
+    }
+
+    /// Insert a configuration-only imported project as a new catalog object.
+    /// All identities are regenerated even when the source happens not to
+    /// collide, keeping repeated imports independent and preventing overwrite.
+    @discardableResult
+    func importProject(_ project: Project) throws -> Project {
+        try requireMutable()
+        guard catalog.projects.count < maxProjects else {
+            throw ProjectMutationError.capacityReached(limit: maxProjects)
+        }
+        let normalizedName = try normalizeName(project.name)
+        guard !containsProjectName(normalizedName, excluding: nil) else {
+            throw ProjectMutationError.duplicateName
+        }
+        guard project.workspaces.count <= maxWorkspacesPerProject else {
+            throw ProjectMutationError.workspaceCapacityReached(limit: maxWorkspacesPerProject)
+        }
+
+        var source = project
+        source.name = normalizedName
+        let validated: Project
+        do {
+            let temporary = ProjectCatalog(projects: [source], activeProjectID: source.id)
+            validated = try temporary.normalizedValidated(
+                maxProjects: 1,
+                maxWorkspacesPerProject: maxWorkspacesPerProject
+            ).projects[0]
+        } catch let error as ProjectCatalogValidationError {
+            throw ProjectMutationError.invalidWorkspaceSnapshot(error)
+        }
+
+        let imported = regeneratedProject(validated)
+        try commitMutation { catalog in
+            catalog.projects.append(imported)
+            catalog.activeProjectID = imported.id
+        }
+        return imported
+    }
+
+    func selectProject(id: UUID) throws {
+        try requireMutable()
+        guard catalog.projects.contains(where: { $0.id == id }) else {
+            throw ProjectMutationError.projectNotFound
+        }
+        guard catalog.activeProjectID != id else {
+            return
+        }
+        try commitMutation { catalog in
+            catalog.activeProjectID = id
+        }
+    }
+
+    func renameProject(id: UUID, to name: String) throws {
+        try requireMutable()
+        guard let index = catalog.projects.firstIndex(where: { $0.id == id }) else {
+            throw ProjectMutationError.projectNotFound
+        }
+        let normalizedName = try normalizeName(name)
+        guard !containsProjectName(normalizedName, excluding: id) else {
+            throw ProjectMutationError.duplicateName
+        }
+        guard catalog.projects[index].name != normalizedName else {
+            return
+        }
+        try commitMutation { catalog in
+            catalog.projects[index].name = normalizedName
+            catalog.projects[index].updatedAt = now()
+        }
+    }
+
+    func deleteProject(id: UUID) throws {
+        try requireMutable()
+        guard catalog.projects.count > ProjectLimits.minimumProjects else {
+            throw ProjectMutationError.cannotDeleteFinalProject
+        }
+        guard let index = catalog.projects.firstIndex(where: { $0.id == id }) else {
+            throw ProjectMutationError.projectNotFound
+        }
+        try commitMutation { catalog in
+            catalog.projects.remove(at: index)
+            if catalog.activeProjectID == id {
+                catalog.activeProjectID = catalog.projects[min(index, catalog.projects.count - 1)].id
+            }
+        }
+    }
+
+    func updateActiveProjectWorkspaces(
+        _ workspaces: [ProjectWorkspaceSnapshot],
+        activeWorkspaceID: UUID
+    )
+        throws
+    {
+        try requireMutable()
+        guard workspaces.count <= maxWorkspacesPerProject else {
+            throw ProjectMutationError.workspaceCapacityReached(limit: maxWorkspacesPerProject)
+        }
+        guard let projectIndex = catalog.projects.firstIndex(where: { $0.id == catalog.activeProjectID }) else {
+            throw ProjectMutationError.projectNotFound
+        }
+        do {
+            try commitMutation { catalog in
+                catalog.projects[projectIndex].workspaces = workspaces
+                catalog.projects[projectIndex].activeWorkspaceID = activeWorkspaceID
+                catalog.projects[projectIndex].updatedAt = now()
+            }
+        } catch let error as ProjectCatalogValidationError {
+            throw ProjectMutationError.invalidWorkspaceSnapshot(error)
+        }
+    }
+
+    func waitForPendingPersistence() async {
+        let pending = pendingPersistenceTask
+        await pending?.value
+    }
+
+    // MARK: Private
+
+    private var catalog: ProjectCatalog
+    private var seedCatalog: ProjectCatalog
+
+    @ObservationIgnored private let repository: ProjectCatalogPersisting?
+
+    @ObservationIgnored private let now: () -> Date
+
+    @ObservationIgnored private var pendingPersistenceTask: Task<Void, Never>?
+
+    @ObservationIgnored private var pendingPersistenceToken: UUID?
+
+    private static func errorDescription(_ error: Error) -> String {
+        if let error = error as? LocalizedError, let description = error.errorDescription {
+            return description
+        }
+        return String(describing: error)
+    }
+
+    private func requireMutable() throws {
+        guard isMutable else {
+            throw ProjectMutationError.storeNotReady
+        }
+    }
+
+    private func normalizeName(_ name: String) throws -> String {
+        do {
+            return try ProjectNameNormalization.normalize(name)
+        } catch let error as ProjectNameNormalizationError {
+            throw ProjectMutationError.nameInvalid(error)
+        }
+    }
+
+    private func containsProjectName(_ name: String, excluding projectID: UUID?) -> Bool {
+        let key = ProjectNameNormalization.uniquenessKey(name)
+        return catalog.projects.contains { project in
+            project.id != projectID && ProjectNameNormalization.uniquenessKey(project.name) == key
+        }
+    }
+
+    private func nextRevision(after revision: UInt64) throws -> UInt64 {
+        guard revision < UInt64.max else {
+            throw ProjectMutationError.revisionExhausted
+        }
+        return revision + 1
+    }
+
+    private func regeneratedProject(_ source: Project) -> Project {
+        var workspaceIDs: [UUID: UUID] = [:]
+        let workspaces = source.workspaces.map { workspace -> ProjectWorkspaceSnapshot in
+            let newID = UUID()
+            workspaceIDs[workspace.id] = newID
+            var copy = workspace
+            copy.id = newID
+            copy.filterRules = workspace.filterRules.map { rule in
+                var copy = rule
+                copy.id = UUID()
+                return copy
+            }
+            return copy
+        }
+        let timestamp = now()
+        return Project(
+            name: source.name,
+            workspaces: workspaces,
+            activeWorkspaceID: workspaceIDs[source.activeWorkspaceID] ?? workspaces[0].id,
+            createdAt: timestamp,
+            updatedAt: timestamp
+        )
+    }
+
+    private func validatedForPolicy(_ candidate: ProjectCatalog) throws -> ProjectCatalog {
+        try candidate.normalizedValidated(
+            maxProjects: maxProjects,
+            maxWorkspacesPerProject: maxWorkspacesPerProject
+        )
+    }
+
+    private func commitMutation(_ mutation: (inout ProjectCatalog) -> Void) throws {
+        let expectedRevision = catalog.revision
+        var candidate = catalog
+        mutation(&candidate)
+        candidate.revision = try nextRevision(after: expectedRevision)
+        candidate = try validatedForPolicy(candidate)
+        catalog = candidate
+        enqueuePersistence(candidate, expectedRevision: expectedRevision)
+    }
+
+    private func enqueuePersistence(_ snapshot: ProjectCatalog, expectedRevision: UInt64) {
+        guard let repository else {
+            persistenceState = .saved
+            return
+        }
+        let previous = pendingPersistenceTask
+        let token = UUID()
+        pendingPersistenceToken = token
+        persistenceState = .saving
+        pendingPersistenceTask = Task { @MainActor [weak self] in
+            await previous?.value
+            do {
+                try await repository.save(snapshot, expectedRevision: expectedRevision)
+                guard self?.pendingPersistenceToken == token else {
+                    return
+                }
+                self?.persistenceState = .saved
+            } catch {
+                guard self?.pendingPersistenceToken == token else {
+                    return
+                }
+                self?.persistenceState = .failed(Self.errorDescription(error))
+            }
+        }
+    }
+}

--- a/Tracexy/Models/Projects/ProjectStore.swift
+++ b/Tracexy/Models/Projects/ProjectStore.swift
@@ -62,6 +62,46 @@ enum ProjectMutationError: Error, Equatable {
     }
 }
 
+// MARK: - ProjectCatalogTransition
+
+/// The catalog change one Project lifecycle transition intends to make. Kept
+/// separate from the UI's confirmation request so the store validates a change
+/// without knowing why it was asked for.
+nonisolated enum ProjectCatalogTransition: Sendable {
+    case select(UUID)
+    case create(name: String)
+    case adopt(Project)
+    case delete(UUID)
+}
+
+// MARK: - PreparedProjectCatalogTransition
+
+/// A validated catalog change that has **not** been published or written.
+///
+/// Preparing one freezes every other catalog mutation until it is committed or
+/// discarded, so nothing can interleave between validation and the durable
+/// write. A preparation that is never committed leaves the catalog — and the
+/// Project the user is on — exactly as it was.
+nonisolated struct PreparedProjectCatalogTransition: Sendable {
+    // MARK: Internal
+
+    let id: UUID
+    /// The Project that becomes active once this transition is published. Its
+    /// identity is minted at validation time, so a caller can name the
+    /// destination before the change is durable.
+    let destinationProject: Project
+    /// The Project this transition removes from the catalog, if any. Only the
+    /// JSON configuration is removed; its History database, Library folder and
+    /// spool stay exactly where they are on disk.
+    let deletedProjectID: UUID?
+
+    // MARK: Fileprivate
+
+    fileprivate let candidate: ProjectCatalog
+    fileprivate let expectedRevision: UInt64
+    fileprivate var resetsCatalog = false
+}
+
 // MARK: - ProjectStore
 
 @MainActor
@@ -130,8 +170,20 @@ final class ProjectStore {
         catalog.projects.first(where: { $0.id == catalog.activeProjectID }) ?? catalog.projects[0]
     }
 
+    /// The Project that owns the pre-Projects History database and Captures
+    /// folder, or `nil` before it has been assigned on first load.
+    var legacyDataOwnerProjectID: UUID? {
+        catalog.legacyDataOwnerProjectID
+    }
+
+    /// True while a prepared transition is holding the catalog. Every ordinary
+    /// mutation is frozen until it commits or is discarded.
+    var isCatalogTransitionPrepared: Bool {
+        preparedTransitionID != nil
+    }
+
     var isMutable: Bool {
-        guard loadState == .ready else {
+        guard loadState == .ready, preparedTransitionID == nil else {
             return false
         }
         if case .failed = persistenceState {
@@ -171,7 +223,33 @@ final class ProjectStore {
         await loadPersistedCatalog()
     }
 
+    /// Bind the pre-Projects data to exactly one Project, exactly once.
+    ///
+    /// A catalog written before Project isolation carries no owner, so the first
+    /// listed Project adopts the existing History database and Captures folder and
+    /// that choice is persisted before any capture, History write, or Library scan
+    /// is allowed. A catalog that already names an owner — including the retired
+    /// sentinel left by recovery — is returned unchanged: the owner is never
+    /// reassigned when it is deleted or when the active Project changes.
+    @discardableResult
+    func assignLegacyDataOwnerIfNeeded() throws -> UUID {
+        if let existing = catalog.legacyDataOwnerProjectID {
+            return existing
+        }
+        try requireMutable()
+        let owner = catalog.projects[0].id
+        try commitMutation { catalog in
+            catalog.legacyDataOwnerProjectID = owner
+        }
+        return owner
+    }
+
     func resetToDefaultCatalog() async {
+        // A prepared transition owns the catalog until it settles; replacing it
+        // underneath would publish a catalog the transition never validated.
+        guard preparedTransitionID == nil else {
+            return
+        }
         await waitForPendingPersistence()
         guard let nextRevision = try? nextRevision(after: catalog.revision) else {
             let message = ProjectMutationError.revisionExhausted.userFacingDescription
@@ -181,6 +259,12 @@ final class ProjectStore {
         }
         var resetCatalog = ProjectCatalog.defaultCatalog(now: now())
         resetCatalog.revision = nextRevision
+        // Recovery mints a brand-new Project. Handing it the pre-Projects History
+        // and Captures would silently reassign someone else's data, so the owner
+        // is either preserved (when the previous catalog was readable) or retired.
+        // Either way the files stay on disk and no new Project inherits them.
+        resetCatalog.legacyDataOwnerProjectID = catalog.legacyDataOwnerProjectID
+            ?? ProjectCatalog.retiredLegacyDataOwnerID
         guard let validated = try? validatedForPolicy(resetCatalog) else {
             let message = "The default project catalog could not be prepared."
             loadState = .failed(message)
@@ -237,36 +321,170 @@ final class ProjectStore {
     @discardableResult
     func importProject(_ project: Project) throws -> Project {
         try requireMutable()
-        guard catalog.projects.count < maxProjects else {
-            throw ProjectMutationError.capacityReached(limit: maxProjects)
-        }
-        let normalizedName = try normalizeName(project.name)
-        guard !containsProjectName(normalizedName, excluding: nil) else {
-            throw ProjectMutationError.duplicateName
-        }
-        guard project.workspaces.count <= maxWorkspacesPerProject else {
-            throw ProjectMutationError.workspaceCapacityReached(limit: maxWorkspacesPerProject)
-        }
-
-        var source = project
-        source.name = normalizedName
-        let validated: Project
-        do {
-            let temporary = ProjectCatalog(projects: [source], activeProjectID: source.id)
-            validated = try temporary.normalizedValidated(
-                maxProjects: 1,
-                maxWorkspacesPerProject: maxWorkspacesPerProject
-            ).projects[0]
-        } catch let error as ProjectCatalogValidationError {
-            throw ProjectMutationError.invalidWorkspaceSnapshot(error)
-        }
-
-        let imported = regeneratedProject(validated)
+        let imported = try validatedImport(project)
         try commitMutation { catalog in
             catalog.projects.append(imported)
             catalog.activeProjectID = imported.id
         }
         return imported
+    }
+
+    // MARK: The durable prepared transition
+
+    /// Explicit recovery prepares fresh ownership without publishing the new
+    /// catalog. The coordinator can open its resources before replacing a file.
+    func prepareResetTransition() throws -> PreparedProjectCatalogTransition {
+        guard preparedTransitionID == nil, loadState != .loading else {
+            throw ProjectMutationError.storeNotReady
+        }
+        var candidate = ProjectCatalog.defaultCatalog(now: now())
+        candidate.revision = try nextRevision(after: catalog.revision)
+        candidate.legacyDataOwnerProjectID = catalog.legacyDataOwnerProjectID
+            ?? ProjectCatalog.retiredLegacyDataOwnerID
+        candidate = try validatedForPolicy(candidate)
+        let prepared = PreparedProjectCatalogTransition(
+            id: UUID(),
+            destinationProject: candidate.projects[0],
+            deletedProjectID: nil,
+            candidate: candidate,
+            expectedRevision: catalog.revision,
+            resetsCatalog: true
+        )
+        preparedTransitionID = prepared.id
+        return prepared
+    }
+
+    /// Validate `transition` against the current catalog and return the resulting
+    /// candidate **without publishing or writing it**.
+    ///
+    /// The catalog is frozen from here until the returned value is committed or
+    /// discarded, so a caller can resolve the destination Project's storage — and
+    /// wait out a capture's final drain — knowing nothing else can move underneath.
+    func prepareTransition(_ transition: ProjectCatalogTransition) throws -> PreparedProjectCatalogTransition {
+        try requireMutable()
+        let expectedRevision = catalog.revision
+        var candidate = catalog
+        var deletedProjectID: UUID?
+        let destinationID: UUID
+
+        switch transition {
+        case let .select(id):
+            guard candidate.projects.contains(where: { $0.id == id }) else {
+                throw ProjectMutationError.projectNotFound
+            }
+            candidate.activeProjectID = id
+            destinationID = id
+        case let .create(name):
+            guard candidate.projects.count < maxProjects else {
+                throw ProjectMutationError.capacityReached(limit: maxProjects)
+            }
+            let normalizedName = try normalizeName(name)
+            guard !containsProjectName(normalizedName, excluding: nil) else {
+                throw ProjectMutationError.duplicateName
+            }
+            let timestamp = now()
+            let workspace = ProjectWorkspaceSnapshot(title: "Live", isClosable: false)
+            let project = Project(
+                name: normalizedName,
+                workspaces: [workspace],
+                activeWorkspaceID: workspace.id,
+                createdAt: timestamp,
+                updatedAt: timestamp
+            )
+            candidate.projects.append(project)
+            candidate.activeProjectID = project.id
+            destinationID = project.id
+        case let .adopt(project):
+            let imported = try validatedImport(project)
+            candidate.projects.append(imported)
+            candidate.activeProjectID = imported.id
+            destinationID = imported.id
+        case let .delete(id):
+            guard candidate.projects.count > ProjectLimits.minimumProjects else {
+                throw ProjectMutationError.cannotDeleteFinalProject
+            }
+            guard let index = candidate.projects.firstIndex(where: { $0.id == id }) else {
+                throw ProjectMutationError.projectNotFound
+            }
+            candidate.projects.remove(at: index)
+            if candidate.activeProjectID == id {
+                candidate.activeProjectID = candidate.projects[min(index, candidate.projects.count - 1)].id
+            }
+            deletedProjectID = id
+            destinationID = candidate.activeProjectID
+        }
+
+        candidate.revision = try nextRevision(after: expectedRevision)
+        do {
+            candidate = try validatedForPolicy(candidate)
+        } catch let error as ProjectCatalogValidationError {
+            throw ProjectMutationError.invalidWorkspaceSnapshot(error)
+        }
+        guard let destination = candidate.projects.first(where: { $0.id == destinationID }) else {
+            throw ProjectMutationError.projectNotFound
+        }
+
+        let prepared = PreparedProjectCatalogTransition(
+            id: UUID(),
+            destinationProject: destination,
+            deletedProjectID: deletedProjectID,
+            candidate: candidate,
+            expectedRevision: expectedRevision
+        )
+        preparedTransitionID = prepared.id
+        return prepared
+    }
+
+    /// Publish a prepared transition, but only after it has been written durably.
+    ///
+    /// The candidate is never adopted before the write succeeds, so a failed save
+    /// leaves both the in-memory catalog and the file on disk exactly as they
+    /// were. Because nothing diverged, the persisted state is restored rather than
+    /// marked failed and the transition stays retryable.
+    func commitPreparedTransition(_ prepared: PreparedProjectCatalogTransition) async throws {
+        guard preparedTransitionID == prepared.id else {
+            throw ProjectMutationError.storeNotReady
+        }
+        // Every earlier write must have settled before the candidate is written, so
+        // a slow previous save can never land on top of the new catalog.
+        await waitForPendingPersistence()
+        guard preparedTransitionID == prepared.id,
+              catalog.revision == prepared.expectedRevision else
+        {
+            preparedTransitionID = nil
+            throw ProjectMutationError.storeNotReady
+        }
+        if let repository {
+            let previousPersistenceState = persistenceState
+            persistenceState = .saving
+            do {
+                if prepared.resetsCatalog {
+                    _ = try await repository.reset(to: prepared.candidate)
+                } else {
+                    try await repository.save(prepared.candidate, expectedRevision: prepared.expectedRevision)
+                }
+            } catch {
+                persistenceState = previousPersistenceState
+                preparedTransitionID = nil
+                throw error
+            }
+        }
+        catalog = prepared.candidate
+        if prepared.resetsCatalog {
+            seedCatalog = catalog
+        }
+        loadState = .ready
+        persistenceState = .saved
+        preparedTransitionID = nil
+    }
+
+    /// Release a prepared transition without publishing it. The catalog is
+    /// unfrozen and nothing it described ever happened.
+    func discardPreparedTransition(_ prepared: PreparedProjectCatalogTransition) {
+        guard preparedTransitionID == prepared.id else {
+            return
+        }
+        preparedTransitionID = nil
     }
 
     func selectProject(id: UUID) throws {
@@ -350,6 +568,11 @@ final class ProjectStore {
     private var catalog: ProjectCatalog
     private var seedCatalog: ProjectCatalog
 
+    /// The prepared-but-unpublished transition currently holding the catalog.
+    /// Deliberately observed, so surfaces gated on ``isMutable`` refresh when the
+    /// catalog freezes and unfreezes.
+    private var preparedTransitionID: UUID?
+
     @ObservationIgnored private let repository: ProjectCatalogPersisting?
 
     @ObservationIgnored private let now: () -> Date
@@ -391,6 +614,35 @@ final class ProjectStore {
             throw ProjectMutationError.revisionExhausted
         }
         return revision + 1
+    }
+
+    /// Validate an imported configuration and regenerate every identity. Shared by
+    /// the direct insert and the prepared transition so both apply the same policy.
+    private func validatedImport(_ project: Project) throws -> Project {
+        guard catalog.projects.count < maxProjects else {
+            throw ProjectMutationError.capacityReached(limit: maxProjects)
+        }
+        let normalizedName = try normalizeName(project.name)
+        guard !containsProjectName(normalizedName, excluding: nil) else {
+            throw ProjectMutationError.duplicateName
+        }
+        guard project.workspaces.count <= maxWorkspacesPerProject else {
+            throw ProjectMutationError.workspaceCapacityReached(limit: maxWorkspacesPerProject)
+        }
+
+        var source = project
+        source.name = normalizedName
+        let validated: Project
+        do {
+            let temporary = ProjectCatalog(projects: [source], activeProjectID: source.id)
+            validated = try temporary.normalizedValidated(
+                maxProjects: 1,
+                maxWorkspacesPerProject: maxWorkspacesPerProject
+            ).projects[0]
+        } catch let error as ProjectCatalogValidationError {
+            throw ProjectMutationError.invalidWorkspaceSnapshot(error)
+        }
+        return regeneratedProject(validated)
     }
 
     private func regeneratedProject(_ source: Project) -> Project {

--- a/Tracexy/Models/Projects/ProjectWorkspaceSnapshot+WorkspaceState.swift
+++ b/Tracexy/Models/Projects/ProjectWorkspaceSnapshot+WorkspaceState.swift
@@ -1,0 +1,97 @@
+import Foundation
+
+extension ProjectWorkspaceSnapshot {
+    @MainActor
+    init(capturing workspace: WorkspaceState) {
+        self.init(
+            id: workspace.id,
+            title: workspace.title,
+            isClosable: workspace.isClosable,
+            sidebarSelection: workspace.sidebarSelection.rawValue,
+            navigatorMode: workspace.navigatorMode.rawValue,
+            isLiveChartExpanded: workspace.isLiveChartExpanded,
+            inspectorTab: workspace.inspectorTab.rawValue,
+            inspectorLayout: workspace.inspectorLayout.rawValue,
+            isContextDockVisible: workspace.isContextDockVisible,
+            contextDockTab: workspace.contextDockTab.rawValue,
+            allowsAutomaticInspectorReveal: workspace.allowsAutomaticInspectorReveal,
+            sessionGrouping: workspace.sessionGrouping.rawValue,
+            filterText: workspace.filterText,
+            searchField: workspace.searchField.rawValue,
+            isSearchEnabled: workspace.isSearchEnabled,
+            categoryFilters: workspace.categoryFilters.map(\.rawValue).sorted(),
+            hostFilter: workspace.hostFilter,
+            processFilter: workspace.processFilter,
+            ipFilter: workspace.ipFilter,
+            filterRules: workspace.filterRules.map(ProjectFilterRuleSnapshot.init),
+            isAdvancedFilterVisible: workspace.isAdvancedFilterVisible,
+            isFilterBarVisible: workspace.isFilterBarVisible,
+            isFollowingLiveSessions: workspace.isFollowingLiveSessions
+        )
+    }
+
+    @MainActor
+    func hydrateWorkspaceState(
+        maxFilterRules: Int,
+        allowsAutomaticInspectorReveal defaultAutomaticReveal: Bool?
+    )
+        -> WorkspaceState
+    {
+        let workspace = WorkspaceState(
+            id: id,
+            title: title,
+            isClosable: isClosable,
+            sidebarSelection: SidebarItem(rawValue: sidebarSelection) ?? .sessions,
+            inspectorLayout: InspectorLayout(rawValue: inspectorLayout) ?? .hidden,
+            isContextDockVisible: isContextDockVisible
+        )
+        workspace.navigatorMode = SidebarNavigatorMode(rawValue: navigatorMode) ?? .browse
+        workspace.isLiveChartExpanded = isLiveChartExpanded
+        workspace.inspectorTab = InspectorTab(rawValue: inspectorTab) ?? .timeline
+        workspace.contextDockTab = ContextDockTab(rawValue: contextDockTab) ?? .details
+        workspace.allowsAutomaticInspectorReveal = allowsAutomaticInspectorReveal ?? defaultAutomaticReveal
+        workspace.sessionGrouping = SessionGrouping(rawValue: sessionGrouping) ?? .none
+        workspace.filterText = filterText
+        workspace.searchField = SessionSearchField(rawValue: searchField) ?? .allFields
+        workspace.isSearchEnabled = isSearchEnabled
+        workspace.categoryFilters = Set(categoryFilters.compactMap(SessionFilterCategory.init(rawValue:)))
+        workspace.hostFilter = hostFilter
+        workspace.processFilter = processFilter
+        workspace.ipFilter = ipFilter
+        workspace.filterRules = SessionFilterRule.normalized(
+            filterRules.map(SessionFilterRule.init),
+            limit: min(max(1, maxFilterRules), ProjectLimits.maximumFilterRules)
+        )
+        workspace.isAdvancedFilterVisible = isAdvancedFilterVisible
+        workspace.isFilterBarVisible = isFilterBarVisible
+        workspace.isFollowingLiveSessions = isFollowingLiveSessions
+        return workspace
+    }
+}
+
+private extension ProjectFilterRuleSnapshot {
+    @MainActor
+    init(_ rule: SessionFilterRule) {
+        self.init(
+            id: rule.id,
+            isEnabled: rule.isEnabled,
+            connector: rule.connector.rawValue,
+            field: rule.field.rawValue,
+            filterOperator: rule.filterOperator.rawValue,
+            value: rule.value
+        )
+    }
+}
+
+private extension SessionFilterRule {
+    nonisolated init(_ snapshot: ProjectFilterRuleSnapshot) {
+        self.init(
+            id: snapshot.id,
+            isEnabled: snapshot.isEnabled,
+            connector: FilterLogicConnector(rawValue: snapshot.connector) ?? .and,
+            field: SessionFilterField(rawValue: snapshot.field) ?? .host,
+            filterOperator: SessionFilterOperator(rawValue: snapshot.filterOperator) ?? .contains,
+            value: snapshot.value
+        )
+    }
+}

--- a/Tracexy/Models/Settings/AppPolicy.swift
+++ b/Tracexy/Models/Settings/AppPolicy.swift
@@ -13,6 +13,8 @@ import Foundation
 ///
 /// The shipping baseline is ``DefaultAppPolicy``.
 protocol AppPolicy: Sendable {
+    /// Maximum local Projects, including the default Project.
+    var maxProjects: Int { get }
     /// Maximum user-created workspace tabs, including the first one.
     var maxWorkspaceTabs: Int { get }
     /// Maximum saved focus sets in the sidebar's focus library.
@@ -24,6 +26,10 @@ protocol AppPolicy: Sendable {
 }
 
 extension AppPolicy {
+    var maxProjects: Int {
+        3
+    }
+
     var maxWorkspaceTabs: Int {
         8
     }
@@ -47,6 +53,7 @@ extension AppPolicy {
 /// rather than inherited from the protocol extension so this file reads as the
 /// single answer to "what are the limits?".
 struct DefaultAppPolicy: AppPolicy {
+    let maxProjects = 3
     let maxWorkspaceTabs = 8
     let maxFocusSets = 5
     let maxPinnedHosts = 5

--- a/Tracexy/Models/UI/AppSettings.swift
+++ b/Tracexy/Models/UI/AppSettings.swift
@@ -44,6 +44,33 @@ enum SettingsKeys {
     }
 }
 
+// MARK: - ProjectScopedSettingsKeys
+
+/// Preference keys that are *not* surfaced in the Settings window but are still
+/// owned independently by each Project (pins, Focus Sets, muted noise, hidden
+/// sources, remembered panel layout). Centralized here so the per-Project suite
+/// seeding and the readers below can never drift apart.
+enum ProjectScopedSettingsKeys {
+    // MARK: Internal
+
+    static let pinnedHosts = key("pinnedHosts")
+    static let focusSets = key("focusSets")
+    static let mutedHosts = key("noise.mutedHosts")
+    static let mutedProtocols = key("noise.mutedProtocols")
+    static let hiddenSourceApps = key("sources.hiddenApps")
+    static let hiddenSourceDomains = key("sources.hiddenDomains")
+    static let hiddenSourceIPs = key("sources.hiddenIPs")
+    static let inspectorLayout = key("workspace.inspectorLayout")
+    static let contextDockVisible = key("workspace.contextDockVisible")
+    static let allowsAutomaticInspectorReveal = key("workspace.allowsAutomaticInspectorReveal")
+
+    // MARK: Private
+
+    private static func key(_ suffix: String) -> String {
+        TracexyIdentity.current.defaultsKey(suffix)
+    }
+}
+
 // MARK: - SettingsTab
 
 enum SettingsTab: String, CaseIterable, Identifiable, Hashable {

--- a/Tracexy/Models/UI/MainContentPresentationModels.swift
+++ b/Tracexy/Models/UI/MainContentPresentationModels.swift
@@ -1,0 +1,67 @@
+import Foundation
+
+// MARK: - CaptureDisplayState
+
+/// Coarse capture state shown in the toolbar status capsule.
+enum CaptureDisplayState {
+    case stopped
+    case starting
+    case capturing
+    case error
+
+    // MARK: Internal
+
+    var title: String {
+        switch self {
+        case .stopped: String(localized: "Stopped")
+        case .starting: String(localized: "Starting")
+        case .capturing: String(localized: "Capturing")
+        case .error: String(localized: "Error")
+        }
+    }
+}
+
+// MARK: - SavedCapture
+
+/// One saved `.pcap` or `.pcapng` file listed under Saved Captures.
+struct SavedCapture: Identifiable, Hashable, Sendable {
+    let url: URL
+    let name: String
+    let date: Date
+    let byteCount: Int
+
+    var id: URL {
+        url
+    }
+}
+
+// MARK: - DomainGroup
+
+struct DomainGroup: Identifiable {
+    let domain: String
+    let ips: [String]
+    let count: Int
+
+    var id: String {
+        domain
+    }
+}
+
+// MARK: - AppGroup
+
+struct AppGroup: Identifiable {
+    let app: String
+    let hosts: [String]
+    let count: Int
+
+    var id: String {
+        app
+    }
+}
+
+// MARK: - ThroughputSample
+
+struct ThroughputSample: Identifiable {
+    let id = UUID()
+    let bytesPerSecond: Double
+}

--- a/Tracexy/Models/UI/WorkspaceLayoutPreferences.swift
+++ b/Tracexy/Models/UI/WorkspaceLayoutPreferences.swift
@@ -47,12 +47,9 @@ struct WorkspaceLayoutPreferences {
 
     // MARK: Private
 
-    private static let inspectorLayoutKey = TracexyIdentity.current
-        .defaultsKey("workspace.inspectorLayout")
-    private static let contextDockKey = TracexyIdentity.current
-        .defaultsKey("workspace.contextDockVisible")
-    private static let automaticRevealKey = TracexyIdentity.current
-        .defaultsKey("workspace.allowsAutomaticInspectorReveal")
+    private static let inspectorLayoutKey = ProjectScopedSettingsKeys.inspectorLayout
+    private static let contextDockKey = ProjectScopedSettingsKeys.contextDockVisible
+    private static let automaticRevealKey = ProjectScopedSettingsKeys.allowsAutomaticInspectorReveal
 
     private let defaults: UserDefaults
 }

--- a/Tracexy/Models/UI/WorkspaceStore.swift
+++ b/Tracexy/Models/UI/WorkspaceStore.swift
@@ -8,12 +8,18 @@ final class WorkspaceStore {
     /// `maxWorkspaces` arrives as a plain number: the store enforces a cap, it
     /// does not decide one. The composition root resolves it from the app
     /// policy and hands the value in.
-    init(maxWorkspaces: Int, layoutPreferences: WorkspaceLayoutPreferences? = nil) {
+    /// `defaults` is the active Project's preferences suite, so "Default view" is
+    /// resolved per Project rather than app-wide.
+    init(
+        maxWorkspaces: Int,
+        layoutPreferences: WorkspaceLayoutPreferences? = nil,
+        defaults: UserDefaults = .standard
+    ) {
         self.maxWorkspaces = maxWorkspaces
-        let preferences = layoutPreferences ?? WorkspaceLayoutPreferences()
+        let preferences = layoutPreferences ?? WorkspaceLayoutPreferences(defaults: defaults)
         self.layoutPreferences = preferences
         // Honor the General → "Default view" preference for the first workspace.
-        let stored = UserDefaults.standard.string(forKey: SettingsKeys.defaultView)
+        let stored = defaults.string(forKey: SettingsKeys.defaultView)
         let landing = stored.flatMap(DefaultView.init(rawValue:))?.sidebarItem ?? .sessions
         // Both panels start closed, whatever the remembered preference is.
         //

--- a/Tracexy/Models/UI/WorkspaceStore.swift
+++ b/Tracexy/Models/UI/WorkspaceStore.swift
@@ -85,6 +85,36 @@ final class WorkspaceStore {
         }
     }
 
+    /// Captures only the bounded, durable view intent owned by the active
+    /// Project. Session selection, Investigation results, and capture evidence
+    /// deliberately remain outside the Project catalog.
+    func captureProjectWorkspaces() -> [ProjectWorkspaceSnapshot] {
+        workspaces.map(ProjectWorkspaceSnapshot.init(capturing:))
+    }
+
+    /// Replaces the live workspace set from a validated Project snapshot. This
+    /// changes presentation only: the coordinator's capture/session/History
+    /// state is app-wide and is never swapped or cleared by Project navigation.
+    func applyProjectWorkspaces(
+        _ snapshots: [ProjectWorkspaceSnapshot],
+        activeWorkspaceID desiredActiveWorkspaceID: UUID,
+        maxFilterRules: Int
+    ) {
+        let hydrated = snapshots.map {
+            $0.hydrateWorkspaceState(
+                maxFilterRules: maxFilterRules,
+                allowsAutomaticInspectorReveal: layoutPreferences.allowsAutomaticInspectorReveal
+            )
+        }
+        guard !hydrated.isEmpty else {
+            return
+        }
+        workspaces = hydrated
+        activeWorkspaceID = hydrated.contains { $0.id == desiredActiveWorkspaceID }
+            ? desiredActiveWorkspaceID
+            : hydrated[0].id
+    }
+
     // MARK: Private
 
     /// Seeds new workspaces from the remembered inspector-dock choice.

--- a/Tracexy/Theme/Theme.swift
+++ b/Tracexy/Theme/Theme.swift
@@ -118,6 +118,8 @@ enum Theme {
         /// at narrow desktop widths. The menu and full accessible label stay intact.
         static let toolbarCompactWindowWidth: CGFloat = 1_180
         static let toolbarInterfaceLabelMaximumWidth: CGFloat = 140
+        static let toolbarSeparatorWidth: CGFloat = 1
+        static let toolbarSeparatorHeight: CGFloat = 18
         /// The label frame inside a small native glass button. Native button
         /// insets expand this to a comfortable pointer target; keeping the inner
         /// square at the approved 27pt rhythm prevents toolbar glyphs from looking

--- a/Tracexy/Theme/Theme.swift
+++ b/Tracexy/Theme/Theme.swift
@@ -114,6 +114,10 @@ enum Theme {
         /// Center toolbar status + software-update badge: one 32pt native control
         /// with a 24pt continuous capsule inset.
         static let toolbarControlHeight: CGFloat = 32
+        /// Keep capture-source text away from Project identity and centered status
+        /// at narrow desktop widths. The menu and full accessible label stay intact.
+        static let toolbarCompactWindowWidth: CGFloat = 1_180
+        static let toolbarInterfaceLabelMaximumWidth: CGFloat = 140
         /// The label frame inside a small native glass button. Native button
         /// insets expand this to a comfortable pointer target; keeping the inner
         /// square at the approved 27pt rhythm prevents toolbar glyphs from looking

--- a/Tracexy/TracexyApp.swift
+++ b/Tracexy/TracexyApp.swift
@@ -23,6 +23,7 @@ struct TracexyApp: App {
                     AppThemeApplier.apply(AppAppearance(rawValue: newValue) ?? .system)
                 }
                 .task {
+                    appDelegate.coordinator = coordinator
                     updater.startIfConfigured()
                 }
         }
@@ -31,6 +32,7 @@ struct TracexyApp: App {
         .windowToolbarStyle(.unified)
         .commands {
             TracexySettingsCommands()
+            TracexyProjectCommands(coordinator: coordinator)
 
             // View ▸ Show/Hide Sidebar (⌃⌘S). Routes through the NSSplitViewController
             // responder chain, so the native collapse KVO resynchronizes RootView's
@@ -124,6 +126,8 @@ struct TracexyApp: App {
         historyDemoDefaults ?? .standard
     }
 
+    @NSApplicationDelegateAdaptor(AppDelegate.self) private var appDelegate
+
     /// The single shared coordinator, owned by the app so every scene (main
     /// window + editor/manager windows) reads and mutates the same state.
     ///
@@ -164,16 +168,86 @@ struct TracexyApp: App {
             }
         }
 
+        let projectRepository = JSONProjectCatalogRepository(
+            directoryURL: TracexyIdentity.current.appSupportPath("Projects", fileManager: .default)
+        )
+
         switch HistoryStoreFactory.production() {
         case let .ready(store):
-            let coordinator = MainContentCoordinator(policy: AppPolicyProvider.current, sessionStore: store)
+            let coordinator = MainContentCoordinator(
+                policy: AppPolicyProvider.current,
+                sessionStore: store,
+                projectRepository: projectRepository
+            )
             coordinator.configureHistoryAutoClear(HistoryRetentionSettingsResolver.autoClear())
             return coordinator
         case let .unavailable(reason):
-            let coordinator = MainContentCoordinator(policy: AppPolicyProvider.current)
+            let coordinator = MainContentCoordinator(
+                policy: AppPolicyProvider.current,
+                projectRepository: projectRepository
+            )
             coordinator.historyError = reason
             coordinator.configureHistoryAutoClear(HistoryRetentionSettingsResolver.autoClear())
             return coordinator
+        }
+    }
+}
+
+// MARK: - TracexyProjectCommands
+
+private struct TracexyProjectCommands: Commands {
+    let coordinator: MainContentCoordinator
+
+    var body: some Commands {
+        CommandMenu("Project") {
+            Button("New Project…") {
+                coordinator.presentNewProjectEditor()
+            }
+            .keyboardShortcut("n", modifiers: [.command, .shift])
+            .disabled(!coordinator.projectStore.canCreateProject)
+
+            Button("Rename Project…") {
+                coordinator.presentRenameProjectEditor(id: coordinator.projectStore.activeProjectID)
+            }
+            .disabled(!coordinator.projectStore.isMutable)
+
+            Button("Manage Projects…") {
+                coordinator.isProjectManagerPresented = true
+            }
+
+            Divider()
+
+            Button("Export Project Configuration…") {
+                coordinator.exportProjectConfiguration(coordinator.projectStore.activeProject)
+            }
+            .disabled(!coordinator.projectStore.isMutable)
+
+            Button("Import Project Configuration…") {
+                coordinator.importProjectConfiguration()
+            }
+            .disabled(!coordinator.projectStore.canCreateProject)
+
+            Divider()
+
+            ForEach(coordinator.projectStore.projects) { project in
+                Button {
+                    coordinator.switchToProject(id: project.id)
+                } label: {
+                    if project.id == coordinator.projectStore.activeProjectID {
+                        Label(project.name, systemImage: "checkmark")
+                    } else {
+                        Text(project.name)
+                    }
+                }
+                .disabled(!coordinator.projectStore.isMutable)
+            }
+
+            if case .failed = coordinator.projectStore.loadState {
+                Divider()
+                Button("Repair Projects…") {
+                    coordinator.isProjectRecoveryPresented = true
+                }
+            }
         }
     }
 }

--- a/Tracexy/TracexyApp.swift
+++ b/Tracexy/TracexyApp.swift
@@ -76,8 +76,12 @@ struct TracexyApp: App {
 
         // Focus / Noise managers open as real Mac windows (not sheets), sharing the
         // one app-level coordinator so edits flow straight back to the main window.
+        // The auxiliary editors are remounted on the Project identity, so a draft
+        // left open across a Project change cannot be saved into the new Project.
         Window("Edit Focus Set", id: Self.focusSetEditorWindowID) {
             FocusSetEditorWindow(coordinator: coordinator)
+                .id(coordinator.projectStore.activeProjectID)
+                .disabled(!coordinator.hasHydratedProjects || coordinator.projectTransitionStatus.isPending)
                 .preferredColorScheme(colorScheme)
         }
         .defaultSize(width: 600, height: 420)
@@ -86,6 +90,8 @@ struct TracexyApp: App {
 
         Window("Noise Control", id: Self.noiseControlWindowID) {
             NoiseControlWindow(coordinator: coordinator)
+                .id(coordinator.projectStore.activeProjectID)
+                .disabled(!coordinator.hasHydratedProjects || coordinator.projectTransitionStatus.isPending)
                 .preferredColorScheme(colorScheme)
         }
         .defaultSize(width: 460, height: 560)
@@ -100,11 +106,21 @@ struct TracexyApp: App {
         Window("Settings", id: "settings") {
             SettingsView(
                 updater: updater,
+                applicationDefaults: Self.applicationDefaults,
+                activeProjectName: coordinator.projectStore.activeProject.name,
+                isProjectReady: coordinator.hasHydratedProjects,
                 historyRetentionError: coordinator.historyRetentionError,
                 isHistoryDemoMode: coordinator.isHistoryDemoMode,
                 onAutoClearChange: { coordinator.configureHistoryAutoClear($0) }
             )
-            .defaultAppStorage(Self.settingsDefaults)
+            // Capture, Privacy and default-view preferences belong to the active
+            // Project's own suite. Remounting on the Project identity is what stops
+            // an editor left open across a switch from applying one Project's draft
+            // to another; the panes that must stay app-wide (appearance, updater,
+            // helper, selected tab) name `.standard` explicitly.
+            .defaultAppStorage(coordinator.activeProjectDefaults)
+            .id(coordinator.projectStore.activeProjectID)
+            .disabled(coordinator.projectTransitionStatus.isPending)
             .preferredColorScheme(colorScheme)
         }
         .defaultSize(width: 900, height: 640)
@@ -122,8 +138,14 @@ struct TracexyApp: App {
         ? HistoryDemoLaunchMode.freshSettingsDefaults()
         : nil
 
-    private static var settingsDefaults: UserDefaults {
-        historyDemoDefaults ?? .standard
+    private static var applicationDefaults: UserDefaults {
+        guard isHistoryDemoMode else {
+            return .standard
+        }
+        guard let historyDemoDefaults else {
+            preconditionFailure("Synthetic History requires an isolated settings store.")
+        }
+        return historyDemoDefaults
     }
 
     @NSApplicationDelegateAdaptor(AppDelegate.self) private var appDelegate
@@ -139,7 +161,10 @@ struct TracexyApp: App {
 
     /// The user's General → Appearance preference, applied app-wide. `nil` follows
     /// the system.
-    @AppStorage(SettingsKeys.appearance) private var appearance = AppAppearance.system.rawValue
+    /// Appearance is an application preference, so it names the shared domain
+    /// explicitly and is unaffected by the per-Project settings suites.
+    @AppStorage(SettingsKeys.appearance, store: TracexyApp.applicationDefaults)
+    private var appearance = AppAppearance.system.rawValue
 
     private var colorScheme: ColorScheme? {
         AppAppearance(rawValue: appearance)?.colorScheme
@@ -148,48 +173,51 @@ struct TracexyApp: App {
     /// Resolve the terminal-history store for production. A directory/open/migration
     /// failure is isolated here: the app and capture engine start regardless, and
     /// History simply reports itself unavailable.
+    /// Resolve per-Project storage for production. History, the managed capture
+    /// Library and the preferences suite are now resolved *per Project* by the
+    /// provider at hydration, so a directory/open/migration failure stays isolated
+    /// to the Project it belongs to: the app and capture engine start regardless,
+    /// and that Project's History simply reports itself unavailable.
     private static func composeCoordinator() -> MainContentCoordinator {
         if isHistoryDemoMode {
-            guard historyDemoDefaults != nil else {
-                let coordinator = MainContentCoordinator(policy: AppPolicyProvider.current)
-                coordinator.historyError = "Synthetic History couldn’t start because its isolated settings store is unavailable."
-                return coordinator
-            }
+            let demoDefaults = applicationDefaults
+            let demoRoot = FileManager.default.temporaryDirectory
+                .appendingPathComponent("Tracexy-HistoryDemo-\(UUID().uuidString)", isDirectory: true)
+            let provider = DefaultProjectDataProvider(
+                applicationSupportRoot: demoRoot.appendingPathComponent("Support", isDirectory: true),
+                cacheRoot: demoRoot.appendingPathComponent("Cache", isDirectory: true),
+                settingsSuitePrefix: "\(HistoryDemoLaunchMode.settingsSuiteName()).project",
+                legacySettingsSource: nil
+            )
             do {
+                // The demo never shares the production defaults domain, and its
+                // Project suites are namespaced under the demo suite as well.
                 return try MainContentCoordinator(
                     policy: AppPolicyProvider.current,
                     sessionStore: SessionStore(),
-                    isHistoryDemoMode: true
+                    projectDataProvider: provider,
+                    isHistoryDemoMode: true,
+                    settingsDefaults: demoDefaults
                 )
             } catch {
-                let coordinator = MainContentCoordinator(policy: AppPolicyProvider.current)
+                let coordinator = MainContentCoordinator(
+                    policy: AppPolicyProvider.current,
+                    projectDataProvider: provider,
+                    isHistoryDemoMode: true,
+                    settingsDefaults: demoDefaults
+                )
                 coordinator.historyError = "Synthetic History couldn’t start — \(error.localizedDescription)"
                 return coordinator
             }
         }
 
-        let projectRepository = JSONProjectCatalogRepository(
-            directoryURL: TracexyIdentity.current.appSupportPath("Projects", fileManager: .default)
+        return MainContentCoordinator(
+            policy: AppPolicyProvider.current,
+            projectRepository: JSONProjectCatalogRepository(
+                directoryURL: TracexyIdentity.current.appSupportPath("Projects", fileManager: .default)
+            ),
+            projectDataProvider: DefaultProjectDataProvider()
         )
-
-        switch HistoryStoreFactory.production() {
-        case let .ready(store):
-            let coordinator = MainContentCoordinator(
-                policy: AppPolicyProvider.current,
-                sessionStore: store,
-                projectRepository: projectRepository
-            )
-            coordinator.configureHistoryAutoClear(HistoryRetentionSettingsResolver.autoClear())
-            return coordinator
-        case let .unavailable(reason):
-            let coordinator = MainContentCoordinator(
-                policy: AppPolicyProvider.current,
-                projectRepository: projectRepository
-            )
-            coordinator.historyError = reason
-            coordinator.configureHistoryAutoClear(HistoryRetentionSettingsResolver.autoClear())
-            return coordinator
-        }
     }
 }
 
@@ -264,6 +292,8 @@ private struct SessionInspectorWindowScene: Scene {
     var body: some Scene {
         let base = Window("Session Inspector", id: TracexyApp.sessionInspectorWindowID) {
             InspectorView(coordinator: coordinator, allowsDetaching: false)
+                .id(coordinator.projectStore.activeProjectID)
+                .disabled(coordinator.projectTransitionStatus.isPending)
                 .frame(minWidth: 640, minHeight: 400)
                 .preferredColorScheme(colorScheme)
         }

--- a/Tracexy/ViewModels/MainContentCoordinator+CaptureDrain.swift
+++ b/Tracexy/ViewModels/MainContentCoordinator+CaptureDrain.swift
@@ -1,0 +1,148 @@
+import Foundation
+
+// MARK: - The exact final boundary a stopped capture owes
+
+/// One stop owes exactly one final drain: the helper's last atomic batch folded,
+/// published as the stopped snapshot, and its terminal History write enqueued.
+/// Everything that must not run across that boundary — Start, Clear, adopting
+/// another capture source, and every Project change — parks on the owed
+/// *operation* rather than on a generation token, so a retry issued while the same
+/// stop is still draining awaits that same boundary instead of opening a second,
+/// independently satisfiable one.
+///
+/// The operation is retired exactly once, either by the ingest chain's own
+/// completion or by a recovery path that terminates it as failed. It is never
+/// retired by a timer: a bounded wait that elapses fails its waiter and leaves the
+/// operation owed, because "we stopped waiting" is not "the tail arrived".
+@MainActor
+extension MainContentCoordinator {
+    /// True from the moment Stop is issued until this capture's final helper drain,
+    /// fold, and terminal publication have completed. The Project lifecycle path
+    /// waits on the completion signal rather than polling for it.
+    var isFinalDrainPending: Bool {
+        owedFinalDrain != nil
+    }
+
+    /// The identity of the drain operation currently owed, or `nil` when none is.
+    var pendingFinalDrainOperationID: Int? {
+        owedFinalDrain?.operationID
+    }
+
+    /// Record that a stop owes an exact final drain, and return the identity of the
+    /// drain operation now owed.
+    ///
+    /// A stop still waiting behind an in-flight helper fetch owes a drain before it
+    /// has a stopped generation, so `stoppedToken` is `nil` there and is resolved
+    /// onto the *same* operation once the stop actually runs. A genuinely new stop
+    /// supersedes an unfinished one: its waiters were parked on a boundary that
+    /// will never be reached, so they are failed rather than released by the wrong
+    /// capture or left to time out.
+    ///
+    /// The engine epoch this drain belongs to and the Project that owns it are
+    /// recorded on the operation itself, so a recovery path can finalize exactly the
+    /// capture that owes it instead of deriving one from token arithmetic.
+    /// `captureToken` defaults to the current generation, which is the capture epoch
+    /// at every call site that has not already minted a stopped generation.
+    @discardableResult
+    func beginFinalCaptureDrain(stoppedToken: Int?, captureToken: Int? = nil) -> Int {
+        if var owed = owedFinalDrain {
+            if owed.stoppedToken == nil {
+                // The same stop reaching its generation: resolve it onto the
+                // operation already owed, keeping the epoch recorded when it began.
+                owed.stoppedToken = stoppedToken
+                owedFinalDrain = owed
+                return owed.operationID
+            }
+            finishOwedFinalDrain(owed.operationID, drained: false)
+        }
+        finalDrainOperationID &+= 1
+        owedFinalDrain = OwedFinalDrain(
+            operationID: finalDrainOperationID,
+            captureToken: captureToken ?? startGeneration,
+            stoppedToken: stoppedToken,
+            originProjectID: activeRuntime.projectID
+        )
+        return finalDrainOperationID
+    }
+
+    /// Register a waiter for the exact final-drain completion the current stop owes.
+    /// Returns `false` when the bounded wait elapsed first, so the caller can stay
+    /// on the outgoing Project and offer a retry instead of guessing it drained.
+    ///
+    /// The elapsed bound fails only *this* waiter. The operation stays owed, because
+    /// a tail that has not arrived is still owed and may still arrive; only an
+    /// explicit recovery boundary retires it.
+    func waitForFinalCaptureDrain(timeout: Duration, operationID expectedOperationID: Int? = nil) async -> Bool {
+        guard let operationID = expectedOperationID ?? owedFinalDrain?.operationID else {
+            return true
+        }
+        if let completion = lastFinalDrainCompletion, completion.operationID == operationID {
+            return completion.drained
+        }
+        guard owedFinalDrain?.operationID == operationID else {
+            return false
+        }
+        let waiterID = UUID()
+        let timeoutTask = Task { @MainActor [weak self] in
+            try? await Task.sleep(for: timeout)
+            guard !Task.isCancelled else {
+                return
+            }
+            self?.resumeFinalDrainWaiter(waiterID, drained: false)
+        }
+        defer { timeoutTask.cancel() }
+        return await withCheckedContinuation { continuation in
+            finalDrainWaiters[waiterID] = FinalDrainWaiter(
+                operationID: operationID,
+                continuation: continuation
+            )
+        }
+    }
+
+    /// Signal that the stopped capture identified by `stoppedToken` has folded and
+    /// published its exact last snapshot and enqueued its terminal History write.
+    ///
+    /// Called from the exact ingest-chain completion, never from a timer. A
+    /// completion stamped with any other stop is stale and releases nothing: a
+    /// transition parked on the current boundary must not be resumed by a
+    /// superseded capture's callback.
+    func completeFinalCaptureDrain(stoppedToken: Int, succeeded: Bool = true) {
+        guard let owed = owedFinalDrain, owed.stoppedToken == stoppedToken else {
+            return
+        }
+        finishOwedFinalDrain(owed.operationID, drained: succeeded)
+    }
+
+    /// The current capture is definitively over and owes no further batch even
+    /// though it never reached a stopped-generation boundary — a helper failure, or
+    /// a stop abandoned before its generation was minted. Nothing more will be
+    /// folded, but this is not a confirmed drain. Keep the current Project and
+    /// require an explicit retry after the failure has been surfaced.
+    func abortOwedFinalCaptureDrain() {
+        guard let owed = owedFinalDrain else {
+            return
+        }
+        finishOwedFinalDrain(owed.operationID, drained: false)
+    }
+
+    // MARK: Private
+
+    private func resumeFinalDrainWaiter(_ id: UUID, drained: Bool) {
+        guard let waiter = finalDrainWaiters.removeValue(forKey: id) else {
+            return
+        }
+        waiter.continuation.resume(returning: drained)
+    }
+
+    /// Retire one owed drain and release exactly the waiters parked on it.
+    private func finishOwedFinalDrain(_ operationID: Int, drained: Bool) {
+        lastFinalDrainCompletion = (operationID, drained)
+        if owedFinalDrain?.operationID == operationID {
+            owedFinalDrain = nil
+        }
+        for (id, waiter) in finalDrainWaiters where waiter.operationID == operationID {
+            finalDrainWaiters.removeValue(forKey: id)
+            waiter.continuation.resume(returning: drained)
+        }
+    }
+}

--- a/Tracexy/ViewModels/MainContentCoordinator+CapturePersistence.swift
+++ b/Tracexy/ViewModels/MainContentCoordinator+CapturePersistence.swift
@@ -1,5 +1,36 @@
 import Foundation
 
+// MARK: - CaptureMutationError
+
+nonisolated enum CaptureMutationError: LocalizedError {
+    case sourceInUse(String)
+
+    // MARK: Internal
+
+    var errorDescription: String? {
+        switch self {
+        case let .sourceInUse(reason): reason
+        }
+    }
+}
+
+// MARK: - CaptureSaveOperation
+
+/// Capture I/O is injectable without changing source ownership or queue ordering.
+nonisolated struct CaptureSaveOperation: Sendable {
+    static let copy = Self { source, spool, destination in
+        if let source {
+            try await Task.detached(priority: .userInitiated) {
+                try FileManager.default.copyItem(at: source, to: destination)
+            }.value
+        } else {
+            try await spool.copy(to: destination)
+        }
+    }
+
+    var run: @Sendable (URL?, LiveCaptureSpool, URL) async throws -> Void
+}
+
 // MARK: - Capture persistence
 
 extension MainContentCoordinator {
@@ -8,6 +39,17 @@ extension MainContentCoordinator {
     /// cleared so the workspace cannot keep presenting a capture that no longer
     /// exists in the Library.
     func moveSavedCaptureToTrash(_ capture: SavedCapture) throws {
+        // An accepted Save or an in-flight export may be reading exactly this file,
+        // or writing beside it. Removing it underneath them is refused.
+        if let held = captureSourceHoldMessage {
+            throw CaptureMutationError.sourceInUse(held)
+        }
+        guard hasHydratedProjects, !isProjectBoundaryBusy,
+              let directory = capturesDirectory(),
+              capture.url.deletingLastPathComponent().standardizedFileURL == directory.standardizedFileURL else
+        {
+            throw CocoaError(.fileWriteNoPermission)
+        }
         try FileManager.default.trashItem(at: capture.url, resultingItemURL: nil)
         if activeSavedCapture?.url.standardizedFileURL == capture.url.standardizedFileURL {
             clearSessions()
@@ -15,62 +57,130 @@ extension MainContentCoordinator {
         refreshSavedCaptures()
     }
 
-    /// Saves the complete current capture under Application Support. Live frames
-    /// come from the disk-backed pcapng spool, not the bounded UI retention window.
+    /// Saves the complete current capture into the *active Project's* managed
+    /// Library folder. Live frames come from that Project's disk-backed pcapng
+    /// spool, not the bounded UI retention window.
+    ///
+    /// The spool and destination Project are captured *before* the first `await`,
+    /// so a Project change that lands mid-copy can neither redirect the write nor
+    /// make it read the incoming Project's spool. The task handle is published so
+    /// the Project lifecycle path can wait for it before swapping references — and
+    /// so ``isCaptureSourceHeld`` freezes destructive source mutations for exactly
+    /// as long as this save, and any save queued behind it, still needs its source.
     func saveCurrentCapture() {
-        guard !retainedFrames.isEmpty, let directory = Self.capturesDirectory() else {
+        // A save started while the Project boundary is settling would read a spool
+        // that has not reached its exact final boundary, or one that is about to be
+        // swapped for another Project's.
+        guard hasHydratedProjects, !retainedFrames.isEmpty,
+              !isProjectBoundaryBusy,
+              let directory = capturesDirectory() else
+        {
             return
         }
         let stamp = Self.fileStampFormatter.string(from: Date())
         let savedSource = activeSavedCapture?.url
         let fileExtension = savedSource?.pathExtension ?? "pcapng"
-        let url = directory.appendingPathComponent("Capture \(stamp).\(fileExtension)")
+        let baseURL = directory.appendingPathComponent("Capture \(stamp).\(fileExtension)")
+        let url = pendingCaptureIOTask != nil || FileManager.default.fileExists(atPath: baseURL.path)
+            ? directory.appendingPathComponent("Capture \(stamp)-\(UUID().uuidString).\(fileExtension)")
+            : baseURL
+        // Spool, destination and origin Project are captured before the first
+        // `await`, so a Project change landing mid-copy can neither redirect the
+        // write nor make it read the incoming Project's evidence.
         let pendingIngest = ingestChain
-        Task { @MainActor [weak self] in
+        let spool = liveCaptureSpool
+        let operation = captureSaveOperation
+        let originProjectID = activeRuntime.projectID
+        let originGeneration = startGeneration
+        let previousSave = pendingCaptureIOTask
+        captureIORequestID &+= 1
+        let requestID = captureIORequestID
+        pendingCaptureIOTask = Task { @MainActor [weak self] in
+            await previousSave?.value
+            await pendingIngest?.value
+            var failure: String?
+            var warning: String?
+            do {
+                try await operation.run(savedSource, spool, url)
+                if savedSource == nil {
+                    warning = await spool.incompletenessReason()
+                }
+            } catch {
+                failure = "Couldn’t save capture: \(error.localizedDescription)"
+            }
             guard let self else {
                 return
             }
-            await pendingIngest?.value
-            do {
-                if let savedSource {
-                    try await Task.detached(priority: .userInitiated) {
-                        try FileManager.default.copyItem(at: savedSource, to: url)
-                    }.value
-                } else {
-                    try await self.liveCaptureSpool.copy(to: url)
-                }
-                if let warning = await self.liveCaptureSpool.incompletenessReason() {
-                    self.captureError = "Saved the recoverable capture prefix. Later frames are missing because "
-                        + "the local spool failed — \(warning)"
-                } else {
-                    self.captureError = nil
-                }
-                self.refreshSavedCaptures()
-            } catch {
-                self.captureError = "Couldn’t save capture: \(error.localizedDescription)"
+            // Only the newest request may clear the shared handle. Clearing it
+            // unconditionally would hide a save already queued behind this one from
+            // the Project transition that must wait for it.
+            if self.captureIORequestID == requestID {
+                self.pendingCaptureIOTask = nil
             }
+            // A result that arrives after the Project changed belongs to the
+            // Project that started it, and must not touch the one on screen.
+            guard self.activeRuntime.projectID == originProjectID else {
+                return
+            }
+            self.refreshSavedCaptures()
+            self.reportCaptureIOOutcome(
+                failure: failure,
+                warning: warning.map {
+                    "Saved the recoverable capture prefix. Later frames are missing because "
+                        + "the local spool failed — \($0)"
+                },
+                didWrite: failure == nil,
+                originProjectID: originProjectID,
+                originGeneration: originGeneration
+            )
+        }
+    }
+
+    /// Stop may advance the publication generation while Save/export still owns
+    /// the same source. Its failure or incompleteness warning remains relevant to
+    /// that Project; a successful copy must not clear a newer Stop diagnostic.
+    func reportCaptureIOOutcome(
+        failure: String?,
+        warning: String?,
+        didWrite: Bool,
+        originProjectID: UUID?,
+        originGeneration: Int
+    ) {
+        guard activeRuntime.projectID == originProjectID else {
+            return
+        }
+        if let failure {
+            captureError = failure
+        } else if let warning {
+            captureError = warning
+        } else if didWrite, startGeneration == originGeneration {
+            captureError = nil
         }
     }
 
     /// Complete source for session export. A saved file is re-read directly; a
     /// live capture is read from its spool after queued ingests have completed.
+    /// The spool reference is taken before awaiting so an export can never read a
+    /// different Project's evidence than the one it was started from.
     func completeCaptureForExport() async throws -> (
         linkType: UInt32,
         frames: [CapturedFrame],
         incompletenessReason: String?
     ) {
+        let spool = liveCaptureSpool
+        let savedSource = activeSavedCapture?.url
         await ingestChain?.value
-        if let activeSavedCapture {
+        if let savedSource {
             let capture = try await Task.detached(priority: .userInitiated) {
-                try CaptureFileReader.read(contentsOf: activeSavedCapture.url)
+                try CaptureFileReader.read(contentsOf: savedSource)
             }.value
             return (capture.linkType, capture.frames, nil)
         }
-        let capture = try await liveCaptureSpool.capture()
+        let capture = try await spool.capture()
         return await (
             capture.linkType,
             capture.frames,
-            liveCaptureSpool.incompletenessReason()
+            spool.incompletenessReason()
         )
     }
 }

--- a/Tracexy/ViewModels/MainContentCoordinator+FocusAndNoise.swift
+++ b/Tracexy/ViewModels/MainContentCoordinator+FocusAndNoise.swift
@@ -1,0 +1,198 @@
+import Foundation
+
+// MARK: - Navigation, pins, Focus Sets, and Noise Control
+
+/// All of these are Project-owned: pins, Focus Sets and muted noise persist into
+/// the *active Project's* preferences suite, never the shared domain, so one
+/// investigation's saved filters can never leak into another's.
+@MainActor
+extension MainContentCoordinator {
+    // MARK: Search
+
+    /// ⌘F: bring the user to the session search box and put the cursor in it.
+    ///
+    /// Routes to the Sessions surface if they are elsewhere, reveals the filter
+    /// bar, and switches the search on — the three states the box needs to be
+    /// usable — then bumps a focus token the existing field observes. It does
+    /// *not* touch the query text or any active filter (host/process/IP drill-down,
+    /// category chips, advanced rules), so an in-progress investigation is
+    /// preserved; ⌘F only reveals and focuses the box that is already there.
+    func beginSessionSearch() {
+        let ws = activeWorkspace
+        ws.sidebarSelection = .sessions
+        ws.isFilterBarVisible = true
+        ws.isSearchEnabled = true
+        ws.searchFocusRequest = UUID()
+    }
+
+    // MARK: Sidebar selection
+
+    /// Selects a top-level sidebar item, clearing any host/process/IP drill-down.
+    func selectSidebarItem(_ item: SidebarItem) {
+        let ws = activeWorkspace
+        ws.sidebarSelection = item
+        ws.hostFilter = nil
+        ws.processFilter = nil
+        ws.ipFilter = nil
+    }
+
+    /// Drills into a single host/domain (from the sidebar "Domains"/"Pinned" groups).
+    func selectHost(_ host: String) {
+        let ws = activeWorkspace
+        ws.sidebarSelection = .sessions
+        ws.processFilter = nil
+        ws.ipFilter = nil
+        ws.hostFilter = host
+    }
+
+    /// Drills into a single process (from the sidebar "Apps" group).
+    func selectProcess(_ process: String) {
+        let ws = activeWorkspace
+        ws.sidebarSelection = .sessions
+        ws.hostFilter = nil
+        ws.ipFilter = nil
+        ws.processFilter = process
+    }
+
+    /// Drills into a single IP address (a sub-IP under a domain).
+    func selectIP(_ ip: String) {
+        let ws = activeWorkspace
+        ws.sidebarSelection = .sessions
+        ws.hostFilter = nil
+        ws.processFilter = nil
+        ws.ipFilter = ip
+    }
+
+    // MARK: Pinned hosts (Favorites)
+
+    func isHostPinned(_ host: String) -> Bool {
+        pinnedHosts.contains(host)
+    }
+
+    /// Pins or unpins a host and persists the new set into this Project's suite.
+    func togglePinHost(_ host: String) {
+        guard !host.isEmpty, host != "—" else {
+            return
+        }
+        if let index = pinnedHosts.firstIndex(of: host) {
+            pinnedHosts.remove(at: index)
+        } else {
+            do {
+                try focusGate.validatePinningHost(host, into: pinnedHosts)
+            } catch {
+                policyNotice = error.localizedDescription
+                return
+            }
+            pinnedHosts.append(host)
+        }
+        policyNotice = nil
+        activeProjectDefaults.set(pinnedHosts, forKey: ProjectScopedSettingsKeys.pinnedHosts)
+    }
+
+    // MARK: Focus Sets
+
+    /// Inserts or updates a focus set (used by the editor sheet), then persists.
+    /// A save that would exceed the focus-set cap leaves the stored sets
+    /// untouched and reports why through ``policyNotice``.
+    func saveFocusSet(_ set: FocusSet) {
+        var normalizedSet = set
+        normalizedSet.rules = SessionFilterRule.normalized(
+            set.rules,
+            limit: policy.maxSessionFilterRules
+        )
+        do {
+            try focusGate.validateSavingFocusSet(normalizedSet, into: focusSets)
+        } catch {
+            policyNotice = error.localizedDescription
+            return
+        }
+        if let index = focusSets.firstIndex(where: { $0.id == normalizedSet.id }) {
+            focusSets[index] = normalizedSet
+        } else {
+            focusSets.append(normalizedSet)
+        }
+        policyNotice = nil
+        persistFocusSets()
+    }
+
+    /// Loads a focus set's rules into the active workspace's advanced filter.
+    func applyFocusSet(_ set: FocusSet) {
+        let ws = activeWorkspace
+        ws.sidebarSelection = .sessions
+        ws.hostFilter = nil
+        ws.processFilter = nil
+        ws.ipFilter = nil
+        // A saved set may hold more rows than this build allows (it was saved on
+        // a different build, or the cap changed). Clamp to capacity, and never
+        // leave the builder with zero rows.
+        ws.filterRules = SessionFilterRule.normalized(set.rules, limit: policy.maxSessionFilterRules)
+        ws.isFilterBarVisible = true
+        ws.isAdvancedFilterVisible = true
+    }
+
+    func deleteFocusSet(_ set: FocusSet) {
+        focusSets.removeAll { $0.id == set.id }
+        persistFocusSets()
+    }
+
+    /// A blank draft seeded from the active workspace's current active rules, so
+    /// "Add" captures whatever the user is already filtering by.
+    func draftFocusSet() -> FocusSet {
+        let active = activeWorkspace.activeFilterRules
+        return FocusSet(
+            name: "",
+            rules: active.isEmpty ? [SessionFilterRule()] : active
+        )
+    }
+
+    // MARK: Noise Control
+
+    func isHostMuted(_ host: String) -> Bool {
+        mutedHosts.contains(host)
+    }
+
+    func isProtocolMuted(_ proto: ProtocolKind) -> Bool {
+        mutedProtocols.contains(proto)
+    }
+
+    func toggleMuteHost(_ host: String) {
+        if mutedHosts.contains(host) {
+            mutedHosts.remove(host)
+        } else {
+            mutedHosts.insert(host)
+        }
+        persistMutedNoise()
+    }
+
+    func toggleMuteProtocol(_ proto: ProtocolKind) {
+        if mutedProtocols.contains(proto) {
+            mutedProtocols.remove(proto)
+        } else {
+            mutedProtocols.insert(proto)
+        }
+        persistMutedNoise()
+    }
+
+    func clearNoiseControl() {
+        mutedHosts = []
+        mutedProtocols = []
+        persistMutedNoise()
+    }
+
+    // MARK: Private
+
+    private func persistFocusSets() {
+        guard let data = try? JSONEncoder().encode(focusSets) else {
+            return
+        }
+        activeProjectDefaults.set(data, forKey: ProjectScopedSettingsKeys.focusSets)
+    }
+
+    private func persistMutedNoise() {
+        activeProjectDefaults.set(Array(mutedHosts), forKey: ProjectScopedSettingsKeys.mutedHosts)
+        activeProjectDefaults.set(
+            mutedProtocols.map(\.rawValue),
+            forKey: ProjectScopedSettingsKeys.mutedProtocols
+        )
+    }
+}

--- a/Tracexy/ViewModels/MainContentCoordinator+History.swift
+++ b/Tracexy/ViewModels/MainContentCoordinator+History.swift
@@ -187,6 +187,20 @@ extension MainContentCoordinator {
         frozenHistoryLifetime = nil
     }
 
+    /// Recovery retires an unconfirmed stop's callbacks without creating a second
+    /// capture or changing its frozen timestamps. Only its publication token moves.
+    func rebaseFrozenHistoryLifetime(from stoppedToken: Int, to recoveryToken: Int) {
+        guard let frozen = frozenHistoryLifetime, frozen.stoppedGeneration == stoppedToken else {
+            return
+        }
+        frozenHistoryLifetime = FrozenHistoryLifetime(
+            captureID: frozen.captureID,
+            startedAt: frozen.startedAt,
+            endedAt: frozen.endedAt,
+            stoppedGeneration: recoveryToken
+        )
+    }
+
     // MARK: Terminal write hooks
 
     /// Persist the terminated live capture exactly once, consuming the frozen
@@ -212,7 +226,8 @@ extension MainContentCoordinator {
             sourceKind: .live,
             completeness: completeness,
             sessions: sessions,
-            maskIPAddresses: PrivacySettingsResolver.exportPolicy().maskIPAddresses
+            maskIPAddresses: PrivacySettingsResolver
+                .exportPolicy(defaults: activeProjectDefaults).maskIPAddresses
         )
         scheduleHistoryWrite(store: store, input: input)
     }
@@ -242,7 +257,8 @@ extension MainContentCoordinator {
             sourceKind: .saved,
             completeness: completeness,
             sessions: result.sessions,
-            maskIPAddresses: PrivacySettingsResolver.exportPolicy().maskIPAddresses
+            maskIPAddresses: PrivacySettingsResolver
+                .exportPolicy(defaults: activeProjectDefaults).maskIPAddresses
         )
         scheduleHistoryWrite(store: store, input: input)
     }
@@ -418,8 +434,15 @@ extension MainContentCoordinator {
                 guard let self, self.historyRequestID == requestID else {
                     return
                 }
-                self.historyAvailability = .failed("Couldn’t load History — \(Self.describe(error))")
+                let message = "Couldn’t load History — \(Self.describe(error))"
+                self.historyAvailability = .failed(message)
                 self.historyTask = nil
+                // A restored initial session read may be waiting for this refresh
+                // to re-select its capture. Failure must settle that orphaned slot
+                // too, without interrupting an independently running session read.
+                if self.historySessionsAvailability == .loading, self.historySessionTask == nil {
+                    self.historySessionsAvailability = .failed(message)
+                }
             }
         }
     }
@@ -427,6 +450,43 @@ extension MainContentCoordinator {
     /// Retry after a failure — identical to a refresh.
     func retryHistory() {
         refreshHistory()
+    }
+
+    /// Restart the first-page History reads a Project change interrupted.
+    ///
+    /// ``invalidateOutgoingProjectWork()`` cancels this Project's in-flight reads,
+    /// so its bucket parks `.loading` with no reader behind it. Nothing on the
+    /// History surface would ever start one again: its `task` reads only from
+    /// `.idle`, and it auto-selects a capture only when *nothing* is selected — so
+    /// a restored Project would sit on a spinner until the user pressed Refresh.
+    /// Demoting the parked state to `.idle` is not enough either, because a capture
+    /// list that had already loaded keeps its restored selection and would leave
+    /// that selection's interrupted session page unread.
+    ///
+    /// Only interrupted *first* pages are restarted. `loadMore` appends behind
+    /// `.loaded`, so an interrupted page append is never restarted and no
+    /// already-loaded page or cursor is discarded. Reads run against the restored
+    /// Project's own store, and no retention or write is performed here: a Project
+    /// change is not a History mutation boundary.
+    func resumeInterruptedHistoryReads() {
+        guard sessionStore != nil else {
+            // No store to read from: say so instead of leaving either surface on a
+            // spinner that nothing will ever resolve.
+            if historyAvailability == .loading {
+                historyAvailability = .unavailable
+            }
+            if historySessionsAvailability == .loading {
+                historySessionsAvailability = .unavailable
+            }
+            return
+        }
+        if historyAvailability == .loading {
+            // A successful refresh re-selects the preserved capture, which restarts
+            // that capture's session page too — so this covers both interruptions.
+            refreshHistory()
+        } else if historySessionsAvailability == .loading, let captureID = selectedHistoryCaptureID {
+            selectHistoryCapture(captureID)
+        }
     }
 
     /// Append the next newest-first page when one exists and no read is in flight.
@@ -542,7 +602,10 @@ extension MainContentCoordinator {
     /// touches the current capture's sessions or capture state, and it never
     /// activates Auto Clear.
     func clearAllHistory() {
-        guard let store = sessionStore else {
+        // A clear started while the Project boundary is settling would run against
+        // a store that is about to be swapped, or race the terminal write a
+        // stopping capture still owes.
+        guard let store = sessionStore, !isProjectBoundaryBusy else {
             return
         }
         historyTask?.cancel()

--- a/Tracexy/ViewModels/MainContentCoordinator+InvestigationQuery.swift
+++ b/Tracexy/ViewModels/MainContentCoordinator+InvestigationQuery.swift
@@ -58,6 +58,23 @@ extension MainContentCoordinator {
         }
     }
 
+    /// Project-boundary retirement. Retires only the *in-flight evaluation*: the
+    /// parked Project keeps its structured drafts, its accepted queries and their
+    /// results, because those are user state that belongs to it and are restored
+    /// verbatim when it comes back. Bumping each workspace's request ID retires any
+    /// evaluation still in flight, so a late result can never adopt into a workspace
+    /// under another Project's published snapshot.
+    func cancelInFlightInvestigationQueries() {
+        for task in investigationQueryTasks.values {
+            task.cancel()
+        }
+        investigationQueryTasks.removeAll()
+        for workspace in workspaces.workspaces {
+            workspace.investigationQueryRequestID &+= 1
+            workspace.isEvaluatingInvestigationQuery = false
+        }
+    }
+
     /// Reevaluate only accepted queries after the current capture publishes a new
     /// immutable snapshot. Existing matched IDs stay visible until the fresh guarded
     /// result arrives, avoiding a transient unfiltered flash on live updates.

--- a/Tracexy/ViewModels/MainContentCoordinator+ProjectRuntime.swift
+++ b/Tracexy/ViewModels/MainContentCoordinator+ProjectRuntime.swift
@@ -1,0 +1,665 @@
+import Foundation
+
+// MARK: - ProjectRuntimeError
+
+nonisolated enum ProjectRuntimeError: Error, Equatable, Sendable {
+    case settingsUnavailable
+    case projectNotFound
+
+    // MARK: Internal
+
+    var userFacingDescription: String {
+        switch self {
+        case .settingsUnavailable:
+            "Tracexy couldn’t open this Project’s private settings store, so it did not take any capture data in for it."
+        case .projectNotFound:
+            "That Project is no longer available."
+        }
+    }
+}
+
+// MARK: - Per-Project runtime buckets and the single lifecycle path
+
+@MainActor
+extension MainContentCoordinator {
+    /// Intake is refused until ownership is bound, while that ownership changes,
+    /// while a stopped capture still owes its exact final tail, and while an
+    /// accepted Save or session export still owns the current capture source.
+    ///
+    /// Start mints a new generation and resets the engine and spool, so every one
+    /// of these is a refusal *before* any side effect: an owed drain would otherwise
+    /// be superseded and its final tail discarded, and a queued Save would be left
+    /// copying a source that has already been reset underneath it.
+    var captureStartBlockedMessage: String? {
+        if projectTransitionStatus.isPending || pendingProjectSwitchConfirmation != nil {
+            return "Capture can’t start while Tracexy is switching Projects. Try again in a moment."
+        }
+        guard activeRuntime.projectID != nil else {
+            return "Capture can’t start until Projects finish loading."
+        }
+        if isFinalDrainPending {
+            return "Capture can’t start until the capture you stopped has finished writing its last packets. "
+                + "Try again in a moment."
+        }
+        return captureSourceHoldMessage
+    }
+
+    /// True while an accepted Save or an in-flight session export still owns the
+    /// current capture source.
+    ///
+    /// This is the explicit source-use gate: while it is set, every *destructive*
+    /// source mutation — Clear, Start, adopting another saved capture, an import
+    /// that replaces a Library file, and trashing one — is refused, because each
+    /// resets or removes exactly the bytes the accepted operation is copying.
+    /// Deliberately not gated: Stop (settling a live capture is how an owed source
+    /// reaches its final boundary) and a Project change (which waits for the queued
+    /// save instead of racing it).
+    var isCaptureSourceHeld: Bool {
+        pendingCaptureIOTask != nil || isExportingSession
+    }
+
+    /// The refusal above in the user's words, or `nil` when nothing owns the source.
+    var captureSourceHoldMessage: String? {
+        if isExportingSession {
+            return "Finish or cancel the session export before changing the capture source."
+        }
+        if pendingCaptureIOTask != nil {
+            return "Tracexy is still saving this capture. Try again once the save has finished."
+        }
+        return nil
+    }
+
+    /// Resolve this Project's preference, falling back to an active real interface.
+    static func resolvedDefaultInterface(defaults: UserDefaults) -> String {
+        let interfaces = NetworkInterfaces.available()
+        let preferred = defaults.string(forKey: SettingsKeys.defaultInterface)
+        if let preferred, !preferred.isEmpty, interfaces.contains(where: { $0.id == preferred }) {
+            return preferred
+        }
+        let active = interfaces.first { !$0.isLoopback && $0.isUp && $0.ipv4 != nil }
+        let anyReal = interfaces.first { !$0.isLoopback }
+        return active?.id ?? anyReal?.id ?? "en0"
+    }
+
+    // MARK: Bucket construction
+
+    /// Build the complete runtime a Project owns: its preferences suite, its own
+    /// History database, its own managed capture folder, its own live spool, and a
+    /// fresh workspace store seeded from that Project's layout preferences.
+    ///
+    /// A Project whose settings suite cannot be created is *not* given a fallback
+    /// to the shared domain — construction fails and the caller stays on the
+    /// outgoing Project, so no data is ever taken in for an unresolved identity.
+    ///
+    /// Storage preparation is `async` because opening a Project's SQLite History
+    /// and creating its Library folder is file I/O; it is prepared off the main
+    /// actor from a Sendable descriptor rather than blocking every switch on it.
+    func makeProjectRuntime(for project: Project) async throws -> ProjectRuntimeState {
+        let isLegacyOwner = projectStore.legacyDataOwnerProjectID == project.id
+        let location = projectDataProvider.location(
+            forProject: project.id,
+            isLegacyOwner: isLegacyOwner
+        )
+        guard let defaults = projectDataProvider.makeSettingsDefaults(at: location) else {
+            throw ProjectRuntimeError.settingsUnavailable
+        }
+
+        // Composition-injected resources describe the pre-Projects data, so they
+        // belong to the legacy owner and to no one else. A second Project always
+        // gets its own store and spool.
+        let canConsumeInjected = !hasBoundInitialRuntime && isLegacyOwner
+        var store: SessionStore?
+        var historyUnavailableReason: String?
+        if canConsumeInjected, let injected = injectedSessionStore {
+            store = injected
+        } else {
+            switch await projectDataProvider.makeSessionStore(at: location) {
+            case let .ready(opened):
+                store = opened
+            case let .unavailable(reason):
+                historyUnavailableReason = reason
+            }
+        }
+        let spool = (canConsumeInjected ? injectedLiveCaptureSpool : nil)
+            ?? projectDataProvider.makeLiveCaptureSpool(at: location)
+
+        let capturesDirectory = await projectDataProvider.prepareCapturesDirectory(at: location)
+        let preferences = WorkspaceLayoutPreferences(defaults: defaults)
+        let runtime = ProjectRuntimeState(
+            projectID: project.id,
+            location: location,
+            settingsDefaults: defaults,
+            layoutPreferences: preferences,
+            workspaces: WorkspaceStore(
+                maxWorkspaces: policy.maxWorkspaceTabs,
+                layoutPreferences: preferences,
+                defaults: defaults
+            ),
+            sessionStore: store,
+            historyUnavailableReason: historyUnavailableReason,
+            liveCaptureSpool: spool,
+            capturesDirectory: capturesDirectory,
+            captureInterface: Self.resolvedDefaultInterface(defaults: defaults)
+        )
+        runtime.loadPreferenceBackedState()
+        return runtime
+    }
+
+    /// Bind the launch runtime to the *hydrated* active Project rather than to the
+    /// provisional identity the seed catalog carries.
+    func bindInitialProjectRuntime() async throws {
+        let project = projectStore.activeProject
+        let runtime = try await makeProjectRuntime(for: project)
+        hasBoundInitialRuntime = true
+        projectRuntimes[project.id] = runtime
+        adoptProjectRuntime(runtime)
+    }
+
+    // MARK: Park and adopt
+
+    /// Copy the coordinator's live state back into the active Project's bucket.
+    /// The bucket keeps the *actual* store/spool/workspace instances, so nothing is
+    /// re-derived from portable configuration when the Project comes back.
+    func parkActiveProjectRuntime() {
+        let runtime = activeRuntime
+        runtime.sessions = sessions
+        runtime.investigationSnapshot = investigationSnapshot
+        runtime.retainedFrames = retainedFrames
+        runtime.throughputSamples = throughputSamples
+        runtime.pendingChartBytes = pendingChartBytes
+        runtime.captureInterface = captureInterface
+        runtime.captureError = captureError
+        runtime.captureStatistics = captureStatistics
+        runtime.helperBufferDropCount = helperBufferDropCount
+        runtime.currentLinkType = currentLinkType
+        runtime.removedSessionIDs = removedSessionIDs
+        // The token itself is generation-scoped and never travels; only the fact
+        // that this Project's stopped spool had reached its exact final boundary.
+        runtime.isStoppedCaptureReady = stoppedCaptureReadyGeneration == startGeneration
+            && stoppedCaptureReadyGeneration != nil
+
+        runtime.savedCaptures = savedCaptures
+        runtime.isViewingSavedCapture = isViewingSavedCapture
+        runtime.activeSavedCapture = activeSavedCapture
+        runtime.savedCaptureActivity = savedCaptureActivity
+        runtime.savedCaptureWarning = savedCaptureWarning
+        runtime.savedCaptureEvidence = savedCaptureEvidence
+        runtime.savedCaptureEvidenceURL = savedCaptureEvidenceURL
+        runtime.selectedSessionEvidenceID = selectedSessionEvidenceID
+        runtime.selectedSessionEvidenceBytes = selectedSessionEvidenceBytes
+        runtime.selectedSessionEvidenceError = selectedSessionEvidenceError
+
+        runtime.pinnedHosts = pinnedHosts
+        runtime.focusSets = focusSets
+        runtime.mutedHosts = mutedHosts
+        runtime.mutedProtocols = mutedProtocols
+        runtime.hiddenSourceApps = hiddenSourceApps
+        runtime.hiddenSourceDomains = hiddenSourceDomains
+        runtime.hiddenSourceIPs = hiddenSourceIPs
+
+        runtime.sessionStore = sessionStore
+        runtime.historyAvailability = historyAvailability
+        runtime.historyCaptures = historyCaptures
+        runtime.historyCaptureCursor = historyCaptureCursor
+        runtime.selectedHistoryCaptureID = selectedHistoryCaptureID
+        runtime.historySessions = historySessions
+        runtime.historySessionCursor = historySessionCursor
+        runtime.historySessionsAvailability = historySessionsAvailability
+        runtime.historyAutoClear = historyAutoClear
+        runtime.historyError = historyError
+        runtime.historyRetentionError = historyRetentionError
+        runtime.scheduledHistoryTerminals = scheduledHistoryTerminals
+    }
+
+    /// Make `runtime` the coordinator's live state.
+    func adoptProjectRuntime(_ runtime: ProjectRuntimeState) {
+        activeRuntime = runtime
+        workspaces = runtime.workspaces
+        layoutPreferences = runtime.layoutPreferences
+        activeProjectDefaults = runtime.settingsDefaults
+        activeCapturesDirectory = runtime.capturesDirectory
+        liveCaptureSpool = runtime.liveCaptureSpool
+        sessionStore = runtime.sessionStore
+
+        // Every generation/request token is globally monotonic and is never
+        // restored to an older counter. Bumping once here retires any async work
+        // still stamped with the outgoing Project's token, and the restored
+        // stopped-readiness marker is rebased onto the new token while the spool's
+        // own opaque locator identities stay exactly as they were.
+        startGeneration &+= 1
+        stoppedCaptureReadyGeneration = runtime.isStoppedCaptureReady ? startGeneration : nil
+
+        captureInterface = runtime.captureInterface
+        captureError = runtime.captureError
+        captureStatistics = runtime.captureStatistics
+        helperBufferDropCount = runtime.helperBufferDropCount
+        currentLinkType = runtime.currentLinkType
+        retainedFrames = runtime.retainedFrames
+        throughputSamples = runtime.throughputSamples
+        pendingChartBytes = runtime.pendingChartBytes
+        removedSessionIDs = runtime.removedSessionIDs
+        isCapturing = false
+        isStarting = false
+        captureStartedAt = nil
+
+        savedCaptures = runtime.savedCaptures
+        isViewingSavedCapture = runtime.isViewingSavedCapture
+        activeSavedCapture = runtime.activeSavedCapture
+        savedCaptureActivity = runtime.savedCaptureActivity
+        savedCaptureWarning = runtime.savedCaptureWarning
+        savedCaptureEvidence = runtime.savedCaptureEvidence
+        savedCaptureEvidenceURL = runtime.savedCaptureEvidenceURL
+        selectedSessionEvidenceID = runtime.selectedSessionEvidenceID
+        selectedSessionEvidenceBytes = runtime.selectedSessionEvidenceBytes
+        selectedSessionEvidenceError = runtime.selectedSessionEvidenceError
+        isLoadingSelectedSessionEvidence = false
+        isOpeningSavedCapture = false
+        savedCaptureOpenProgress = nil
+
+        pinnedHosts = runtime.pinnedHosts
+        focusSets = runtime.focusSets
+        mutedHosts = runtime.mutedHosts
+        mutedProtocols = runtime.mutedProtocols
+        hiddenSourceApps = runtime.hiddenSourceApps
+        hiddenSourceDomains = runtime.hiddenSourceDomains
+        hiddenSourceIPs = runtime.hiddenSourceIPs
+
+        historyAvailability = runtime.historyAvailability
+        historyCaptures = runtime.historyCaptures
+        historyCaptureCursor = runtime.historyCaptureCursor
+        selectedHistoryCaptureID = runtime.selectedHistoryCaptureID
+        historySessions = runtime.historySessions
+        historySessionCursor = runtime.historySessionCursor
+        historySessionsAvailability = runtime.historySessionsAvailability
+        historyAutoClear = runtime.historyAutoClear
+        historyError = runtime.historyError ?? runtime.historyUnavailableReason
+        historyRetentionError = runtime.historyRetentionError
+        scheduledHistoryTerminals = runtime.scheduledHistoryTerminals
+        liveHistoryLifetime = nil
+        frozenHistoryLifetime = nil
+
+        // Sessions last: the `didSet` rebuilds correlation, and the immutable
+        // snapshot adoption refreshes this Project's accepted queries and the
+        // selected session's evidence projection from its own restored selection.
+        sessions = runtime.sessions
+        adoptInvestigation(runtime.investigationSnapshot)
+        refreshSavedCaptures()
+        // A read this Project had in flight when it was parked was cancelled with
+        // the rest of its Project-scoped work, so restart exactly those first pages
+        // against the store this Project owns.
+        resumeInterruptedHistoryReads()
+    }
+
+    /// Retire every in-flight, Project-scoped async job before the store, spool and
+    /// preferences references are swapped. Durable History writes are *not*
+    /// cancelled here — the transition awaits them first.
+    func invalidateOutgoingProjectWork() {
+        suspendProjectWorkspaceObservation()
+
+        cancelFollowStream(clearResult: true)
+        cancelSavedCaptureOpen(clearPublishedEvidence: false)
+        // Cancel evaluation only. A Project boundary is not a capture boundary:
+        // clearing here would erase the outgoing Project's structured drafts and
+        // accepted results — user state its own workspaces are keeping for it.
+        cancelInFlightInvestigationQueries()
+
+        historyTask?.cancel()
+        historyTask = nil
+        historyRequestID &+= 1
+        historySessionTask?.cancel()
+        historySessionTask = nil
+        historySessionRequestID &+= 1
+        historyRetentionRequestID &+= 1
+    }
+
+    // MARK: The one lifecycle path
+
+    /// Accept a Project change. Returns `true` when the change was applied or an
+    /// asynchronous transition was started, `false` when it was rejected or needs
+    /// the native Stop-and-Switch confirmation first.
+    @discardableResult
+    func beginProjectTransition(_ kind: ProjectSwitchConfirmationRequest.Kind) -> Bool {
+        guard !projectTransitionStatus.isPending, pendingProjectSwitchConfirmation == nil else {
+            return false
+        }
+        guard projectStore.isMutable else {
+            lastProjectOperationError = .storeNotReady
+            return false
+        }
+        guard hasHydratedProjects, activeRuntime.projectID != nil else {
+            lastProjectOperationError = .storeNotReady
+            return false
+        }
+        // A session export has already read this Project's spool and is holding a
+        // modal panel. Gate explicitly instead of swapping the reference under it.
+        guard !isExportingSession else {
+            retryableProjectTransition = kind
+            projectTransitionStatus = .failed(
+                "Finish or cancel the session export before changing Projects."
+            )
+            return false
+        }
+        if case let .deleteProject(id) = kind, id != projectStore.activeProjectID {
+            return startProjectTransition(kind)
+        }
+        if isCapturing || isStarting {
+            pendingProjectSwitchConfirmation = ProjectSwitchConfirmationRequest(
+                id: UUID(),
+                kind: kind,
+                outgoingProjectName: projectStore.activeProject.name,
+                destinationDescription: destinationDescription(for: kind)
+            )
+            return false
+        }
+        return startProjectTransition(kind)
+    }
+
+    func confirmPendingProjectSwitch() {
+        guard let request = pendingProjectSwitchConfirmation else {
+            return
+        }
+        pendingProjectSwitchConfirmation = nil
+        _ = startProjectTransition(request.kind)
+    }
+
+    /// Cancel leaves the outgoing Project entirely untouched: the capture keeps
+    /// running and no catalog mutation has been attempted.
+    func cancelPendingProjectSwitch() {
+        pendingProjectSwitchConfirmation = nil
+    }
+
+    func retryProjectTransition() {
+        guard let kind = retryableProjectTransition else {
+            return
+        }
+        retryableProjectTransition = nil
+        projectTransitionStatus = .idle
+        _ = beginProjectTransition(kind)
+    }
+
+    func dismissProjectTransitionFailure() {
+        retryableProjectTransition = nil
+        projectTransitionStatus = .idle
+    }
+
+    /// Test/diagnostic seam: await the asynchronous half of a transition without
+    /// timing sleeps. Returns `false` when the transition ended in a failure.
+    @discardableResult
+    func waitForProjectTransition() async -> Bool {
+        if let task = projectTransitionTask {
+            _ = await task.value
+        }
+        return projectTransitionStatus == .idle
+    }
+
+    // MARK: Private
+
+    private func destinationDescription(for kind: ProjectSwitchConfirmationRequest.Kind) -> String {
+        switch kind {
+        case let .switchProject(id):
+            projectStore.projects.first { $0.id == id }?.name ?? String(localized: "another Project")
+        case let .createProject(name):
+            name
+        case let .importProject(project):
+            project.name
+        case let .deleteProject(id):
+            projectStore.projects.first { $0.id == id }?.name ?? String(localized: "that Project")
+        }
+    }
+
+    /// Validate the change and *hold* it, then finish it asynchronously.
+    ///
+    /// The outgoing Project's own workspace configuration is written first — it is
+    /// the last catalog mutation that still belongs to the Project being left. The
+    /// candidate catalog is then prepared without being published, which freezes
+    /// every other catalog and workspace mutation for the rest of the transition.
+    /// Nothing else moves until the destination's storage is resolved and the
+    /// candidate has been written durably.
+    private func startProjectTransition(_ kind: ProjectSwitchConfirmationRequest.Kind) -> Bool {
+        // Confirmation can outlive its initial eligibility check. An export may
+        // have acquired the source while that sheet was open, so recheck at the
+        // actual acceptance boundary before freezing or mutating the catalog.
+        guard !isExportingSession else {
+            retryableProjectTransition = kind
+            projectTransitionStatus = .failed(
+                "Finish or cancel the session export before changing Projects."
+            )
+            return false
+        }
+        preparedProjectTransition = nil
+        guard flushProjectWorkspaceSnapshot() else {
+            return false
+        }
+        let prepared: PreparedProjectCatalogTransition
+        do {
+            prepared = try projectStore.prepareTransition(Self.catalogTransition(for: kind))
+        } catch let error as ProjectMutationError {
+            lastProjectOperationError = error
+            return false
+        } catch {
+            projectTransferErrorMessage = error.localizedDescription
+            return false
+        }
+        // A surviving autosave debounce would only fail against the frozen catalog.
+        suspendProjectWorkspaceObservation()
+        preparedProjectTransition = prepared
+        lastProjectOperationError = nil
+        projectTransferErrorMessage = nil
+        projectTransitionStatus = .pending
+        retryableProjectTransition = kind
+        // Retire producers before draining their write queues. A saved loader
+        // finishing during destination preparation must not enqueue a late write
+        // against the outgoing store after its queue was already drained.
+        if prepared.destinationProject.id != activeRuntime.projectID {
+            cancelSavedCaptureOpen(clearPublishedEvidence: false)
+        }
+
+        let outgoingName = projectStore.activeProject.name
+        let drainAtAcceptance = pendingFinalDrainOperationID
+        let originProjectID = activeRuntime.projectID
+        projectTransitionTask = Task { @MainActor [weak self] in
+            guard let self else {
+                return false
+            }
+            defer {
+                self.projectTransitionTask = nil
+                self.preparedProjectTransition = nil
+            }
+            let applied = await self.finishProjectTransition(
+                prepared,
+                kind: kind,
+                outgoingName: outgoingName,
+                drainAtAcceptance: drainAtAcceptance,
+                originProjectID: originProjectID
+            )
+            if applied {
+                self.projectTransitionStatus = .idle
+                self.retryableProjectTransition = nil
+            } else if self.projectTransitionStatus.isPending {
+                self.projectTransitionStatus = .failed(
+                    self.projectOperationErrorMessage
+                        ?? "Tracexy couldn’t change Projects. Nothing was discarded."
+                )
+            }
+            return applied
+        }
+        return true
+    }
+
+    /// The one durable application of a prepared Project change:
+    /// settle outgoing work → resolve destination storage → persist the candidate
+    /// → publish catalog and runtime together. Every entry point (switch, create,
+    /// import, delete-active) goes through exactly this.
+    ///
+    /// Each failure step leaves the outgoing Project active with its catalog,
+    /// runtime and data untouched, and offers a retry. Because the catalog is only
+    /// ever published after a successful write, a delete can never remove the
+    /// Project a failed transition has to fall back to.
+    private func finishProjectTransition(
+        _ prepared: PreparedProjectCatalogTransition,
+        kind: ProjectSwitchConfirmationRequest.Kind,
+        outgoingName: String,
+        drainAtAcceptance: Int?,
+        originProjectID: UUID?
+    )
+        async -> Bool
+    {
+        // 1. Everything the outgoing Project still owes must settle first.
+        let changesActiveProject = prepared.destinationProject.id != activeRuntime.projectID
+        if changesActiveProject, isCapturing || isStarting {
+            stopCapture()
+        }
+        if changesActiveProject, let operationID = pendingFinalDrainOperationID ?? drainAtAcceptance {
+            let drained = await waitForFinalCaptureDrain(
+                timeout: projectTransitionDrainTimeout,
+                operationID: operationID
+            )
+            guard drained else {
+                return failProjectTransition(
+                    prepared,
+                    kind: kind,
+                    originProjectID: originProjectID,
+                    message: "The capture helper didn’t confirm its final drain, so Tracexy stayed in "
+                        + "“\(outgoingName)”. Nothing was discarded — recover the helper in "
+                        + "Settings → Helper, then try again."
+                )
+            }
+        }
+        if changesActiveProject {
+            await drainOutgoingProjectIO()
+        }
+
+        // 2. Resolve the destination's storage *before* anything is published, so a
+        //    Project whose data Tracexy cannot own never becomes active.
+        var runtime = projectRuntimes[prepared.destinationProject.id]
+        let isFreshRuntime = runtime == nil
+        if isFreshRuntime, prepared.destinationProject.id != activeRuntime.projectID {
+            do {
+                runtime = try await makeProjectRuntime(for: prepared.destinationProject)
+            } catch {
+                return failProjectTransition(
+                    prepared,
+                    kind: kind,
+                    originProjectID: originProjectID,
+                    message: (error as? ProjectRuntimeError)?.userFacingDescription
+                        ?? error.localizedDescription
+                )
+            }
+        }
+
+        // 3. Write the candidate. Only a durable write publishes it; a failure
+        //    leaves both the in-memory catalog and the file on disk as they were.
+        do {
+            try await projectStore.commitPreparedTransition(prepared)
+        } catch {
+            return failProjectTransition(
+                prepared,
+                kind: kind,
+                originProjectID: originProjectID,
+                message: "Tracexy couldn’t save the Project catalog, so it stayed in "
+                    + "“\(outgoingName)”. Nothing was discarded — try again."
+            )
+        }
+
+        // 4. Publish. The catalog is durable now, so the runtime swap happens in
+        //    this same main-actor turn with no suspension in between.
+        if let deletedProjectID = prepared.deletedProjectID {
+            // Only the in-memory bucket is released. The deleted Project's History
+            // database and Library folder stay exactly where they are. Unsaved
+            // spool evidence is released with its deleted runtime.
+            projectRuntimes.removeValue(forKey: deletedProjectID)
+        }
+        if let runtime, runtime !== activeRuntime {
+            if isFreshRuntime {
+                // A Project is hydrated from its durable configuration exactly once,
+                // when its bucket is first built. A Project that has been open in
+                // this app session keeps its real workspace instances — selection,
+                // drafts, query results and layout — instead of being rebuilt.
+                hydratePersistedWorkspaces(of: prepared.destinationProject, into: runtime)
+                projectRuntimes[prepared.destinationProject.id] = runtime
+            }
+            parkActiveProjectRuntime()
+            invalidateOutgoingProjectWork()
+            adoptProjectRuntime(runtime)
+        }
+        resumeProjectWorkspaceObservation()
+        lastProjectOperationError = nil
+        projectTransferErrorMessage = nil
+        return true
+    }
+
+    /// Unwind a transition that could not be completed. Nothing was published, so
+    /// this releases the catalog freeze, rebuilds the outgoing Project's retired
+    /// selection-scoped evidence, re-arms autosave and offers a retry.
+    private func failProjectTransition(
+        _ prepared: PreparedProjectCatalogTransition,
+        kind: ProjectSwitchConfirmationRequest.Kind,
+        originProjectID: UUID?,
+        message: String
+    )
+        -> Bool
+    {
+        projectStore.discardPreparedTransition(prepared)
+        restoreSelectedEvidenceAfterFailedTransition(originProjectID: originProjectID)
+        resumeProjectWorkspaceObservation()
+        retryableProjectTransition = kind
+        projectTransitionStatus = .failed(message)
+        return false
+    }
+
+    /// Accepting a transition retires the outgoing Project's selection-scoped
+    /// evidence work before the destination is prepared. When the transition then
+    /// fails, nothing was published: that selection is still the live one, so its
+    /// projection and lazily-read saved bytes are rebuilt here rather than leaving
+    /// the still-selected session with no evidence at all.
+    ///
+    /// Guarded by the origin Project so a failure that somehow lands after a
+    /// successful publication cannot rebuild one Project's evidence inside another.
+    /// Both rebuilds bump their own monotonic request ids, which retires the loader
+    /// results the acceptance step cancelled. Session ids, the immutable snapshot,
+    /// query drafts and accepted results are untouched — they were never cleared.
+    private func restoreSelectedEvidenceAfterFailedTransition(originProjectID: UUID?) {
+        guard activeRuntime.projectID == originProjectID,
+              activeWorkspace.selectedSessionID != nil else
+        {
+            return
+        }
+        loadSelectedSavedCaptureEvidence()
+        refreshSelectedSessionEvidenceProjection()
+    }
+
+    /// Wait for the outgoing Project's own durable work — the managed capture save
+    /// and the serialized History mutation tail — to settle against the store and
+    /// spool that produced it.
+    ///
+    /// Each queue is drained until its monotonic request identity stops advancing,
+    /// so a write queued behind the one being awaited is awaited too rather than
+    /// being silently abandoned after a fixed number of turns. New capture I/O and
+    /// History mutations are refused while the transition is pending, so this
+    /// terminates.
+    private func drainOutgoingProjectIO() async {
+        var awaitedSave = -1
+        while let save = pendingCaptureIOTask, captureIORequestID != awaitedSave {
+            awaitedSave = captureIORequestID
+            await save.value
+        }
+        var awaitedMutation = -1
+        while let mutation = historyMutationTask, historyMutationRequestID != awaitedMutation {
+            awaitedMutation = historyMutationRequestID
+            await mutation.value
+        }
+    }
+
+    private static func catalogTransition(
+        for kind: ProjectSwitchConfirmationRequest.Kind
+    )
+        -> ProjectCatalogTransition
+    {
+        switch kind {
+        case let .switchProject(id): .select(id)
+        case let .createProject(name): .create(name: name)
+        case let .importProject(project): .adopt(project)
+        case let .deleteProject(id): .delete(id)
+        }
+    }
+}

--- a/Tracexy/ViewModels/MainContentCoordinator+ProjectTransfer.swift
+++ b/Tracexy/ViewModels/MainContentCoordinator+ProjectTransfer.swift
@@ -1,0 +1,132 @@
+import AppKit
+import Foundation
+import UniformTypeIdentifiers
+
+// MARK: - Configuration-only Project transfer
+
+extension MainContentCoordinator {
+    @discardableResult
+    func exportProjectConfiguration(_ project: Project) -> Bool {
+        guard projectStore.isMutable,
+              projectStore.projects.contains(where: { $0.id == project.id }) else
+        {
+            lastProjectOperationError = .storeNotReady
+            return false
+        }
+        if project.id == projectStore.activeProjectID, !flushProjectWorkspaceSnapshot() {
+            return false
+        }
+
+        let panel = NSSavePanel()
+        panel.allowedContentTypes = [Self.projectDocumentType]
+        panel.canCreateDirectories = true
+        panel.nameFieldStringValue = "\(safeProjectFileStem(project.name)).\(PortableProjectCodec.fileExtension)"
+        panel.message = String(
+            localized: "Exports workspace names, filters, grouping, and layout only. Captured traffic and History are excluded."
+        ) + " " + String(
+            localized: "Filter text may be sensitive; review it before sharing."
+        )
+        guard panel.runModal() == .OK, let url = panel.url else {
+            return false
+        }
+
+        do {
+            guard let currentProject = projectStore.projects.first(where: { $0.id == project.id }) else {
+                lastProjectOperationError = .projectNotFound
+                return false
+            }
+            try PortableProjectDocumentIO.write(currentProject, to: url)
+            lastProjectOperationError = nil
+            projectTransferErrorMessage = nil
+            return true
+        } catch {
+            projectTransferErrorMessage = projectTransferFailureMessage(for: error)
+            return false
+        }
+    }
+
+    @discardableResult
+    func importProjectConfiguration() -> Bool {
+        guard projectStore.canCreateProject else {
+            lastProjectOperationError = projectStore.isMutable
+                ? .capacityReached(limit: projectStore.maxProjects)
+                : .storeNotReady
+            return false
+        }
+
+        let panel = NSOpenPanel()
+        panel.allowedContentTypes = [Self.projectDocumentType, .json]
+        panel.allowsMultipleSelection = false
+        panel.canChooseDirectories = false
+        panel.message = String(localized: "Choose a configuration-only .tracexyproject file")
+        guard panel.runModal() == .OK, let url = panel.url else {
+            return false
+        }
+
+        do {
+            let importedConfiguration = try PortableProjectDocumentIO.read(from: url)
+            guard confirmProjectImport(importedConfiguration, fileName: url.lastPathComponent) else {
+                return false
+            }
+            guard flushProjectWorkspaceSnapshot() else {
+                return false
+            }
+            let importedProject = try projectStore.importProject(importedConfiguration)
+            activateCurrentProjectWorkspaces()
+            lastProjectOperationError = nil
+            projectTransferErrorMessage = nil
+            return importedProject.id == projectStore.activeProjectID
+        } catch let error as ProjectMutationError {
+            lastProjectOperationError = error
+            return false
+        } catch {
+            projectTransferErrorMessage = projectTransferFailureMessage(for: error)
+            return false
+        }
+    }
+
+    // MARK: Private
+
+    private static var projectDocumentType: UTType {
+        UTType(
+            exportedAs: TracexyIdentity.current.projectUTTypeIdentifier,
+            conformingTo: .json
+        )
+    }
+
+    private func confirmProjectImport(_ project: Project, fileName: String) -> Bool {
+        let alert = NSAlert()
+        alert.messageText = String(localized: "Import \(project.name) as a New Project?")
+        alert.informativeText = String(
+            localized: "\(fileName) contains \(project.workspaces.count) workspace(s), user-authored filter text, and layout preferences. It contains no captured traffic, payloads, local file paths, findings, or History. Existing Projects will not be replaced."
+        )
+        alert.alertStyle = .informational
+        alert.addButton(withTitle: String(localized: "Import"))
+        alert.addButton(withTitle: String(localized: "Cancel"))
+        return alert.runModal() == .alertFirstButtonReturn
+    }
+
+    private func safeProjectFileStem(_ name: String) -> String {
+        let invalid = CharacterSet(charactersIn: "/:")
+        let components = name.components(separatedBy: invalid).filter { !$0.isEmpty }
+        let stem = components.joined(separator: "-").trimmingCharacters(in: .whitespacesAndNewlines)
+        return stem.isEmpty ? "Tracexy-Project" : stem
+    }
+
+    private func projectTransferFailureMessage(for error: Error) -> String {
+        switch error {
+        case PortableProjectCodecError.documentTooLarge:
+            "The Project file is too large for a configuration-only document."
+        case PortableProjectCodecError.unsupportedSchema:
+            "This Project file uses a newer or unsupported format."
+        case PortableProjectCodecError.documentIsSymbolicLink,
+             PortableProjectCodecError.directoryIsSymbolicLink:
+            "Tracexy will not import from or export through a symbolic link."
+        case PortableProjectCodecError.documentIsNotRegularFile,
+             PortableProjectCodecError.directoryIsNotDirectory:
+            "Choose a regular Project file in a normal folder."
+        default:
+            "The Project configuration could not be processed safely. Verify the file and try again."
+        }
+    }
+}

--- a/Tracexy/ViewModels/MainContentCoordinator+ProjectTransfer.swift
+++ b/Tracexy/ViewModels/MainContentCoordinator+ProjectTransfer.swift
@@ -68,17 +68,10 @@ extension MainContentCoordinator {
             guard confirmProjectImport(importedConfiguration, fileName: url.lastPathComponent) else {
                 return false
             }
-            guard flushProjectWorkspaceSnapshot() else {
-                return false
-            }
-            let importedProject = try projectStore.importProject(importedConfiguration)
-            activateCurrentProjectWorkspaces()
-            lastProjectOperationError = nil
-            projectTransferErrorMessage = nil
-            return importedProject.id == projectStore.activeProjectID
-        } catch let error as ProjectMutationError {
-            lastProjectOperationError = error
-            return false
+            // Import lands on the same Project lifecycle path as switch, create and
+            // delete-active, so an in-flight capture is stopped and fully drained
+            // before the imported Project becomes active.
+            return beginProjectTransition(.importProject(importedConfiguration))
         } catch {
             projectTransferErrorMessage = projectTransferFailureMessage(for: error)
             return false

--- a/Tracexy/ViewModels/MainContentCoordinator+Projects.swift
+++ b/Tracexy/ViewModels/MainContentCoordinator+Projects.swift
@@ -1,0 +1,322 @@
+import Foundation
+import Observation
+
+// MARK: - ProjectWorkspaceObservationTarget
+
+private final class ProjectWorkspaceObservationTarget: @unchecked Sendable {
+    // MARK: Lifecycle
+
+    init(_ coordinator: MainContentCoordinator) {
+        self.coordinator = coordinator
+    }
+
+    // MARK: Internal
+
+    weak var coordinator: MainContentCoordinator?
+}
+
+// MARK: - Project lifecycle and workspace configuration
+
+extension MainContentCoordinator {
+    /// Loads the local Project catalog once, then applies only the active
+    /// Project's durable workspace configuration. Capture/session/History state
+    /// is intentionally untouched.
+    func hydrateProjectsOnLaunch() async {
+        if let projectHydrationTask {
+            await projectHydrationTask.value
+            return
+        }
+        guard !hasHydratedProjects else {
+            return
+        }
+
+        let task = Task { @MainActor [weak self] in
+            guard let self else {
+                return
+            }
+            await self.projectStore.loadPersistedCatalog()
+            guard self.projectStore.loadState == .ready else {
+                self.isProjectRecoveryPresented = true
+                return
+            }
+            self.activateCurrentProjectWorkspaces()
+            self.hasHydratedProjects = true
+            self.beginProjectWorkspaceObservation()
+        }
+        projectHydrationTask = task
+        await task.value
+        if !hasHydratedProjects {
+            projectHydrationTask = nil
+        }
+    }
+
+    @discardableResult
+    func switchToProject(id: UUID) -> Bool {
+        guard projectStore.isMutable else {
+            lastProjectOperationError = .storeNotReady
+            return false
+        }
+        guard id != projectStore.activeProjectID else {
+            lastProjectOperationError = nil
+            return true
+        }
+        guard projectStore.projects.contains(where: { $0.id == id }) else {
+            lastProjectOperationError = .projectNotFound
+            return false
+        }
+        guard flushProjectWorkspaceSnapshot() else {
+            return false
+        }
+        do {
+            try projectStore.selectProject(id: id)
+            activateCurrentProjectWorkspaces()
+            lastProjectOperationError = nil
+            return true
+        } catch let error as ProjectMutationError {
+            lastProjectOperationError = error
+            return false
+        } catch {
+            projectTransferErrorMessage = error.localizedDescription
+            return false
+        }
+    }
+
+    @discardableResult
+    func createProject(named name: String) -> Project? {
+        guard flushProjectWorkspaceSnapshot() else {
+            return nil
+        }
+        do {
+            let project = try projectStore.createProject(name: name)
+            activateCurrentProjectWorkspaces()
+            lastProjectOperationError = nil
+            return project
+        } catch let error as ProjectMutationError {
+            lastProjectOperationError = error
+            return nil
+        } catch {
+            projectTransferErrorMessage = error.localizedDescription
+            return nil
+        }
+    }
+
+    @discardableResult
+    func renameProject(id: UUID, to name: String) -> Bool {
+        do {
+            try projectStore.renameProject(id: id, to: name)
+            lastProjectOperationError = nil
+            return true
+        } catch let error as ProjectMutationError {
+            lastProjectOperationError = error
+            return false
+        } catch {
+            projectTransferErrorMessage = error.localizedDescription
+            return false
+        }
+    }
+
+    @discardableResult
+    func deleteProject(id: UUID) -> Bool {
+        guard flushProjectWorkspaceSnapshot() else {
+            return false
+        }
+        let deletingActive = id == projectStore.activeProjectID
+        do {
+            try projectStore.deleteProject(id: id)
+            if deletingActive {
+                activateCurrentProjectWorkspaces()
+            }
+            lastProjectOperationError = nil
+            return true
+        } catch let error as ProjectMutationError {
+            lastProjectOperationError = error
+            return false
+        } catch {
+            projectTransferErrorMessage = error.localizedDescription
+            return false
+        }
+    }
+
+    @discardableResult
+    func flushProjectWorkspaceSnapshot() -> Bool {
+        guard projectStore.isMutable else {
+            lastProjectOperationError = .storeNotReady
+            return false
+        }
+        do {
+            try projectStore.updateActiveProjectWorkspaces(
+                workspaces.captureProjectWorkspaces(),
+                activeWorkspaceID: workspaces.activeWorkspaceID
+            )
+            lastProjectOperationError = nil
+            return true
+        } catch let error as ProjectMutationError {
+            lastProjectOperationError = error
+            return false
+        } catch {
+            projectTransferErrorMessage = error.localizedDescription
+            return false
+        }
+    }
+
+    func flushProjectStateForTermination() async {
+        projectWorkspaceAutosaveTask?.cancel()
+        projectWorkspaceAutosaveTask = nil
+        _ = flushProjectWorkspaceSnapshot()
+        await projectStore.waitForPendingPersistence()
+    }
+
+    func retryProjectCatalogLoad() async {
+        await projectStore.retryLoad()
+        guard projectStore.loadState == .ready else {
+            return
+        }
+        activateCurrentProjectWorkspaces()
+        hasHydratedProjects = true
+        isProjectRecoveryPresented = false
+        beginProjectWorkspaceObservation()
+    }
+
+    func resetProjectCatalog() async {
+        await projectStore.resetToDefaultCatalog()
+        guard projectStore.loadState == .ready else {
+            return
+        }
+        activateCurrentProjectWorkspaces()
+        hasHydratedProjects = true
+        isProjectRecoveryPresented = false
+        beginProjectWorkspaceObservation()
+    }
+
+    func presentNewProjectEditor() {
+        guard projectStore.isMutable else {
+            lastProjectOperationError = .storeNotReady
+            return
+        }
+        guard projectStore.canCreateProject else {
+            lastProjectOperationError = .capacityReached(limit: projectStore.maxProjects)
+            return
+        }
+        projectNameEditorContext = ProjectNameEditorContext(
+            mode: .create,
+            initialName: nextUntakenProjectName()
+        )
+    }
+
+    func presentRenameProjectEditor(id: UUID) {
+        guard let project = projectStore.projects.first(where: { $0.id == id }) else {
+            lastProjectOperationError = .projectNotFound
+            return
+        }
+        projectNameEditorContext = ProjectNameEditorContext(
+            mode: .rename(project.id),
+            initialName: project.name
+        )
+    }
+
+    func requestProjectDeletion(_ project: Project) {
+        projectDeletionRequest = ProjectDeletionRequest(
+            projectID: project.id,
+            projectName: project.name
+        )
+    }
+
+    var projectOperationErrorMessage: String? {
+        guard let error = lastProjectOperationError else {
+            return projectTransferErrorMessage
+        }
+        return error.userFacingDescription
+    }
+
+    var projectPersistenceWarningMessage: String? {
+        switch projectStore.loadState {
+        case .failed:
+            "Projects could not be loaded. Workspace changes will not be saved until Projects are repaired."
+        default:
+            if case .failed = projectStore.persistenceStatus {
+                "Projects could not be saved. Your current workspace is still available in this app session."
+            } else {
+                nil
+            }
+        }
+    }
+
+    // MARK: Private helpers
+
+    func activateCurrentProjectWorkspaces() {
+        let project = projectStore.activeProject
+        isApplyingProjectSnapshot = true
+        workspaces.applyProjectWorkspaces(
+            project.workspaces,
+            activeWorkspaceID: project.activeWorkspaceID,
+            maxFilterRules: policy.maxSessionFilterRules
+        )
+        isApplyingProjectSnapshot = false
+
+        // Raw/evidence work is selection-scoped. Hydrated workspaces deliberately
+        // have no capture selection, so retire any presentation from the outgoing
+        // Project without touching the capture itself.
+        cancelFollowStream(clearResult: true)
+        evidenceNavigationDidChangeSelection()
+    }
+
+    private func beginProjectWorkspaceObservation() {
+        guard hasHydratedProjects, !isObservingProjectWorkspaces else {
+            return
+        }
+        isObservingProjectWorkspaces = true
+        armProjectWorkspaceObservation()
+    }
+
+    private func armProjectWorkspaceObservation() {
+        let target = ProjectWorkspaceObservationTarget(self)
+        withObservationTracking {
+            _ = workspaces.activeWorkspaceID
+            _ = workspaces.captureProjectWorkspaces()
+        } onChange: {
+            Task { @MainActor in
+                guard let coordinator = target.coordinator,
+                      coordinator.isObservingProjectWorkspaces else
+                {
+                    return
+                }
+                coordinator.armProjectWorkspaceObservation()
+                guard !coordinator.isApplyingProjectSnapshot else {
+                    return
+                }
+                coordinator.scheduleProjectWorkspaceAutosave()
+            }
+        }
+    }
+
+    private func scheduleProjectWorkspaceAutosave() {
+        projectWorkspaceAutosaveTask?.cancel()
+        projectWorkspaceAutosaveTask = Task { @MainActor [weak self] in
+            do {
+                try await Task.sleep(for: .milliseconds(500))
+            } catch {
+                return
+            }
+            guard let self, !Task.isCancelled else {
+                return
+            }
+            _ = self.flushProjectWorkspaceSnapshot()
+            self.projectWorkspaceAutosaveTask = nil
+        }
+    }
+
+    private func nextUntakenProjectName() -> String {
+        let base = String(localized: "New Project")
+        let used = Set(projectStore.projects.map { ProjectNameNormalization.uniquenessKey($0.name) })
+        if !used.contains(ProjectNameNormalization.uniquenessKey(base)) {
+            return base
+        }
+        for number in 2 ... projectStore.maxProjects + 1 {
+            let candidate = "\(base) \(number)"
+            if !used.contains(ProjectNameNormalization.uniquenessKey(candidate)) {
+                return candidate
+            }
+        }
+        return base
+    }
+}

--- a/Tracexy/ViewModels/MainContentCoordinator+Projects.swift
+++ b/Tracexy/ViewModels/MainContentCoordinator+Projects.swift
@@ -18,9 +18,15 @@ private final class ProjectWorkspaceObservationTarget: @unchecked Sendable {
 // MARK: - Project lifecycle and workspace configuration
 
 extension MainContentCoordinator {
-    /// Loads the local Project catalog once, then applies only the active
-    /// Project's durable workspace configuration. Capture/session/History state
-    /// is intentionally untouched.
+    /// Load the local Project catalog once, bind the launch runtime to the *real*
+    /// active Project, and only then allow capture intake.
+    ///
+    /// Order matters. The legacy-data owner is assigned and persisted before any
+    /// History write, Library scan, or capture can happen, so the pre-Projects
+    /// database and Captures folder can never end up attached to the wrong
+    /// Project. A load or persistence failure leaves the runtime unbound: the app
+    /// keeps running, Repair is offered, and capture is refused rather than taken
+    /// in for an owner Tracexy cannot name.
     func hydrateProjectsOnLaunch() async {
         if let projectHydrationTask {
             await projectHydrationTask.value
@@ -39,9 +45,26 @@ extension MainContentCoordinator {
                 self.isProjectRecoveryPresented = true
                 return
             }
-            self.activateCurrentProjectWorkspaces()
-            self.hasHydratedProjects = true
-            self.beginProjectWorkspaceObservation()
+            do {
+                try self.projectStore.assignLegacyDataOwnerIfNeeded()
+            } catch let error as ProjectMutationError {
+                self.lastProjectOperationError = error
+                self.isProjectRecoveryPresented = true
+                return
+            } catch {
+                self.projectTransferErrorMessage = error.localizedDescription
+                self.isProjectRecoveryPresented = true
+                return
+            }
+            // The owner must be durable before intake, so a crash between now and
+            // the first write can never leave the data unowned or reassignable.
+            await self.projectStore.waitForPendingPersistence()
+            guard self.projectStore.isMutable else {
+                self.lastProjectOperationError = .storeNotReady
+                self.isProjectRecoveryPresented = true
+                return
+            }
+            await self.finishProjectHydration()
         }
         projectHydrationTask = task
         await task.value
@@ -52,10 +75,6 @@ extension MainContentCoordinator {
 
     @discardableResult
     func switchToProject(id: UUID) -> Bool {
-        guard projectStore.isMutable else {
-            lastProjectOperationError = .storeNotReady
-            return false
-        }
         guard id != projectStore.activeProjectID else {
             lastProjectOperationError = nil
             return true
@@ -64,40 +83,25 @@ extension MainContentCoordinator {
             lastProjectOperationError = .projectNotFound
             return false
         }
-        guard flushProjectWorkspaceSnapshot() else {
-            return false
-        }
-        do {
-            try projectStore.selectProject(id: id)
-            activateCurrentProjectWorkspaces()
-            lastProjectOperationError = nil
-            return true
-        } catch let error as ProjectMutationError {
-            lastProjectOperationError = error
-            return false
-        } catch {
-            projectTransferErrorMessage = error.localizedDescription
-            return false
-        }
+        return beginProjectTransition(.switchProject(id))
     }
 
+    /// Creating a Project is a Project change like any other: it uses the same
+    /// lifecycle path, so a running capture is stopped and drained first and the
+    /// new Project starts genuinely empty.
+    ///
+    /// The returned Project is the *validated destination* of a transition that has
+    /// been accepted and started. Its identity is minted when the catalog change is
+    /// validated, so it is known here, but it becomes the active Project only once
+    /// the change has been written durably — await ``waitForProjectTransition()``
+    /// to observe that outcome. `nil` means the change was rejected outright, or
+    /// needs the Stop-and-Switch confirmation first.
     @discardableResult
     func createProject(named name: String) -> Project? {
-        guard flushProjectWorkspaceSnapshot() else {
+        guard beginProjectTransition(.createProject(name)) else {
             return nil
         }
-        do {
-            let project = try projectStore.createProject(name: name)
-            activateCurrentProjectWorkspaces()
-            lastProjectOperationError = nil
-            return project
-        } catch let error as ProjectMutationError {
-            lastProjectOperationError = error
-            return nil
-        } catch {
-            projectTransferErrorMessage = error.localizedDescription
-            return nil
-        }
+        return preparedProjectTransition?.destinationProject
     }
 
     @discardableResult
@@ -115,26 +119,12 @@ extension MainContentCoordinator {
         }
     }
 
+    /// Deleting a Project never deletes its saved capture files. The JSON configuration
+    /// is removed from the catalog and the in-memory bucket is released; the
+    /// Project's History database and Captures folder stay exactly where they are.
     @discardableResult
     func deleteProject(id: UUID) -> Bool {
-        guard flushProjectWorkspaceSnapshot() else {
-            return false
-        }
-        let deletingActive = id == projectStore.activeProjectID
-        do {
-            try projectStore.deleteProject(id: id)
-            if deletingActive {
-                activateCurrentProjectWorkspaces()
-            }
-            lastProjectOperationError = nil
-            return true
-        } catch let error as ProjectMutationError {
-            lastProjectOperationError = error
-            return false
-        } catch {
-            projectTransferErrorMessage = error.localizedDescription
-            return false
-        }
+        beginProjectTransition(.deleteProject(id))
     }
 
     @discardableResult
@@ -160,32 +150,110 @@ extension MainContentCoordinator {
     }
 
     func flushProjectStateForTermination() async {
+        _ = await projectTransitionTask?.value
+        await pendingCaptureIOTask?.value
+        await waitForHistory()
         projectWorkspaceAutosaveTask?.cancel()
         projectWorkspaceAutosaveTask = nil
+        projectWorkspaceAutosaveOwner = nil
         _ = flushProjectWorkspaceSnapshot()
         await projectStore.waitForPendingPersistence()
     }
 
     func retryProjectCatalogLoad() async {
+        // Reload is startup recovery, not permission to replace an investigation
+        // already in memory with an older file. Explicit Reset has its own path.
+        guard !hasHydratedProjects else {
+            projectTransitionStatus = .failed(
+                "Your investigation is still open. Save any unsaved capture before restarting Tracexy to reload the catalog."
+            )
+            return
+        }
+        // Reloading rebinds the runtime, so nothing may still be owed against the
+        // store, spool or Library the current runtime is holding.
+        guard canRebindProjectRuntime else {
+            projectTransitionStatus = .failed(
+                "Finish the running capture and its pending writes before repairing Projects."
+            )
+            return
+        }
+        projectTransitionStatus = .pending
+        defer {
+            if projectTransitionStatus.isPending {
+                projectTransitionStatus = .idle
+            }
+        }
         await projectStore.retryLoad()
         guard projectStore.loadState == .ready else {
             return
         }
-        activateCurrentProjectWorkspaces()
-        hasHydratedProjects = true
-        isProjectRecoveryPresented = false
-        beginProjectWorkspaceObservation()
-    }
-
-    func resetProjectCatalog() async {
-        await projectStore.resetToDefaultCatalog()
-        guard projectStore.loadState == .ready else {
+        do {
+            try projectStore.assignLegacyDataOwnerIfNeeded()
+        } catch {
             return
         }
-        activateCurrentProjectWorkspaces()
-        hasHydratedProjects = true
+        // The owner must be durable before intake, so a crash between now and the
+        // first write can never leave the data unowned or reassignable.
+        await projectStore.waitForPendingPersistence()
+        guard projectStore.isMutable else {
+            return
+        }
+        await finishProjectHydration()
         isProjectRecoveryPresented = false
-        beginProjectWorkspaceObservation()
+    }
+
+    /// Replace the catalog with a fresh default one. Recovery never reassigns the
+    /// pre-Projects data: the owner is preserved when it is known and retired
+    /// otherwise, so the files stay on disk and no new Project inherits them.
+    func resetProjectCatalog() async {
+        guard projectTransitionTask == nil else {
+            return
+        }
+        let task = Task { @MainActor in
+            await self.performProjectCatalogReset()
+            return self.projectTransitionStatus == .idle
+        }
+        projectTransitionTask = task
+        _ = await task.value
+        projectTransitionTask = nil
+    }
+
+    private func performProjectCatalogReset() async {
+        guard canRebindProjectRuntime else {
+            projectTransitionStatus = .failed(
+                "Stop the running capture and let its pending writes finish before repairing Projects."
+            )
+            return
+        }
+        let prepared: PreparedProjectCatalogTransition
+        do {
+            prepared = try projectStore.prepareResetTransition()
+        } catch {
+            projectTransitionStatus = .failed("Projects could not be prepared for reset. Nothing was discarded.")
+            return
+        }
+        projectTransitionStatus = .pending
+        suspendProjectWorkspaceObservation()
+        do {
+            let runtime = try await makeProjectRuntime(for: prepared.destinationProject)
+            try await projectStore.commitPreparedTransition(prepared)
+            invalidateOutgoingProjectWork()
+            projectRuntimes.removeAll()
+            hydratePersistedWorkspaces(of: prepared.destinationProject, into: runtime)
+            projectRuntimes[prepared.destinationProject.id] = runtime
+            hasBoundInitialRuntime = true
+            adoptProjectRuntime(runtime)
+            hasHydratedProjects = true
+            projectTransitionStatus = .idle
+            configureHistoryAutoClear(runtime.historyAutoClear)
+            resumeProjectWorkspaceObservation()
+            isProjectRecoveryPresented = false
+        } catch {
+            projectStore.discardPreparedTransition(prepared)
+            resumeProjectWorkspaceObservation()
+            projectTransitionStatus =
+                .failed("Projects could not be reset. The previous catalog and investigation were preserved.")
+        }
     }
 
     func presentNewProjectEditor() {
@@ -235,48 +303,96 @@ extension MainContentCoordinator {
         default:
             if case .failed = projectStore.persistenceStatus {
                 "Projects could not be saved. Your current workspace is still available in this app session."
+            } else if projectStore.legacyDataOwnerProjectID == ProjectCatalog.retiredLegacyDataOwnerID {
+                "Capture data written before this Project catalog was repaired is still on disk, but it is "
+                    + "not attached to any Project. Tracexy will not hand it to a new Project."
             } else {
                 nil
             }
         }
     }
 
-    // MARK: Private helpers
+    // MARK: Workspace hydration and autosave
 
-    func activateCurrentProjectWorkspaces() {
-        let project = projectStore.activeProject
-        isApplyingProjectSnapshot = true
-        workspaces.applyProjectWorkspaces(
+    /// Apply a Project's durable workspace configuration onto a freshly built
+    /// runtime. Called once per bucket; a Project that is already open keeps its
+    /// real workspace instances instead.
+    func hydratePersistedWorkspaces(of project: Project, into runtime: ProjectRuntimeState) {
+        runtime.workspaces.applyProjectWorkspaces(
             project.workspaces,
             activeWorkspaceID: project.activeWorkspaceID,
             maxFilterRules: policy.maxSessionFilterRules
         )
-        isApplyingProjectSnapshot = false
-
-        // Raw/evidence work is selection-scoped. Hydrated workspaces deliberately
-        // have no capture selection, so retire any presentation from the outgoing
-        // Project without touching the capture itself.
-        cancelFollowStream(clearResult: true)
-        evidenceNavigationDidChangeSelection()
     }
 
-    private func beginProjectWorkspaceObservation() {
-        guard hasHydratedProjects, !isObservingProjectWorkspaces else {
+    /// Re-arm the Observation-backed autosave against whichever ``WorkspaceStore``
+    /// is now active, stamped with the Project that owns it.
+    func resumeProjectWorkspaceObservation() {
+        guard hasHydratedProjects else {
             return
         }
         isObservingProjectWorkspaces = true
         armProjectWorkspaceObservation()
     }
 
+    /// Stop the Observation-backed autosave. A debounce that survives into a frozen
+    /// catalog can only fail; the next boundary re-arms it against whichever
+    /// ``WorkspaceStore`` becomes active.
+    func suspendProjectWorkspaceObservation() {
+        projectWorkspaceAutosaveTask?.cancel()
+        projectWorkspaceAutosaveTask = nil
+        projectWorkspaceAutosaveOwner = nil
+        isObservingProjectWorkspaces = false
+    }
+
+    // MARK: Private
+
+    /// True when the runtime may be torn down and rebound: no capture is running,
+    /// no stop still owes its final drain, no transition is in flight, and neither
+    /// the managed save nor the History mutation tail is still owed against the
+    /// store, spool and Library the current runtime holds.
+    private var canRebindProjectRuntime: Bool {
+        !isCapturing && !isStarting && !isProjectBoundaryBusy
+            && !isOpeningSavedCapture && !isExportingSession
+            && projectStore.loadState != .loading
+            && pendingProjectSwitchConfirmation == nil
+            && pendingCaptureIOTask == nil
+            && historyMutationTask == nil
+    }
+
+    private func finishProjectHydration() async {
+        do {
+            try await bindInitialProjectRuntime()
+        } catch {
+            lastProjectOperationError = .storeNotReady
+            projectTransitionStatus = .failed(
+                (error as? ProjectRuntimeError)?.userFacingDescription ?? error.localizedDescription
+            )
+            isProjectRecoveryPresented = true
+            return
+        }
+        hydratePersistedWorkspaces(of: projectStore.activeProject, into: activeRuntime)
+        // Raw/evidence work is selection-scoped; the freshly hydrated workspaces
+        // carry no capture selection yet.
+        cancelFollowStream(clearResult: true)
+        evidenceNavigationDidChangeSelection()
+        hasHydratedProjects = true
+        projectTransitionStatus = .idle
+        configureHistoryAutoClear(activeRuntime.historyAutoClear)
+        resumeProjectWorkspaceObservation()
+    }
+
     private func armProjectWorkspaceObservation() {
         let target = ProjectWorkspaceObservationTarget(self)
+        let owner = projectStore.activeProjectID
         withObservationTracking {
             _ = workspaces.activeWorkspaceID
             _ = workspaces.captureProjectWorkspaces()
         } onChange: {
             Task { @MainActor in
                 guard let coordinator = target.coordinator,
-                      coordinator.isObservingProjectWorkspaces else
+                      coordinator.isObservingProjectWorkspaces,
+                      coordinator.projectStore.activeProjectID == owner else
                 {
                     return
                 }
@@ -284,13 +400,14 @@ extension MainContentCoordinator {
                 guard !coordinator.isApplyingProjectSnapshot else {
                     return
                 }
-                coordinator.scheduleProjectWorkspaceAutosave()
+                coordinator.scheduleProjectWorkspaceAutosave(owner: owner)
             }
         }
     }
 
-    private func scheduleProjectWorkspaceAutosave() {
+    private func scheduleProjectWorkspaceAutosave(owner: UUID) {
         projectWorkspaceAutosaveTask?.cancel()
+        projectWorkspaceAutosaveOwner = owner
         projectWorkspaceAutosaveTask = Task { @MainActor [weak self] in
             do {
                 try await Task.sleep(for: .milliseconds(500))
@@ -300,8 +417,17 @@ extension MainContentCoordinator {
             guard let self, !Task.isCancelled else {
                 return
             }
+            // A debounce that outlived its Project must never write the incoming
+            // Project's workspaces into the outgoing Project's catalog entry.
+            guard self.projectWorkspaceAutosaveOwner == owner,
+                  self.projectStore.activeProjectID == owner else
+            {
+                self.projectWorkspaceAutosaveTask = nil
+                return
+            }
             _ = self.flushProjectWorkspaceSnapshot()
             self.projectWorkspaceAutosaveTask = nil
+            self.projectWorkspaceAutosaveOwner = nil
         }
     }
 

--- a/Tracexy/ViewModels/MainContentCoordinator+SavedCaptureOpening.swift
+++ b/Tracexy/ViewModels/MainContentCoordinator+SavedCaptureOpening.swift
@@ -1,5 +1,20 @@
 import Foundation
 
+// MARK: - SavedCaptureLoadOperation
+
+/// Off-main loading operation, injectable for deterministic cancellation tests.
+/// Production always uses the same bounded streaming parser.
+nonisolated struct SavedCaptureLoadOperation: Sendable {
+    static let streaming = Self { url, capacity, progress in
+        try SavedCaptureStreamLoader(
+            contentsOf: url,
+            configuration: .init(retainedCapacity: capacity)
+        ).load(onProgress: progress)
+    }
+
+    var run: @Sendable (URL, Int, @Sendable (PcapStreamProgress) -> Void) async throws -> SavedCaptureLoadResult
+}
+
 // MARK: - SavedCaptureOpenRequest
 
 /// One user intent to open a saved capture. The monotonically increasing ID is
@@ -91,6 +106,25 @@ extension MainContentCoordinator {
     /// active, the request waits behind its final drain; the loader cannot start
     /// until that boundary calls ``resumePendingSavedCaptureOpenAfterLiveDrain``.
     func openSavedCapture(_ capture: SavedCapture) {
+        guard hasHydratedProjects, activeRuntime.projectID != nil else {
+            captureError = "Load or repair Projects before opening capture data."
+            return
+        }
+        // A Project transition is about to swap the Library, spool and store this
+        // request would publish into. It is refused rather than started and then
+        // silently discarded at the boundary. A stop's own final drain is *not* a
+        // refusal: waiting behind it is exactly this method's contract.
+        guard !projectTransitionStatus.isPending else {
+            captureError = "Tracexy is switching Projects. Open “\(capture.name)” again in a moment."
+            return
+        }
+        // Adopting a load resets the engine and the live spool, so an accepted Save
+        // or an in-flight export still reading that source refuses the open here
+        // rather than having its evidence reset out from under it.
+        if let held = captureSourceHoldMessage {
+            captureError = held
+            return
+        }
         cancelFollowStream(clearResult: true)
         cancelSavedCaptureOpen(clearPublishedEvidence: false)
         savedCaptureOpenRequestID &+= 1
@@ -107,7 +141,7 @@ extension MainContentCoordinator {
 
         if isCapturing || isStarting {
             stopCapture()
-        } else {
+        } else if !isFinalDrainPending {
             // Even an already-stopped capture can have one ordered ingest task
             // finishing. Wait for that exact task rather than sleeping/polling.
             queuePendingSavedCaptureOpenAfterCurrentIngest()
@@ -121,7 +155,15 @@ extension MainContentCoordinator {
     /// external file replaces the old copy only after the new one is fully
     /// staged, so a failed import never destroys existing capture data.
     func importCapture(from source: URL) {
-        guard let directory = Self.capturesDirectory() else {
+        // A name collision replaces an existing Library file, which may be exactly
+        // the file an accepted Save or an in-flight export is reading.
+        if let held = captureSourceHoldMessage {
+            captureError = held
+            return
+        }
+        guard hasHydratedProjects, !isProjectBoundaryBusy,
+              let directory = capturesDirectory() else
+        {
             return
         }
         let destination: URL
@@ -137,9 +179,11 @@ extension MainContentCoordinator {
         }
     }
 
-    /// Rescans the captures folder and rebuilds `savedCaptures`, newest first.
+    /// Rescans the *active Project's* captures folder and rebuilds
+    /// `savedCaptures`, newest first. Each Project has its own Library folder, so
+    /// saving or trashing a capture in one never changes another's list.
     func refreshSavedCaptures() {
-        guard let directory = Self.capturesDirectory(),
+        guard let directory = capturesDirectory(),
               let urls = try? FileManager.default.contentsOfDirectory(
                   at: directory,
                   includingPropertiesForKeys: [.contentModificationDateKey, .fileSizeKey]
@@ -270,7 +314,8 @@ extension MainContentCoordinator {
     /// Called only after the final live helper batch has been folded/spooled, or
     /// after the direct/current ingest chain has drained.
     func resumePendingSavedCaptureOpenAfterLiveDrain() {
-        guard let request = pendingSavedCaptureOpen,
+        guard !isFinalDrainPending, !projectTransitionStatus.isPending,
+              let request = pendingSavedCaptureOpen,
               request.id == savedCaptureOpenRequestID else
         {
             return
@@ -288,6 +333,7 @@ extension MainContentCoordinator {
             guard let self,
                   !Task.isCancelled,
                   self.savedCaptureOpenRequestID == requestID,
+                  !self.isFinalDrainPending,
                   !self.isCapturing,
                   !self.isStarting else
             {
@@ -307,22 +353,21 @@ extension MainContentCoordinator {
         savedCaptureBoundaryTask = nil
 
         let expectedStartGeneration = startGeneration
-        let retainedCapacity = CaptureSettingsResolver.retainCapacity()
+        let retainedCapacity = CaptureSettingsResolver.retainCapacity(defaults: activeProjectDefaults)
+        let originProjectID = activeRuntime.projectID
+        let operation = savedCaptureLoadOperation
         let progressRelay = SavedCaptureProgressRelay(coordinator: self, requestID: request.id)
         let task = Task.detached(priority: .userInitiated) { [weak self] in
             do {
-                let loader = try SavedCaptureStreamLoader(
-                    contentsOf: request.capture.url,
-                    configuration: .init(retainedCapacity: retainedCapacity)
-                )
-                let result = try loader.load { progress in
+                let result = try await operation.run(request.capture.url, retainedCapacity) { progress in
                     progressRelay.submit(progress)
                 }
                 try Task.checkCancellation()
                 await self?.adoptSavedCaptureResult(
                     result,
                     request: request,
-                    expectedStartGeneration: expectedStartGeneration
+                    expectedStartGeneration: expectedStartGeneration,
+                    originProjectID: originProjectID
                 )
             } catch is CancellationError {
                 await self?.finishCancelledSavedCaptureOpen(requestID: request.id)
@@ -351,9 +396,27 @@ extension MainContentCoordinator {
     private func adoptSavedCaptureResult(
         _ result: SavedCaptureLoadResult,
         request: SavedCaptureOpenRequest,
-        expectedStartGeneration: Int
+        expectedStartGeneration: Int,
+        originProjectID: UUID?
     ) {
+        // A load that finishes after a Project change belongs to the Project that
+        // asked for it. Adopting it into another Project would publish one
+        // Project's sessions, evidence and History event under another's identity.
+        guard activeRuntime.projectID == originProjectID else {
+            return
+        }
         guard request.id == savedCaptureOpenRequestID else {
+            return
+        }
+        // A Save accepted while this load was running owns the current source, and
+        // the adoption below resets the engine and spool it is copying. Refuse the
+        // adoption instead — the load is retired with a visible reason, and the
+        // capture the user asked to keep stays intact.
+        if let held = captureSourceHoldMessage {
+            failSavedCaptureOpen(
+                message: "Couldn’t open “\(request.capture.name)” — \(held)",
+                requestID: request.id
+            )
             return
         }
         guard startGeneration == expectedStartGeneration,
@@ -516,12 +579,19 @@ extension MainContentCoordinator {
     /// one runloop turn so it can't reload an `NSTableView` reentrantly from inside
     /// a click currently being handled, and it re-checks the capture generation
     /// *and* the expected capture state so a late generation publishes no half.
+    ///
+    /// The deferred publication is returned so the final-drain boundary can await
+    /// the *actual* adoption and terminal History enqueue rather than treating the
+    /// scheduling of this task as the end of the capture.
+    @discardableResult
     func publishLiveDetailed(
         _ snapshot: InvestigationSnapshot,
         expectedGeneration: Int,
         isCapturing expectedCaptureState: Bool,
         terminalHistoryCompleteness: HistoryCompleteness? = nil
-    ) {
+    )
+        -> Task<Void, Never>
+    {
         ProcessResolver.shared.refresh()
         var built = snapshot.sessions
         for index in built.indices where built[index].processName == nil {
@@ -533,7 +603,7 @@ extension MainContentCoordinator {
         }
         let applied = built
         let publishedSnapshot = snapshot.replacingSessions(with: applied)
-        Task { @MainActor in
+        return Task { @MainActor in
             guard self.startGeneration == expectedGeneration,
                   self.isCapturing == expectedCaptureState else
             {

--- a/Tracexy/ViewModels/MainContentCoordinator+SessionExport.swift
+++ b/Tracexy/ViewModels/MainContentCoordinator+SessionExport.swift
@@ -8,14 +8,22 @@ extension MainContentCoordinator {
     /// intentionally separate from frame matching, which happens only after the
     /// user activates an export command.
     var canExportSelectedSession: Bool {
-        selectedSession != nil && canSaveCapture && !isExportingSession
+        selectedSession != nil && canExport()
     }
 
     /// Cheap presentation gate for row menus. Packet matching is deliberately
     /// deferred until activation because reading and decoding the complete capture belongs
     /// off the main actor.
     func canExport(_: SessionSummary) -> Bool {
-        canSaveCapture && !isExportingSession
+        canExport()
+    }
+
+    /// An export reads the complete capture from the active Project's spool. While
+    /// the Project boundary is settling that spool has not reached its exact final
+    /// boundary, or is about to be replaced, so export is refused rather than
+    /// serving a partial or another Project's capture.
+    func canExport() -> Bool {
+        canSaveCapture && !isExportingSession && !isProjectBoundaryBusy
     }
 
     func exportSelectedSession(as format: SessionExportFormat) {
@@ -29,24 +37,37 @@ extension MainContentCoordinator {
     /// toolbar menu and row context menu route here, so scope, serialization,
     /// filename, errors, and privacy behavior cannot drift apart.
     func exportSession(_ session: SessionSummary, as format: SessionExportFormat) {
-        guard !isExportingSession else {
+        guard !isExportingSession, !isProjectBoundaryBusy else {
             return
         }
-        let configuredPrivacy = PrivacySettingsResolver.exportPolicy()
+        let configuredPrivacy = PrivacySettingsResolver.exportPolicy(defaults: activeProjectDefaults)
+        // The raw-capture acknowledgement below is modal, so it spins the run loop:
+        // Start, Clear and Open can all be activated while it is up. The export owns
+        // its capture source from *here*, before the first reentrant presentation,
+        // rather than from the moment the user confirms.
+        setSessionExporting(true)
         guard let exportPrivacy = confirmedPrivacyPolicy(
             for: format,
             configuredPrivacy: configuredPrivacy
         ) else {
+            setSessionExporting(false)
             return
         }
-        setSessionExporting(true)
+        // The source identity this export was started against, captured before any
+        // asynchronous work so a late result can never describe another Project's
+        // or another capture generation's source.
+        let originProjectID = activeRuntime.projectID
+        let originGeneration = startGeneration
 
-        Task { [weak self] in
-            defer { self?.setSessionExporting(false) }
+        Task { @MainActor [weak self] in
+            guard let self else {
+                return
+            }
+            defer { self.setSessionExporting(false) }
+            var failure: String?
+            var warning: String?
+            var didWrite = false
             do {
-                guard let self else {
-                    return
-                }
                 let capture = try await self.completeCaptureForExport()
                 let artifact = try await Task.detached(priority: .userInitiated) {
                     let sessionFrames = SessionExporter.frames(
@@ -80,15 +101,21 @@ extension MainContentCoordinator {
                 try await Task.detached(priority: .userInitiated) {
                     try artifact.data.write(to: url, options: .atomic)
                 }.value
-                if let warning = capture.incompletenessReason {
-                    self.captureError = "Exported the recoverable session prefix. Later frames are missing because "
-                        + "the local spool failed — \(warning)"
-                } else {
-                    self.captureError = nil
-                }
+                didWrite = true
+                warning = capture.incompletenessReason
             } catch {
-                self?.captureError = "Couldn’t export session: \(error.localizedDescription)"
+                failure = "Couldn’t export session: \(error.localizedDescription)"
             }
+            self.reportCaptureIOOutcome(
+                failure: failure,
+                warning: warning.map {
+                    "Exported the recoverable session prefix. Later frames are missing because "
+                        + "the local spool failed — \($0)"
+                },
+                didWrite: didWrite,
+                originProjectID: originProjectID,
+                originGeneration: originGeneration
+            )
         }
     }
 

--- a/Tracexy/ViewModels/MainContentCoordinator+SourceVisibility.swift
+++ b/Tracexy/ViewModels/MainContentCoordinator+SourceVisibility.swift
@@ -80,41 +80,45 @@ extension MainContentCoordinator {
         SourceVisibilityPreferences.persist(
             apps: hiddenSourceApps,
             domains: hiddenSourceDomains,
-            ips: hiddenSourceIPs
+            ips: hiddenSourceIPs,
+            defaults: activeProjectDefaults
         )
     }
 }
 
 // MARK: - SourceVisibilityPreferences
 
+/// Hidden-source presentation state. `defaults` is always the *active Project's*
+/// suite, so hiding a row in one Project never removes it from another.
 enum SourceVisibilityPreferences {
     // MARK: Internal
 
-    static func loadApps() -> Set<String> {
-        load(key: appsKey)
+    static func loadApps(defaults: UserDefaults) -> Set<String> {
+        load(key: ProjectScopedSettingsKeys.hiddenSourceApps, defaults: defaults)
     }
 
-    static func loadDomains() -> Set<String> {
-        load(key: domainsKey)
+    static func loadDomains(defaults: UserDefaults) -> Set<String> {
+        load(key: ProjectScopedSettingsKeys.hiddenSourceDomains, defaults: defaults)
     }
 
-    static func loadIPs() -> Set<String> {
-        load(key: ipsKey)
+    static func loadIPs(defaults: UserDefaults) -> Set<String> {
+        load(key: ProjectScopedSettingsKeys.hiddenSourceIPs, defaults: defaults)
     }
 
-    static func persist(apps: Set<String>, domains: Set<String>, ips: Set<String>) {
-        UserDefaults.standard.set(apps.sorted(), forKey: appsKey)
-        UserDefaults.standard.set(domains.sorted(), forKey: domainsKey)
-        UserDefaults.standard.set(ips.sorted(), forKey: ipsKey)
+    static func persist(
+        apps: Set<String>,
+        domains: Set<String>,
+        ips: Set<String>,
+        defaults: UserDefaults
+    ) {
+        defaults.set(apps.sorted(), forKey: ProjectScopedSettingsKeys.hiddenSourceApps)
+        defaults.set(domains.sorted(), forKey: ProjectScopedSettingsKeys.hiddenSourceDomains)
+        defaults.set(ips.sorted(), forKey: ProjectScopedSettingsKeys.hiddenSourceIPs)
     }
 
     // MARK: Private
 
-    private static let appsKey = TracexyIdentity.current.defaultsKey("sources.hiddenApps")
-    private static let domainsKey = TracexyIdentity.current.defaultsKey("sources.hiddenDomains")
-    private static let ipsKey = TracexyIdentity.current.defaultsKey("sources.hiddenIPs")
-
-    private static func load(key: String) -> Set<String> {
-        Set(UserDefaults.standard.stringArray(forKey: key) ?? [])
+    private static func load(key: String, defaults: UserDefaults) -> Set<String> {
+        Set(defaults.stringArray(forKey: key) ?? [])
     }
 }

--- a/Tracexy/ViewModels/MainContentCoordinator.swift
+++ b/Tracexy/ViewModels/MainContentCoordinator.swift
@@ -22,6 +22,7 @@ final class MainContentCoordinator {
         policy: (any AppPolicy)? = nil,
         layoutPreferences: WorkspaceLayoutPreferences? = nil,
         sessionStore: SessionStore? = nil,
+        projectRepository: ProjectCatalogPersisting? = nil,
         isHistoryDemoMode: Bool = false,
         historyNow: @escaping @Sendable () -> Date = { Date() },
         liveCaptureSpool: LiveCaptureSpool? = nil
@@ -34,6 +35,11 @@ final class MainContentCoordinator {
         )
         let resolvedPolicy = policy ?? DefaultAppPolicy()
         self.policy = resolvedPolicy
+        projectStore = ProjectStore(
+            maxProjects: resolvedPolicy.maxProjects,
+            maxWorkspacesPerProject: resolvedPolicy.maxWorkspaceTabs,
+            repository: projectRepository
+        )
         focusGate = FocusPolicyGate(
             maxFocusSets: resolvedPolicy.maxFocusSets,
             maxPinnedHosts: resolvedPolicy.maxPinnedHosts
@@ -113,6 +119,28 @@ final class MainContentCoordinator {
     let focusGate: FocusPolicyGate
 
     let workspaces: WorkspaceStore
+
+    /// Local, configuration-only Project catalog. Projects own durable workspace
+    /// view intent; capture bytes, current sessions, and terminal History remain
+    /// app-wide and are never stored here.
+    let projectStore: ProjectStore
+
+    /// Project presentation and orchestration state. Stored on the app-level
+    /// coordinator so toolbar, commands, and sheets share one source of truth.
+    var projectNameEditorContext: ProjectNameEditorContext?
+    var projectDeletionRequest: ProjectDeletionRequest?
+    var isProjectManagerPresented = false
+    var isProjectRecoveryPresented = false
+    var lastProjectOperationError: ProjectMutationError?
+    var projectTransferErrorMessage: String?
+
+    /// Launch hydration and Observation-backed workspace autosave are coalesced
+    /// here rather than being owned by a view lifecycle.
+    var hasHydratedProjects = false
+    var isApplyingProjectSnapshot = false
+    var isObservingProjectWorkspaces = false
+    var projectHydrationTask: Task<Void, Never>?
+    var projectWorkspaceAutosaveTask: Task<Void, Never>?
 
     /// The most recent capacity limit the user ran into, in their words.
     /// Cleared when they acknowledge it or when the next successful action
@@ -1800,74 +1828,5 @@ private extension MainContentCoordinator {
             totals[key(session), default: 0] += 1
         }
         return totals.sorted { $0.value > $1.value }.map { (name: $0.key, count: $0.value) }
-    }
-}
-
-// MARK: - CaptureDisplayState
-
-/// Coarse capture state shown in the toolbar status capsule. Drives both the dot color and the trailing word.
-enum CaptureDisplayState {
-    case stopped
-    case starting
-    case capturing
-    case error
-
-    // MARK: Internal
-
-    var title: String {
-        switch self {
-        case .stopped: String(localized: "Stopped")
-        case .starting: String(localized: "Starting")
-        case .capturing: String(localized: "Capturing")
-        case .error: String(localized: "Error")
-        }
-    }
-}
-
-// MARK: - SavedCapture
-
-/// One saved `.pcap` or `.pcapng` file on disk, listed under the sidebar's "Saved Captures".
-struct SavedCapture: Identifiable, Hashable, Sendable {
-    let url: URL
-    let name: String
-    let date: Date
-    let byteCount: Int
-
-    var id: URL {
-        url
-    }
-}
-
-// MARK: - DomainGroup
-
-/// A domain and the set of server IPs it resolved to, for the sidebar tree.
-struct DomainGroup: Identifiable {
-    let domain: String
-    let ips: [String]
-    let count: Int
-
-    var id: String {
-        domain
-    }
-}
-
-// MARK: - ThroughputSample
-
-/// One point on the real-time throughput chart (bytes/sec over an interval).
-struct ThroughputSample: Identifiable {
-    let id = UUID()
-    let bytesPerSecond: Double
-}
-
-// MARK: - AppGroup
-
-/// An app and the set of hosts/IPs it contacted, for the expandable sidebar tree.
-struct AppGroup: Identifiable {
-    let app: String
-    let hosts: [String]
-    let count: Int
-
-    var id: String {
-        app
     }
 }

--- a/Tracexy/ViewModels/MainContentCoordinator.swift
+++ b/Tracexy/ViewModels/MainContentCoordinator.swift
@@ -23,18 +23,20 @@ final class MainContentCoordinator {
         layoutPreferences: WorkspaceLayoutPreferences? = nil,
         sessionStore: SessionStore? = nil,
         projectRepository: ProjectCatalogPersisting? = nil,
+        projectDataProvider: (any ProjectDataProviding)? = nil,
         isHistoryDemoMode: Bool = false,
         historyNow: @escaping @Sendable () -> Date = { Date() },
-        liveCaptureSpool: LiveCaptureSpool? = nil
+        liveCaptureSpool: LiveCaptureSpool? = nil,
+        settingsDefaults: UserDefaults? = nil
     ) {
-        self.sessionStore = sessionStore
         self.isHistoryDemoMode = isHistoryDemoMode
         self.historyNow = historyNow
-        self.liveCaptureSpool = liveCaptureSpool ?? LiveCaptureSpool(
-            directoryName: TracexyIdentity.current.appSupportDirectoryName
-        )
         let resolvedPolicy = policy ?? DefaultAppPolicy()
         self.policy = resolvedPolicy
+        let provider = projectDataProvider ?? DefaultProjectDataProvider()
+        self.projectDataProvider = provider
+        injectedSessionStore = sessionStore
+        injectedLiveCaptureSpool = liveCaptureSpool
         projectStore = ProjectStore(
             maxProjects: resolvedPolicy.maxProjects,
             maxWorkspacesPerProject: resolvedPolicy.maxWorkspaceTabs,
@@ -44,42 +46,87 @@ final class MainContentCoordinator {
             maxFocusSets: resolvedPolicy.maxFocusSets,
             maxPinnedHosts: resolvedPolicy.maxPinnedHosts
         )
-        let preferences = layoutPreferences ?? WorkspaceLayoutPreferences()
-        self.layoutPreferences = preferences
-        workspaces = WorkspaceStore(
-            maxWorkspaces: resolvedPolicy.maxWorkspaceTabs,
-            layoutPreferences: preferences
+
+        // The pre-hydration runtime is deliberately *unbound*: it carries no
+        // Project identity, and capture intake is refused until
+        // `hydrateProjectsOnLaunch` binds it to the real active Project. That is
+        // what keeps a frame from ever being written for a provisional identity.
+        let bootDefaults = settingsDefaults ?? .standard
+        let bootPreferences = layoutPreferences ?? WorkspaceLayoutPreferences(defaults: bootDefaults)
+        let bootLocation = provider.location(
+            forProject: ProjectCatalog.retiredLegacyDataOwnerID,
+            isLegacyOwner: true
         )
+        let bootRuntime = ProjectRuntimeState(
+            projectID: nil,
+            location: bootLocation,
+            settingsDefaults: bootDefaults,
+            layoutPreferences: bootPreferences,
+            workspaces: WorkspaceStore(
+                maxWorkspaces: resolvedPolicy.maxWorkspaceTabs,
+                layoutPreferences: bootPreferences,
+                defaults: bootDefaults
+            ),
+            sessionStore: sessionStore,
+            liveCaptureSpool: liveCaptureSpool ?? provider.makeLiveCaptureSpool(at: bootLocation),
+            // Deliberately absent before hydration. Preparing or scanning a capture
+            // Library here would touch the pre-Projects folder before the legacy
+            // data owner is durably bound, which is exactly what must not happen.
+            capturesDirectory: nil,
+            captureInterface: Self.resolvedDefaultInterface(defaults: bootDefaults)
+        )
+        activeRuntime = bootRuntime
+        self.sessionStore = sessionStore
+        self.liveCaptureSpool = bootRuntime.liveCaptureSpool
+        self.layoutPreferences = bootPreferences
+        workspaces = bootRuntime.workspaces
+        activeProjectDefaults = bootDefaults
+        activeCapturesDirectory = bootRuntime.capturesDirectory
         // Boot empty: nothing is shown until a real capture streams real frames.
-        // Default to the *active* interface (up + has an IPv4), not the first
-        // non-loopback one — virtual interfaces (awdl0/anpi0/bridge0) carry no
-        // traffic, so capturing on them looks like "no data".
-        let interfaces = NetworkInterfaces.available()
-        let active = interfaces.first { !$0.isLoopback && $0.isUp && $0.ipv4 != nil }
-        let anyReal = interfaces.first { !$0.isLoopback }
-        // Honor the Capture → "Default interface" preference when it names a real,
-        // currently-available interface; otherwise fall back to the active one.
-        let preferred = UserDefaults.standard.string(forKey: SettingsKeys.defaultInterface)
-        if let preferred, !preferred.isEmpty, interfaces.contains(where: { $0.id == preferred }) {
-            captureInterface = preferred
-        } else {
-            captureInterface = active?.id ?? anyReal?.id ?? "en0"
-        }
+        captureInterface = bootRuntime.captureInterface
         localIPv4 = NetworkInterfaces.primaryIPv4()
-        pinnedHosts = Self.loadPinnedHosts()
         // History is unavailable until a store is injected; otherwise it begins idle
         // and loads lazily on the first refresh.
         historyAvailability = sessionStore == nil ? .unavailable : .idle
+        bootRuntime.loadPreferenceBackedState()
+        pinnedHosts = bootRuntime.pinnedHosts
+        focusSets = bootRuntime.focusSets
+        mutedHosts = bootRuntime.mutedHosts
+        mutedProtocols = bootRuntime.mutedProtocols
+        hiddenSourceApps = bootRuntime.hiddenSourceApps
+        hiddenSourceDomains = bootRuntime.hiddenSourceDomains
+        hiddenSourceIPs = bootRuntime.hiddenSourceIPs
         refreshSavedCaptures()
-        // Before any destructive/privileged helper op (force reset), stop active
-        // capture and invalidate polling so nothing keeps touching a helper that
-        // is about to be torn down.
+        // Before any destructive/privileged helper op (force reset), settle the
+        // active capture, retire what the destroyed connection still owes, and
+        // invalidate polling so nothing keeps touching a helper that is about to be
+        // torn down.
         helper.willBeginDestructiveReset = { [weak self] in
-            self?.stopCapture()
+            self?.prepareForDestructiveHelperReset()
         }
     }
 
     // MARK: Internal
+
+    /// One parked waiter on a specific owed drain operation.
+    struct FinalDrainWaiter {
+        let operationID: Int
+        let continuation: CheckedContinuation<Bool, Never>
+    }
+
+    /// One stop's owed final drain. It carries the identity every waiter and
+    /// completion is matched against, plus the exact capture epoch and owning
+    /// Project a recovery path needs — never re-derived from token arithmetic.
+    struct OwedFinalDrain {
+        let operationID: Int
+        /// The engine epoch whose accepted prefix this drain belongs to.
+        let captureToken: Int
+        /// The stopped generation this drain completes under, or `nil` while Stop
+        /// is still waiting behind an in-flight helper fetch.
+        var stoppedToken: Int?
+        /// The Project that owned the capture when the stop was issued.
+        let originProjectID: UUID?
+    }
 
     /// True when the app was launched in direct-capture dev mode — via the env
     /// var `TRACEXY_DIRECT_CAPTURE=1` or the launch argument `--direct-capture`
@@ -118,7 +165,26 @@ final class MainContentCoordinator {
     /// Capacity gate for focus sets and pinned hosts.
     let focusGate: FocusPolicyGate
 
-    let workspaces: WorkspaceStore
+    /// Composition seam for per-Project storage: History database, managed
+    /// capture folder, live spool, and preferences suite.
+    let projectDataProvider: any ProjectDataProviding
+
+    /// The active Project's workspace tabs. This is the *actual* store instance a
+    /// Project owns: parking a Project keeps its selection, drafts, query results
+    /// and layout alive rather than rehydrating them from portable configuration.
+    var workspaces: WorkspaceStore
+
+    /// The runtime bucket the coordinator's observable state currently mirrors.
+    var activeRuntime: ProjectRuntimeState
+
+    /// The active Project's preferences suite. Every settings resolver call in the
+    /// coordinator, readiness, saved loader, export, and History paths reads this
+    /// rather than the shared domain.
+    var activeProjectDefaults: UserDefaults
+
+    /// The active Project's managed capture Library folder, or `nil` when it could
+    /// not be prepared.
+    var activeCapturesDirectory: URL?
 
     /// Local, configuration-only Project catalog. Projects own durable workspace
     /// view intent; capture bytes, current sessions, and terminal History remain
@@ -141,6 +207,53 @@ final class MainContentCoordinator {
     var isObservingProjectWorkspaces = false
     var projectHydrationTask: Task<Void, Never>?
     var projectWorkspaceAutosaveTask: Task<Void, Never>?
+    /// The Project a queued autosave was scheduled for. A debounce that survives
+    /// into another Project is discarded rather than writing B's workspaces into A.
+    var projectWorkspaceAutosaveOwner: UUID?
+
+    /// The one Project lifecycle path's state. `pending` forbids capture start and
+    /// further transitions; `failed` keeps the outgoing Project active with a retry.
+    var projectTransitionStatus: ProjectTransitionStatus = .idle
+    /// A Project change waiting on the native Stop-and-Switch confirmation.
+    var pendingProjectSwitchConfirmation: ProjectSwitchConfirmationRequest?
+    var projectTransitionTask: Task<Bool, Never>?
+
+    /// The validated-but-unpublished catalog change the running transition holds.
+    /// It names the destination Project before that Project is durable, which is
+    /// how a caller learns the identity of a Project it just asked to create.
+    var preparedProjectTransition: PreparedProjectCatalogTransition?
+
+    /// One runtime bucket per Project, keyed by Project id and bounded by
+    /// ``ProjectStore/maxProjects``. Buckets are removed only when their Project is
+    /// deleted, so no Project's capture is ever silently evicted.
+    var projectRuntimes: [UUID: ProjectRuntimeState] = [:]
+
+    /// The transition to retry after a bounded stop/drain failure.
+    var retryableProjectTransition: ProjectSwitchConfirmationRequest.Kind?
+
+    /// True once the launch runtime has been bound to the hydrated active Project.
+    var hasBoundInitialRuntime = false
+
+    /// The in-flight managed "Save Capture" copy. A Project transition waits on it
+    /// before swapping the spool it reads from.
+    ///
+    /// It is also the Save half of the source-use gate (``isCaptureSourceHeld``):
+    /// it is non-nil from the moment a Save is accepted until the last save queued
+    /// behind it has finished, which is exactly the window in which the source that
+    /// save reads must not be reset, replaced or trashed.
+    var pendingCaptureIOTask: Task<Void, Never>?
+    @ObservationIgnored var savedCaptureLoadOperation: SavedCaptureLoadOperation = .streaming
+    @ObservationIgnored var captureSaveOperation: CaptureSaveOperation = .copy
+
+    /// Monotonic identity of the newest managed capture-I/O request. The handle
+    /// above is cleared only by the request that still owns it, so an older save
+    /// finishing late can never hide a newer one queued behind it.
+    var captureIORequestID = 0
+
+    /// Bounded wait for the helper's final drain during a Project change.
+    /// Exceeding it is reported as a retryable failure — it never means "assume it
+    /// drained". Injectable so tests exercise the timeout without a 15-second wait.
+    var projectTransitionDrainTimeout: Duration = .seconds(15)
 
     /// The most recent capacity limit the user ran into, in their words.
     /// Cleared when they acknowledge it or when the next successful action
@@ -276,11 +389,13 @@ final class MainContentCoordinator {
 
     // MARK: Terminal history persistence
 
-    /// The injected terminal-history store, or `nil` when no persistent database
-    /// is composed (all unit tests, and any production launch where the factory
+    /// The *active Project's* terminal-history store, or `nil` when no persistent
+    /// database is composed (unit tests, or a production launch where the factory
     /// could not open one). It is written to exactly once per terminated live or
     /// opened saved capture; it is never on the live 0.8-second publication path.
-    let sessionStore: SessionStore?
+    /// Each Project owns its own database file, so History reads, writes, Clear and
+    /// retention in one Project never touch another's.
+    var sessionStore: SessionStore?
 
     /// True only for the explicit synthetic History launch path. Production
     /// composition always leaves this false and never sees the demo fixture.
@@ -360,8 +475,9 @@ final class MainContentCoordinator {
 
     // MARK: Focus Sets
 
-    /// Saved named filter collections (sidebar Focus mode). Persisted as JSON.
-    private(set) var focusSets: [FocusSet] = MainContentCoordinator.loadFocusSets()
+    /// Saved named filter collections (sidebar Focus mode). Persisted as JSON in
+    /// the active Project's own preferences suite.
+    var focusSets: [FocusSet] = []
 
     /// The focus set currently open in the editor window (`nil` = window closed).
     var editingFocusSet: FocusSet?
@@ -369,18 +485,18 @@ final class MainContentCoordinator {
     // MARK: Noise Control
 
     /// Hosts muted from the session list (sidebar Focus → Noise Control).
-    private(set) var mutedHosts: Set<String> = MainContentCoordinator.loadMutedHosts()
+    var mutedHosts: Set<String> = []
     /// Protocols muted from the session list.
-    private(set) var mutedProtocols: Set<ProtocolKind> = MainContentCoordinator.loadMutedProtocols()
+    var mutedProtocols: Set<ProtocolKind> = []
 
     // MARK: Source visibility
 
     /// Source rows the user removed from the Browse sidebar. This is presentation
     /// state only: captured sessions and packet evidence remain untouched and can
     /// still be found from Sessions. Each category can restore its hidden rows.
-    var hiddenSourceApps = SourceVisibilityPreferences.loadApps()
-    var hiddenSourceDomains = SourceVisibilityPreferences.loadDomains()
-    var hiddenSourceIPs = SourceVisibilityPreferences.loadIPs()
+    var hiddenSourceApps: Set<String> = []
+    var hiddenSourceDomains: Set<String> = []
+    var hiddenSourceIPs: Set<String> = []
 
     /// Session rows removed from the current capture's presentation. This is
     /// deliberately capture-scoped and reversible: packet evidence and the
@@ -389,9 +505,11 @@ final class MainContentCoordinator {
     /// Overview rollup, Flow Map, Sources, finding, or related-session card.
     var removedSessionIDs: Set<UUID> = []
 
-    /// Complete local raw-frame retention for save/export. The in-memory frame
-    /// window remains bounded independently for responsive UI.
-    let liveCaptureSpool: LiveCaptureSpool
+    /// The *active Project's* complete local raw-frame retention for save/export.
+    /// Every Project keeps its own spool actor while parked, so starting, clearing
+    /// or resetting a capture in one Project can never destroy another's evidence.
+    /// The in-memory frame window remains bounded independently for responsive UI.
+    var liveCaptureSpool: LiveCaptureSpool
     /// Serializes engine access so batches fold in arrival order even though each
     /// call hops onto the engine actor, and so a boundary reset is ordered ahead
     /// of the ingests that follow it.
@@ -443,6 +561,34 @@ final class MainContentCoordinator {
     /// At most one off-main query evaluation per workspace. Superseding Apply/live
     /// refresh and capture boundaries cancel the prior task before issuing a new request.
     var investigationQueryTasks: [UUID: Task<Void, Never>] = [:]
+
+    /// Remembers the active Project's inspector-dock choice across launches.
+    var layoutPreferences: WorkspaceLayoutPreferences
+
+    /// The owed final drain and its parked waiters. Written only through
+    /// ``beginFinalCaptureDrain(stoppedToken:captureToken:)`` and the completion
+    /// paths beside it, so every owed drain carries an operation identity a
+    /// completion can be matched against.
+    var owedFinalDrain: OwedFinalDrain?
+    var finalDrainWaiters: [UUID: FinalDrainWaiter] = [:]
+    /// Monotonic identity of the drain the current stop owes. Every genuinely new
+    /// stop mints a new one.
+    var finalDrainOperationID = 0
+    var lastFinalDrainCompletion: (operationID: Int, drained: Bool)?
+
+    /// The store/spool a caller injected at composition. They belong to whichever
+    /// Project hydration binds first, and are never handed to a second Project.
+    let injectedSessionStore: SessionStore?
+    let injectedLiveCaptureSpool: LiveCaptureSpool?
+
+    /// True while the Project boundary is settling — a transition is running, or a
+    /// stopped capture still owes its exact final drain. New capture I/O, Library
+    /// mutations, exports and History mutations fail closed here rather than being
+    /// started against a spool, store or Library reference that is about to be
+    /// swapped or is not yet at its final boundary.
+    var isProjectBoundaryBusy: Bool {
+        projectTransitionStatus.isPending || isFinalDrainPending
+    }
 
     /// Cumulative frames evicted from the local in-memory inspection window. This
     /// is a UI memory bound, never kernel/interface loss; sessions and the complete
@@ -622,16 +768,27 @@ final class MainContentCoordinator {
     /// the freshly resolved next-start settings while stopped. The readiness
     /// popover uses this seam so changing Settings mid-capture never rewrites the
     /// truth about the active source.
+    ///
+    /// The retained running configuration is consulted *only* while starting or
+    /// capturing. While stopped there is no active source to describe, so this
+    /// resolves the active Project's own current defaults — otherwise a Project
+    /// left behind mid-capture would keep describing its source in a Project that
+    /// is merely idle.
     var readinessCaptureConfiguration: CaptureConfiguration {
-        activeCaptureConfiguration
-            ?? CaptureSettingsResolver.configuration(interface: captureInterface)
+        if isCapturing || isStarting, let activeCaptureConfiguration {
+            return activeCaptureConfiguration
+        }
+        return CaptureSettingsResolver.configuration(
+            interface: captureInterface,
+            defaults: activeProjectDefaults
+        )
     }
 
     var readinessRetentionCapacity: Int {
         if isCapturing || isStarting {
             return retainedFrames.capacity
         }
-        return CaptureSettingsResolver.retainCapacity()
+        return CaptureSettingsResolver.retainCapacity(defaults: activeProjectDefaults)
     }
 
     // MARK: Aggregate rollups (status bar)
@@ -764,18 +921,6 @@ final class MainContentCoordinator {
         focusGate.canInsertFocusSet(into: focusSets)
     }
 
-    /// `~/Library/Application Support/<bundle id>/Captures`, created on demand.
-    static func capturesDirectory() -> URL? {
-        guard let base = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first else {
-            return nil
-        }
-        let directory = base
-            .appendingPathComponent(TracexyIdentity.current.appBundleIdentifier, isDirectory: true)
-            .appendingPathComponent("Captures", isDirectory: true)
-        try? FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
-        return directory
-    }
-
     /// A host is a domain name (not a bare IPv4/IPv6 literal).
     static func isDomainName(_ host: String) -> Bool {
         if host.contains(":") {
@@ -786,6 +931,15 @@ final class MainContentCoordinator {
             return false // IPv4 literal
         }
         return host.contains(".") && host.contains { $0.isLetter }
+    }
+
+    /// The active Project's managed capture Library folder, created on demand.
+    ///
+    /// The legacy-owner Project keeps the pre-Projects
+    /// `Application Support/<namespace>/Captures`; every other Project is rooted
+    /// under `Projects/<uuid>/Captures`. Nothing is copied, moved, or deleted.
+    func capturesDirectory() -> URL? {
+        activeCapturesDirectory
     }
 
     func setSessionExporting(_ isExporting: Bool) {
@@ -846,88 +1000,6 @@ final class MainContentCoordinator {
         refreshSelectedSessionEvidenceProjection()
     }
 
-    // MARK: Search
-
-    /// ⌘F: bring the user to the session search box and put the cursor in it.
-    ///
-    /// Routes to the Sessions surface if they are elsewhere, reveals the filter
-    /// bar, and switches the search on — the three states the box needs to be
-    /// usable — then bumps a focus token the existing field observes. It does
-    /// *not* touch the query text or any active filter (host/process/IP drill-down,
-    /// category chips, advanced rules), so an in-progress investigation is
-    /// preserved; ⌘F only reveals and focuses the box that is already there.
-    func beginSessionSearch() {
-        let ws = activeWorkspace
-        ws.sidebarSelection = .sessions
-        ws.isFilterBarVisible = true
-        ws.isSearchEnabled = true
-        ws.searchFocusRequest = UUID()
-    }
-
-    // MARK: Sidebar selection
-
-    /// Selects a top-level sidebar item, clearing any host/process/IP drill-down.
-    func selectSidebarItem(_ item: SidebarItem) {
-        let ws = activeWorkspace
-        ws.sidebarSelection = item
-        ws.hostFilter = nil
-        ws.processFilter = nil
-        ws.ipFilter = nil
-    }
-
-    /// Drills into a single host/domain (from the sidebar "Domains"/"Pinned" groups).
-    func selectHost(_ host: String) {
-        let ws = activeWorkspace
-        ws.sidebarSelection = .sessions
-        ws.processFilter = nil
-        ws.ipFilter = nil
-        ws.hostFilter = host
-    }
-
-    /// Drills into a single process (from the sidebar "Apps" group).
-    func selectProcess(_ process: String) {
-        let ws = activeWorkspace
-        ws.sidebarSelection = .sessions
-        ws.hostFilter = nil
-        ws.ipFilter = nil
-        ws.processFilter = process
-    }
-
-    /// Drills into a single IP address (a sub-IP under a domain).
-    func selectIP(_ ip: String) {
-        let ws = activeWorkspace
-        ws.sidebarSelection = .sessions
-        ws.hostFilter = nil
-        ws.processFilter = nil
-        ws.ipFilter = ip
-    }
-
-    // MARK: Pinned hosts (Favorites)
-
-    func isHostPinned(_ host: String) -> Bool {
-        pinnedHosts.contains(host)
-    }
-
-    /// Pins or unpins a host and persists the new set immediately.
-    func togglePinHost(_ host: String) {
-        guard !host.isEmpty, host != "—" else {
-            return
-        }
-        if let index = pinnedHosts.firstIndex(of: host) {
-            pinnedHosts.remove(at: index)
-        } else {
-            do {
-                try focusGate.validatePinningHost(host, into: pinnedHosts)
-            } catch {
-                policyNotice = error.localizedDescription
-                return
-            }
-            pinnedHosts.append(host)
-        }
-        policyNotice = nil
-        UserDefaults.standard.set(pinnedHosts, forKey: Self.pinnedHostsKey)
-    }
-
     /// Bottom evidence inspector. Hiding it by hand also cancels the automatic
     /// reveal — a panel the user dismissed must not reappear on the next
     /// selection.
@@ -986,7 +1058,16 @@ final class MainContentCoordinator {
     }
 
     /// Clears all captured sessions (status-bar "Clear").
+    ///
+    /// Refused while the Project boundary is settling: this resets the engine and
+    /// the live spool, which would destroy the evidence a stopped capture is still
+    /// draining, or the outgoing Project's evidence mid-transition. It is refused
+    /// for the same reason while an accepted Save or an in-flight session export
+    /// still owns that source.
     func clearSessions() {
+        guard !isProjectBoundaryBusy, !isCaptureSourceHeld else {
+            return
+        }
         cancelFollowStream(clearResult: true)
         cancelSavedCaptureOpen(clearPublishedEvidence: true)
         // Supersede any in-flight engine work so a late snapshot can't repopulate
@@ -1021,92 +1102,6 @@ final class MainContentCoordinator {
         }
     }
 
-    /// Inserts or updates a focus set (used by the editor sheet), then persists.
-    /// A save that would exceed the focus-set cap leaves the stored sets
-    /// untouched and reports why through ``policyNotice``.
-    func saveFocusSet(_ set: FocusSet) {
-        var normalizedSet = set
-        normalizedSet.rules = SessionFilterRule.normalized(
-            set.rules,
-            limit: policy.maxSessionFilterRules
-        )
-        do {
-            try focusGate.validateSavingFocusSet(normalizedSet, into: focusSets)
-        } catch {
-            policyNotice = error.localizedDescription
-            return
-        }
-        if let index = focusSets.firstIndex(where: { $0.id == normalizedSet.id }) {
-            focusSets[index] = normalizedSet
-        } else {
-            focusSets.append(normalizedSet)
-        }
-        policyNotice = nil
-        persistFocusSets()
-    }
-
-    /// Loads a focus set's rules into the active workspace's advanced filter.
-    func applyFocusSet(_ set: FocusSet) {
-        let ws = activeWorkspace
-        ws.sidebarSelection = .sessions
-        ws.hostFilter = nil
-        ws.processFilter = nil
-        ws.ipFilter = nil
-        // A saved set may hold more rows than this build allows (it was saved on
-        // a different build, or the cap changed). Clamp to capacity, and never
-        // leave the builder with zero rows.
-        ws.filterRules = SessionFilterRule.normalized(set.rules, limit: policy.maxSessionFilterRules)
-        ws.isFilterBarVisible = true
-        ws.isAdvancedFilterVisible = true
-    }
-
-    func deleteFocusSet(_ set: FocusSet) {
-        focusSets.removeAll { $0.id == set.id }
-        persistFocusSets()
-    }
-
-    /// A blank draft seeded from the active workspace's current active rules, so
-    /// "Add" captures whatever the user is already filtering by.
-    func draftFocusSet() -> FocusSet {
-        let active = activeWorkspace.activeFilterRules
-        return FocusSet(
-            name: "",
-            rules: active.isEmpty ? [SessionFilterRule()] : active
-        )
-    }
-
-    func isHostMuted(_ host: String) -> Bool {
-        mutedHosts.contains(host)
-    }
-
-    func isProtocolMuted(_ proto: ProtocolKind) -> Bool {
-        mutedProtocols.contains(proto)
-    }
-
-    func toggleMuteHost(_ host: String) {
-        if mutedHosts.contains(host) {
-            mutedHosts.remove(host)
-        } else {
-            mutedHosts.insert(host)
-        }
-        persistMutedNoise()
-    }
-
-    func toggleMuteProtocol(_ proto: ProtocolKind) {
-        if mutedProtocols.contains(proto) {
-            mutedProtocols.remove(proto)
-        } else {
-            mutedProtocols.insert(proto)
-        }
-        persistMutedNoise()
-    }
-
-    func clearNoiseControl() {
-        mutedHosts = []
-        mutedProtocols = []
-        persistMutedNoise()
-    }
-
     /// Toolbar Start/Stop. Starts a real libpcap capture (or surfaces why not).
     func toggleCapture() {
         if isCapturing {
@@ -1122,14 +1117,25 @@ final class MainContentCoordinator {
         guard !isStarting else {
             return
         }
+        // Fail closed while the Project boundary is unsettled: a frame must never
+        // be written for a provisional identity, and a capture must never begin
+        // inside a pending switch.
+        if let blocked = captureStartBlockedMessage {
+            captureError = blocked
+            return
+        }
         cancelFollowStream(clearResult: true)
         cancelSavedCaptureOpen(clearPublishedEvidence: true)
         // Read the current Capture-Settings preferences fresh at each start and map
         // them to a validated, bounded configuration (interface, snap length,
         // promiscuous mode, optional BPF). An invalid custom filter — or any
         // out-of-bounds value — surfaces here, before any capture backend is asked
-        // to start, rather than failing silently mid-capture.
-        let resolvedConfiguration = CaptureSettingsResolver.configuration(interface: captureInterface)
+        // to start, rather than failing silently mid-capture. Preferences come from
+        // the *active Project's* suite, never the shared domain.
+        let resolvedConfiguration = CaptureSettingsResolver.configuration(
+            interface: captureInterface,
+            defaults: activeProjectDefaults
+        )
         let configuration: CaptureConfiguration
         switch resolvedConfiguration.validated() {
         case let .success(valid):
@@ -1154,7 +1160,9 @@ final class MainContentCoordinator {
         // "Retain up to" preference, resetting it to a clean, zeroed window. This
         // bounds memory only — sessions accumulate independently (see
         // ``retainedFrameLimit``).
-        retainedFrames = RetainedFrameBuffer(capacity: CaptureSettingsResolver.retainCapacity())
+        retainedFrames = RetainedFrameBuffer(
+            capacity: CaptureSettingsResolver.retainCapacity(defaults: activeProjectDefaults)
+        )
         removedSessionIDs.removeAll()
         sessions = []
         // Clear stale connection + analysis publication at the start boundary
@@ -1210,6 +1218,11 @@ final class MainContentCoordinator {
     }
 
     func stopCapture() {
+        // An idle Project may hold a parked snapshot from another engine epoch.
+        // Helper maintenance or a repeated Stop must not republish that engine.
+        guard isCapturing || isStarting else {
+            return
+        }
         pollTimer?.invalidate()
         pollTimer = nil
         // A fetch destructively drains the helper buffer. Let the one outstanding
@@ -1219,23 +1232,84 @@ final class MainContentCoordinator {
         if !Self.forceDirectCapture, helperFetchInFlight {
             helperStopRequested = true
             isStarting = false
+            // Stop is now owed a final drain even though `performStopCapture` has
+            // not run yet, so a Project transition must wait for it rather than
+            // seeing an idle pipeline and swapping the spool mid-stop. The stopped
+            // generation is not minted yet; `performStopCapture` resolves it onto
+            // this same owed drain, under the epoch recorded here.
+            beginFinalCaptureDrain(stoppedToken: nil, captureToken: startGeneration)
             return
         }
         performStopCapture()
     }
 
+    /// The app-side half of an explicit destructive helper reset (Settings → Helper
+    /// → Force Reset). It runs *before* the privileged removal, and the XPC
+    /// connection this capture depends on is destroyed immediately afterwards, so no
+    /// reply the running or stopping capture is still waiting for can ever arrive.
+    ///
+    /// Stopping is not enough on its own. ``stopCapture()`` returns at its idle
+    /// guard when a previous stop is already settling, and its in-flight-fetch
+    /// branch defers the stop to a reply this reset makes unreachable — either way
+    /// the owed final drain would stay owed forever, and with it Start, Clear,
+    /// opening a saved capture and every Project change would stay refused for the
+    /// rest of the app session.
+    ///
+    /// So the obsolete operation is terminated as **failed**, and the accepted
+    /// prefix that did fold is finalized under the exact capture epoch and stopped
+    /// generation the owed operation recorded — published as this capture's stopped
+    /// snapshot and written to History as `incomplete`. Nothing here claims the
+    /// missing tail arrived, discards the recoverable prefix or its spool bytes,
+    /// changes Projects, or touches the helper.
+    func prepareForDestructiveHelperReset() {
+        // Retire the in-flight work of the connection this reset destroys, so a late
+        // reply from it can never be folded into whatever comes next.
+        helperFetchGeneration &+= 1
+        helperFetchInFlight = false
+        helperStopRequested = false
+
+        let owed = owedFinalDrain
+        // Normal idle helper maintenance: nothing is running and nothing is owed, so
+        // this must not stop, republish or write anything.
+        guard isCapturing || isStarting || owed != nil else {
+            return
+        }
+        pollTimer?.invalidate()
+        pollTimer = nil
+        // A drain owed by a Project that is no longer active is retired by identity
+        // only: its prefix, spool and History belong to that Project, and finalizing
+        // it here would publish one Project's capture inside another.
+        if let owed, owed.originProjectID != activeRuntime.projectID {
+            abortOwedFinalCaptureDrain()
+            return
+        }
+
+        if let owed, let stoppedToken = owed.stoppedToken, !isCapturing, !isStarting {
+            // Retire the old reply and any queued publication synchronously, before
+            // awaiting the accepted prefix. Keep the same owed operation and exact
+            // engine epoch, but only recovery may complete its new publication token.
+            startGeneration &+= 1
+            let recoveryToken = startGeneration
+            owedFinalDrain?.stoppedToken = recoveryToken
+            rebaseFrozenHistoryLifetime(from: stoppedToken, to: recoveryToken)
+            publishStoppedSnapshotAfterCurrentIngest(
+                captureToken: owed.captureToken,
+                stoppedToken: recoveryToken,
+                finalDrainConfirmed: false
+            )
+        } else {
+            // A capture still running, or a stop parked behind an in-flight fetch
+            // that never minted its stopped generation: mint that boundary here
+            // instead of asking the helper for a reply it can no longer send.
+            performStopCapture(canAwaitHelperReply: false)
+        }
+        if !Self.forceDirectCapture {
+            captureError = "Capture stopped because the capture helper was reset. Only the packets Tracexy had "
+                + "already accepted are available — the last batch could not be confirmed."
+        }
+    }
+
     // MARK: Private
-
-    private static let pinnedHostsKey = TracexyIdentity.current.defaultsKey("pinnedHosts")
-
-    // MARK: Focus / Noise persistence
-
-    private static let focusSetsKey = TracexyIdentity.current.defaultsKey("focusSets")
-    private static let mutedHostsKey = TracexyIdentity.current.defaultsKey("noise.mutedHosts")
-    private static let mutedProtocolsKey = TracexyIdentity.current.defaultsKey("noise.mutedProtocols")
-
-    /// Remembers the user's inspector-dock choice across launches.
-    private let layoutPreferences: WorkspaceLayoutPreferences
 
     private let live = try? LiveCapture()
     /// Off-main incremental session engine: decodes and groups each captured frame
@@ -1259,28 +1333,6 @@ final class MainContentCoordinator {
     /// newer drain request replaces them.
     private var helperFetchGeneration = 0
 
-    private static func loadPinnedHosts() -> [String] {
-        UserDefaults.standard.stringArray(forKey: pinnedHostsKey) ?? []
-    }
-
-    private static func loadFocusSets() -> [FocusSet] {
-        guard let data = UserDefaults.standard.data(forKey: focusSetsKey),
-              let sets = try? JSONDecoder().decode([FocusSet].self, from: data) else
-        {
-            return []
-        }
-        return sets
-    }
-
-    private static func loadMutedHosts() -> Set<String> {
-        Set(UserDefaults.standard.stringArray(forKey: mutedHostsKey) ?? [])
-    }
-
-    private static func loadMutedProtocols() -> Set<ProtocolKind> {
-        let raw = UserDefaults.standard.stringArray(forKey: mutedProtocolsKey) ?? []
-        return Set(raw.compactMap(ProtocolKind.init(rawValue:)))
-    }
-
     /// The IP portion of an "ip:port" endpoint (handles IPv6's inner colons).
     private static func ipPart(_ endpoint: String) -> String? {
         guard !endpoint.isEmpty, endpoint != "—" else {
@@ -1293,16 +1345,29 @@ final class MainContentCoordinator {
         return comps.dropLast().joined(separator: ":")
     }
 
-    private func performStopCapture() {
+    /// Settle the current capture at its exact stopped boundary.
+    ///
+    /// `canAwaitHelperReply` is `false` only on the explicit destructive-reset path,
+    /// where the helper connection is about to be destroyed: asking it for a final
+    /// batch there would park this capture on a reply that can never arrive. The
+    /// stop then finalizes locally, exactly as a helper that could not be reached
+    /// at all already does — reporting the accepted prefix as unconfirmed rather
+    /// than claiming the tail drained.
+    private func performStopCapture(canAwaitHelperReply: Bool = true) {
         helperStopRequested = false
         let captureToken = startGeneration
         // Invalidate any in-flight start attempt so its watchdog/reply is ignored.
         startGeneration &+= 1
         let stoppedToken = startGeneration
+        // From here until the final batch has folded and published, a Project
+        // transition must wait rather than swap the spool/store out from under it.
+        // A Stop parked behind an in-flight helper fetch already owes this drain;
+        // this resolves that same operation onto the generation it completes under.
+        beginFinalCaptureDrain(stoppedToken: stoppedToken, captureToken: captureToken)
         helperFetchGeneration &+= 1
         helperFetchInFlight = false
         var awaitsHelperStopReply = false
-        if !Self.forceDirectCapture, let proxy = try? helper.proxy() {
+        if canAwaitHelperReply, !Self.forceDirectCapture, let proxy = try? helper.proxy() {
             awaitsHelperStopReply = true
             proxy.stopCapture { [weak self] batch in
                 // The helper worker has now finished its read loop, sampled final
@@ -1324,7 +1389,12 @@ final class MainContentCoordinator {
                         let detail = "The capture helper returned \(rejectedFrameCount) frame(s) with invalid metadata."
                         self.helper.recordRuntimeConnectionFailure(detail)
                         self.captureError = detail
-                        self.queuePendingSavedCaptureOpenAfterCurrentIngest()
+                        self.cancelSavedCaptureOpen(clearPublishedEvidence: false)
+                        self.publishStoppedSnapshotAfterCurrentIngest(
+                            captureToken: captureToken,
+                            stoppedToken: stoppedToken,
+                            finalDrainConfirmed: false
+                        )
                         return
                     }
                     self.helperBufferDropCount = batch.bufferDroppedCount
@@ -1363,7 +1433,14 @@ final class MainContentCoordinator {
         isStarting = false
         captureStartedAt = nil
         if !awaitsHelperStopReply {
-            publishStoppedSnapshotAfterCurrentIngest(captureToken: captureToken, stoppedToken: stoppedToken)
+            if !Self.forceDirectCapture {
+                captureError = "The helper’s final capture batch could not be confirmed. Only the recoverable prefix is available."
+            }
+            publishStoppedSnapshotAfterCurrentIngest(
+                captureToken: captureToken,
+                stoppedToken: stoppedToken,
+                finalDrainConfirmed: Self.forceDirectCapture
+            )
         }
     }
 
@@ -1429,24 +1506,12 @@ final class MainContentCoordinator {
         }
         activityIndex = index
     }
-
-    private func persistFocusSets() {
-        guard let data = try? JSONEncoder().encode(focusSets) else {
-            return
-        }
-        UserDefaults.standard.set(data, forKey: Self.focusSetsKey)
-    }
-
-    private func persistMutedNoise() {
-        UserDefaults.standard.set(Array(mutedHosts), forKey: Self.mutedHostsKey)
-        UserDefaults.standard.set(mutedProtocols.map(\.rawValue), forKey: Self.mutedProtocolsKey)
-    }
 }
 
 // MARK: - Live capture pipeline
 
-private extension MainContentCoordinator {
-    func startViaHelper(token: Int) {
+extension MainContentCoordinator {
+    private func startViaHelper(token: Int) {
         guard let configuration = activeCaptureConfiguration else {
             handleCaptureError("Capture configuration was unavailable.")
             return
@@ -1637,7 +1702,9 @@ private extension MainContentCoordinator {
         beginLiveHistoryLifetime(captureGeneration: startGeneration)
     }
 
-    private func ingest(_ frames: [CapturedFrame], linkType: UInt32) {
+    /// Shared receipt path for backend batches and deterministic synthetic lifecycle
+    /// tests. Callers establish the active capture generation before delivering frames.
+    func ingest(_ frames: [CapturedFrame], linkType: UInt32) {
         currentLinkType = linkType
         appendRetainedFrames(frames)
         pendingChartBytes += frames.reduce(0) { $0 + $1.originalLength }
@@ -1735,6 +1802,7 @@ private extension MainContentCoordinator {
             await self.sessionEngine.ingest(
                 frames, linkType: linkType, epoch: captureToken, locators: locators, loss: loss
             )
+            var publication: Task<Void, Never>?
             if self.startGeneration == stoppedToken,
                !self.isCapturing,
                let snapshot = await self.sessionEngine.investigationSnapshot(epoch: captureToken)
@@ -1743,13 +1811,23 @@ private extension MainContentCoordinator {
                 let completeness: HistoryCompleteness = self.currentCaptureLoss == .lossReported || spoolIncomplete
                     ? .incomplete
                     : .complete
-                self.publishLiveDetailed(
+                publication = self.publishLiveDetailed(
                     snapshot,
                     expectedGeneration: stoppedToken,
                     isCapturing: false,
                     terminalHistoryCompleteness: completeness
                 )
             }
+            // Publication hops one runloop turn. The drain is complete only once
+            // that exact last snapshot has actually been adopted and its terminal
+            // History write enqueued — not merely scheduled.
+            await publication?.value
+            guard self.startGeneration == stoppedToken else {
+                return
+            }
+            // The exact end of this capture's final fold and publication. A Project
+            // transition parked behind it resumes here — never on a timer.
+            self.completeFinalCaptureDrain(stoppedToken: stoppedToken)
             self.resumePendingSavedCaptureOpenAfterLiveDrain()
         }
     }
@@ -1760,26 +1838,45 @@ private extension MainContentCoordinator {
     /// so ordinary coalesced live publications intentionally fail their old-token
     /// guard; this final hop uses the old engine epoch for the snapshot and the
     /// new stopped token for publication, matching the helper final-drain path.
-    private func publishStoppedSnapshotAfterCurrentIngest(captureToken: Int, stoppedToken: Int) {
+    private func publishStoppedSnapshotAfterCurrentIngest(
+        captureToken: Int,
+        stoppedToken: Int,
+        finalDrainConfirmed: Bool
+    ) {
         let previous = ingestChain
         ingestChain = Task { @MainActor in
             await previous?.value
+            var publication: Task<Void, Never>?
             if self.startGeneration == stoppedToken,
                !self.isCapturing,
                let snapshot = await self.sessionEngine.investigationSnapshot(epoch: captureToken)
             {
                 let spoolIncomplete = await self.liveCaptureSpool.incompletenessReason() != nil
-                let completeness: HistoryCompleteness = self.currentCaptureLoss == .lossReported || spoolIncomplete
+                let completeness: HistoryCompleteness = !finalDrainConfirmed || self
+                    .currentCaptureLoss == .lossReported || spoolIncomplete
                     ? .incomplete
                     : .complete
-                self.publishLiveDetailed(
+                publication = self.publishLiveDetailed(
                     snapshot,
                     expectedGeneration: stoppedToken,
                     isCapturing: false,
                     terminalHistoryCompleteness: completeness
                 )
             }
-            self.resumePendingSavedCaptureOpenAfterLiveDrain()
+            // See `ingestFinalHelperBatch`: the signal must mean the publication
+            // and terminal History enqueue happened, not that they were scheduled.
+            await publication?.value
+            guard self.startGeneration == stoppedToken else {
+                return
+            }
+            // The exact end of this capture's final fold and publication. A Project
+            // transition parked behind it resumes here — never on a timer.
+            self.completeFinalCaptureDrain(stoppedToken: stoppedToken, succeeded: finalDrainConfirmed)
+            if finalDrainConfirmed {
+                self.resumePendingSavedCaptureOpenAfterLiveDrain()
+            } else {
+                self.cancelSavedCaptureOpen(clearPublishedEvidence: false)
+            }
         }
     }
 
@@ -1794,9 +1891,13 @@ private extension MainContentCoordinator {
     /// Clears the engine and adopts a new capture generation. Enqueued on the
     /// ingest chain so it is ordered ahead of subsequent ingests; older in-flight
     /// work carries the previous token and is dropped by the engine's epoch guard.
-    func resetSessionEngine(token: Int) {
+    private func resetSessionEngine(token: Int) {
         let engine = sessionEngine
         let spool = liveCaptureSpool
+        // The runtime this reset belongs to, captured before the first `await`. A
+        // queued reset can outlive a Project change, and its spool failure describes
+        // the Project that owns that spool — never the one now on screen.
+        let origin = activeRuntime
         let previous = ingestChain
         ingestChain = Task { @MainActor in
             await previous?.value
@@ -1804,7 +1905,14 @@ private extension MainContentCoordinator {
             do {
                 try await spool.reset(epoch: token)
             } catch {
-                self.captureError = "Capture spool unavailable — \(error.localizedDescription)"
+                let message = "Capture spool unavailable — \(error.localizedDescription)"
+                if self.activeRuntime !== origin {
+                    // Already parked: report it into its own Project's bucket so the
+                    // failure is still there when that Project comes back.
+                    origin.captureError = message
+                } else if self.startGeneration == token {
+                    self.captureError = message
+                }
             }
         }
     }
@@ -1820,6 +1928,11 @@ private extension MainContentCoordinator {
         // Retire this attempt so a late reply/watchdog can't flip state back.
         startGeneration &+= 1
         captureStartedAt = nil
+        // This capture is definitively over and no final batch is still owed, so a
+        // Project transition parked behind the drain may proceed. The failed
+        // attempt never reached a stopped-generation boundary, so the owed drain is
+        // aborted by identity rather than matched against a token it never minted.
+        abortOwedFinalCaptureDrain()
     }
 
     private func groupCounts(_ key: (SessionSummary) -> String) -> [(name: String, count: Int)] {

--- a/Tracexy/Views/Common/CaptureInterfaceToolbarPicker.swift
+++ b/Tracexy/Views/Common/CaptureInterfaceToolbarPicker.swift
@@ -1,0 +1,123 @@
+import AppKit
+import SwiftUI
+
+// MARK: - CaptureInterfaceToolbarHost
+
+/// Only source-label density follows the window width. The same native menu,
+/// selection, tooltip, and accessibility value survive either presentation.
+final class CaptureInterfaceToolbarHost: NSHostingView<CaptureInterfaceToolbarPicker> {
+    // MARK: Lifecycle
+
+    convenience init(coordinator: MainContentCoordinator) {
+        self.init(rootView: CaptureInterfaceToolbarPicker(coordinator: coordinator))
+    }
+
+    required init(rootView: CaptureInterfaceToolbarPicker) {
+        super.init(rootView: rootView)
+        // NSToolbar measures custom views through constraints. Keep both bounds
+        // current as SwiftUI changes between icon-only and labelled content.
+        sizingOptions = [.minSize, .intrinsicContentSize, .maxSize]
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: Internal
+
+    override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+        NotificationCenter.default.removeObserver(self, name: NSWindow.didResizeNotification, object: nil)
+        guard let window else {
+            return
+        }
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(updateDensity),
+            name: NSWindow.didResizeNotification,
+            object: window
+        )
+        updateDensity()
+    }
+
+    // MARK: Private
+
+    @objc
+    private func updateDensity() {
+        guard let window else {
+            return
+        }
+        let isCompact = window.frame.width < Theme.Metrics.toolbarCompactWindowWidth
+        guard rootView.isCompact != isCompact else {
+            return
+        }
+        rootView.isCompact = isCompact
+        invalidateIntrinsicContentSize()
+    }
+}
+
+// MARK: - CaptureInterfaceToolbarPicker
+
+struct CaptureInterfaceToolbarPicker: View {
+    // MARK: Internal
+
+    @Bindable var coordinator: MainContentCoordinator
+
+    var isCompact = false
+
+    var body: some View {
+        Menu {
+            Picker(
+                selection: Binding(
+                    get: { coordinator.captureInterface },
+                    set: { coordinator.captureInterface = $0 }
+                )
+            ) {
+                ForEach(interfaceGroups) { group in
+                    Section(group.category.title) {
+                        ForEach(group.interfaces) { iface in
+                            Text(iface.menuLabel).tag(iface.id)
+                        }
+                    }
+                }
+            } label: {
+                EmptyView()
+            }
+            .pickerStyle(.inline)
+        } label: {
+            HStack(spacing: Theme.Metrics.controlSpacing) {
+                Image(systemName: currentInterface?.symbol ?? "network")
+                if !isCompact {
+                    Text(currentInterface?.displayName ?? coordinator.captureInterface)
+                        .lineLimit(1)
+                        .truncationMode(.tail)
+                        .frame(maxWidth: Theme.Metrics.toolbarInterfaceLabelMaximumWidth)
+                }
+            }
+        }
+        .menuStyle(.button)
+        .help("Capture interface: \(fullInterfaceLabel)")
+        .accessibilityLabel("Capture interface")
+        .accessibilityValue(fullInterfaceLabel)
+        .fixedSize()
+        .onAppear {
+            interfaceGroups = NetworkInterfaces.grouped()
+            if currentInterface == nil, let first = interfaceGroups.flatMap(\.interfaces).first {
+                coordinator.captureInterface = first.id
+            }
+        }
+    }
+
+    // MARK: Private
+
+    @State private var interfaceGroups: [InterfaceGroup] = []
+
+    private var currentInterface: NetworkInterface? {
+        interfaceGroups.flatMap(\.interfaces).first { $0.id == coordinator.captureInterface }
+    }
+
+    private var fullInterfaceLabel: String {
+        currentInterface?.menuLabel ?? coordinator.captureInterface
+    }
+}

--- a/Tracexy/Views/Common/NativeWorkspaceWindowChrome.swift
+++ b/Tracexy/Views/Common/NativeWorkspaceWindowChrome.swift
@@ -31,10 +31,10 @@ enum NativeWorkspaceWindowChrome {
         window.toolbarStyle = .unified
         window.titlebarSeparatorStyle = .none
         window.autorecalculatesKeyViewLoop = true
-        // The capture-interface picker is the leading workspace context. Keep a
+        // The Project selector is the leading workspace context. Keep a
         // stable semantic window title for the Window menu and accessibility,
         // but never let SwiftUI promote a surface title or product tagline into
-        // the toolbar and push that picker away from its native position.
+        // the toolbar and push that selector away from its native position.
         window.title = TracexyIdentity.current.displayName
         window.titleVisibility = .hidden
 
@@ -88,6 +88,9 @@ final class NativeWorkspaceToolbar: NSObject, NSToolbarDelegate {
     )
     static let interfacePickerIdentifier = NSToolbarItem.Identifier(
         "\(TracexyIdentity.current.logSubsystem).toolbar.interfacePicker"
+    )
+    static let projectSelectorIdentifier = NSToolbarItem.Identifier(
+        "\(TracexyIdentity.current.logSubsystem).toolbar.projectSelector"
     )
     static let captureStatusIdentifier = NSToolbarItem.Identifier(
         "\(TracexyIdentity.current.logSubsystem).toolbar.captureStatus"
@@ -148,19 +151,20 @@ final class NativeWorkspaceToolbar: NSObject, NSToolbarDelegate {
     )
         -> [NSToolbarItem.Identifier]
     {
-        // The bordered sidebar toggle sits behind a leading flexible space with the
-        // tracking separator immediately after it, so the interface picker returns
-        // to its native leading workspace slot. Capture status is centred; every
-        // capture/inspector commands trail in one coherent native group, with
-        // the native export menu immediately beside it.
+        // Project identity stands alone after the sidebar divider. Capture status
+        // is centred; source selection and Start/Stop form the trailing capture
+        // family. A native space separates capture from export/inspection.
         [
             .flexibleSpace,
             Self.sidebarToggleIdentifier,
             Self.sidebarTrackingSeparatorIdentifier,
-            Self.interfacePickerIdentifier,
+            Self.projectSelectorIdentifier,
             .flexibleSpace,
             Self.captureStatusIdentifier,
             .flexibleSpace,
+            Self.interfacePickerIdentifier,
+            Self.captureActionIdentifier,
+            .space,
             Self.sessionExportIdentifier,
             Self.actionsIdentifier,
         ]
@@ -183,31 +187,44 @@ final class NativeWorkspaceToolbar: NSObject, NSToolbarDelegate {
     {
         switch itemIdentifier {
         case Self.sidebarToggleIdentifier:
-            makeSidebarToggleItem()
+            return makeSidebarToggleItem()
         case Self.sidebarTrackingSeparatorIdentifier:
-            splitViewController.map {
+            return splitViewController.map {
                 NSTrackingSeparatorToolbarItem(
                     identifier: Self.sidebarTrackingSeparatorIdentifier,
                     splitView: $0.splitView,
                     dividerIndex: 0
                 )
             }
-        case Self.interfacePickerIdentifier:
-            hostingItem(
+        case Self.projectSelectorIdentifier:
+            let item = hostingItem(
                 identifier: itemIdentifier,
-                rootView: AnyView(CaptureInterfaceToolbarPicker(coordinator: coordinator))
+                rootView: AnyView(ProjectToolbarSelectorView(coordinator: coordinator))
             )
+            item.label = String(localized: "Project")
+            item.paletteLabel = item.label
+            item.visibilityPriority = .high
+            return item
+        case Self.interfacePickerIdentifier:
+            let item = NSToolbarItem(itemIdentifier: itemIdentifier)
+            item.label = String(localized: "Capture Interface")
+            item.paletteLabel = item.label
+            item.view = CaptureInterfaceToolbarHost(coordinator: coordinator)
+            item.visibilityPriority = .high
+            return item
+        case Self.captureActionIdentifier:
+            return makeCaptureItem()
         case Self.captureStatusIdentifier:
-            hostingItem(
+            return hostingItem(
                 identifier: itemIdentifier,
                 rootView: AnyView(CaptureStatusView(coordinator: coordinator))
             )
         case Self.sessionExportIdentifier:
-            makeSessionExportItem()
+            return makeSessionExportItem()
         case Self.actionsIdentifier:
-            makeActionGroup()
+            return makeActionGroup()
         default:
-            nil
+            return nil
         }
     }
 
@@ -253,6 +270,7 @@ final class NativeWorkspaceToolbar: NSObject, NSToolbarDelegate {
             ? String(localized: "Stop capture")
             : String(localized: "Start capture")
         captureToggleItem = item
+        item.visibilityPriority = .high
         return item
     }
 
@@ -291,11 +309,10 @@ final class NativeWorkspaceToolbar: NSObject, NSToolbarDelegate {
         return menu
     }
 
-    /// Capture and the two inspector commands share one native Liquid Glass
-    /// family. Export remains the adjacent native menu toolbar item because
+    /// The two inspector commands share one native Liquid Glass family.
+    /// Export remains the adjacent native menu toolbar item because
     /// AppKit suppresses an `NSMenuToolbarItem` when nested inside a group.
     private func makeActionGroup() -> NSToolbarItemGroup {
-        let captureItem = makeCaptureItem()
         let bottomInspectorItem = imageItem(
             identifier: NSToolbarItem.Identifier(
                 "\(Self.actionsIdentifier.rawValue).bottomInspector"
@@ -317,10 +334,9 @@ final class NativeWorkspaceToolbar: NSObject, NSToolbarDelegate {
         contextDockItem.toolTip = String(localized: "Show or hide the inspector (Details · AI Assistant).")
 
         let group = NSToolbarItemGroup(itemIdentifier: Self.actionsIdentifier)
-        group.label = String(localized: "Workspace Actions")
+        group.label = String(localized: "Inspectors")
         group.paletteLabel = group.label
         group.subitems = [
-            captureItem,
             bottomInspectorItem,
             contextDockItem,
         ]
@@ -418,72 +434,6 @@ final class NativeWorkspaceToolbar: NSObject, NSToolbarDelegate {
         // requested state before collapse KVO fires, so that KVO callback correctly
         // coalesces the matching change instead of writing the binding a second time.
         splitViewController.onSidebarVisibilityChanged?(isPresented)
-    }
-}
-
-// MARK: - CaptureInterfaceToolbarPicker
-
-/// The capture-interface dropdown, grouped by family (Wi-Fi, Ethernet, Thunderbolt,
-/// …) with macOS's friendly names and a checkmark on the active one. Hosted in a
-/// native toolbar item so it lives in the title area beside the sidebar toggle.
-private struct CaptureInterfaceToolbarPicker: View {
-    // MARK: Internal
-
-    @Bindable var coordinator: MainContentCoordinator
-
-    var body: some View {
-        Menu {
-            Picker(
-                selection: Binding(
-                    get: { coordinator.captureInterface },
-                    set: { coordinator.captureInterface = $0 }
-                )
-            ) {
-                ForEach(interfaceGroups) { group in
-                    Section(group.category.title) {
-                        ForEach(group.interfaces) { iface in
-                            Text(iface.menuLabel).tag(iface.id)
-                        }
-                    }
-                }
-            } label: {
-                EmptyView()
-            }
-            .pickerStyle(.inline)
-        } label: {
-            HStack(spacing: 5) {
-                Image(systemName: currentInterfaceSymbol)
-                Text(currentInterfaceLabel).lineLimit(1).truncationMode(.tail)
-            }
-            .frame(width: 188, alignment: .leading)
-        }
-        .menuStyle(.button)
-        .help("Capture interface")
-        .fixedSize()
-        .onAppear {
-            interfaceGroups = NetworkInterfaces.grouped()
-            // Make sure a real interface is selected by default.
-            if currentInterface == nil, let first = interfaceGroups.flatMap(\.interfaces).first {
-                coordinator.captureInterface = first.id
-            }
-        }
-    }
-
-    // MARK: Private
-
-    @State private var interfaceGroups: [InterfaceGroup] = []
-
-    private var currentInterface: NetworkInterface? {
-        interfaceGroups.flatMap(\.interfaces).first { $0.id == coordinator.captureInterface }
-    }
-
-    private var currentInterfaceSymbol: String {
-        currentInterface?.symbol ?? "network"
-    }
-
-    /// Friendly label for the toolbar button, e.g. "Wi-Fi (en0)".
-    private var currentInterfaceLabel: String {
-        currentInterface?.menuLabel ?? coordinator.captureInterface
     }
 }
 

--- a/Tracexy/Views/Common/NativeWorkspaceWindowChrome.swift
+++ b/Tracexy/Views/Common/NativeWorkspaceWindowChrome.swift
@@ -98,6 +98,9 @@ final class NativeWorkspaceToolbar: NSObject, NSToolbarDelegate {
     static let captureActionIdentifier = NSToolbarItem.Identifier(
         "\(TracexyIdentity.current.logSubsystem).toolbar.captureAction"
     )
+    static let captureSeparatorIdentifier = NSToolbarItem.Identifier(
+        "\(TracexyIdentity.current.logSubsystem).toolbar.captureSeparator"
+    )
     static let sessionExportIdentifier = NSToolbarItem.Identifier(
         "\(TracexyIdentity.current.logSubsystem).toolbar.sessionExport"
     )
@@ -163,6 +166,7 @@ final class NativeWorkspaceToolbar: NSObject, NSToolbarDelegate {
             Self.captureStatusIdentifier,
             .flexibleSpace,
             Self.interfacePickerIdentifier,
+            Self.captureSeparatorIdentifier,
             Self.captureActionIdentifier,
             .space,
             Self.sessionExportIdentifier,
@@ -214,6 +218,8 @@ final class NativeWorkspaceToolbar: NSObject, NSToolbarDelegate {
             return item
         case Self.captureActionIdentifier:
             return makeCaptureItem()
+        case Self.captureSeparatorIdentifier:
+            return makeCaptureSeparatorItem()
         case Self.captureStatusIdentifier:
             return hostingItem(
                 identifier: itemIdentifier,
@@ -255,8 +261,25 @@ final class NativeWorkspaceToolbar: NSObject, NSToolbarDelegate {
         return item
     }
 
-    /// Capture stays independent from export/inspection, preserving a clear
-    /// primary Start/Stop action without adding divider chrome to its border.
+    /// A native, noninteractive hairline distinguishes source configuration from
+    /// the adjacent Start/Stop action without adding another control or label.
+    private func makeCaptureSeparatorItem() -> NSToolbarItem {
+        let separator = NSBox()
+        separator.boxType = .separator
+        separator.translatesAutoresizingMaskIntoConstraints = false
+        separator.setAccessibilityElement(false)
+        NSLayoutConstraint.activate([
+            separator.widthAnchor.constraint(equalToConstant: Theme.Metrics.toolbarSeparatorWidth),
+            separator.heightAnchor.constraint(equalToConstant: Theme.Metrics.toolbarSeparatorHeight),
+        ])
+        let item = NSToolbarItem(itemIdentifier: Self.captureSeparatorIdentifier)
+        item.view = separator
+        item.isBordered = false
+        item.visibilityPriority = .high
+        return item
+    }
+
+    /// Capture stays independent from export/inspection.
     private func makeCaptureItem() -> NSToolbarItem {
         let item = imageItem(
             identifier: Self.captureActionIdentifier,
@@ -286,7 +309,7 @@ final class NativeWorkspaceToolbar: NSObject, NSToolbarDelegate {
             systemSymbolName: "square.and.arrow.up",
             accessibilityDescription: label
         )
-        item.isBordered = false
+        item.isBordered = true
         item.showsIndicator = true
         item.menu = sessionExportMenu()
         item.isEnabled = coordinator.canExportSelectedSession

--- a/Tracexy/Views/Main/RootView.swift
+++ b/Tracexy/Views/Main/RootView.swift
@@ -58,6 +58,42 @@ struct RootView: View {
         .sheet(isPresented: $showHelperInstall) {
             HelperInstallPromptView(coordinator: coordinator)
         }
+        .sheet(item: Binding(
+            get: {
+                coordinator.isProjectManagerPresented ? nil : coordinator.projectNameEditorContext
+            },
+            set: { coordinator.projectNameEditorContext = $0 }
+        )) { context in
+            ProjectNameEditorSheet(context: context, coordinator: coordinator)
+        }
+        .sheet(isPresented: $coordinator.isProjectManagerPresented) {
+            ProjectManagerSheet(coordinator: coordinator)
+        }
+        .sheet(isPresented: $coordinator.isProjectRecoveryPresented) {
+            ProjectRecoverySheet(coordinator: coordinator)
+        }
+        .alert(
+            "Project Operation Failed",
+            isPresented: Binding(
+                get: {
+                    coordinator.lastProjectOperationError != nil
+                        || coordinator.projectTransferErrorMessage != nil
+                },
+                set: {
+                    if !$0 {
+                        coordinator.lastProjectOperationError = nil
+                        coordinator.projectTransferErrorMessage = nil
+                    }
+                }
+            )
+        ) {
+            Button("OK", role: .cancel) {
+                coordinator.lastProjectOperationError = nil
+                coordinator.projectTransferErrorMessage = nil
+            }
+        } message: {
+            Text(coordinator.projectOperationErrorMessage ?? "The Project operation could not be completed.")
+        }
         // A capacity limit is worth one sentence and a dismiss, not a banner
         // that lingers over the traffic the user came here to read.
         .alert(
@@ -112,6 +148,8 @@ struct RootView: View {
     /// setting is the single source of truth for auto-start in both development
     /// and normal launches.
     private func launchSetup() async {
+        await coordinator.hydrateProjectsOnLaunch()
+
         if coordinator.isHistoryDemoMode {
             await coordinator.prepareHistoryDemo()
             return

--- a/Tracexy/Views/Main/RootView.swift
+++ b/Tracexy/Views/Main/RootView.swift
@@ -24,27 +24,37 @@ struct RootView: View {
     @Bindable var coordinator: MainContentCoordinator
 
     var body: some View {
-        NativeWorkspaceSplitView(
-            isSidebarPresented: $isSidebarPresented,
-            isInspectorPresented: contextDockVisibility,
-            autosaveName: Self.workspaceSplitAutosaveName,
-            sidebarMinimumWidth: Theme.Metrics.sidebarMinWidth,
-            sidebarIdealWidth: Theme.Metrics.sidebarIdealWidth,
-            sidebarMaximumWidth: Theme.Metrics.sidebarMaxWidth,
-            workspaceMinimumWidth: Theme.Metrics.sessionTableMinWidth,
-            inspectorMinimumWidth: Theme.Metrics.contextDockMinWidth,
-            inspectorIdealWidth: Theme.Metrics.contextDockIdealWidth,
-            inspectorMaximumWidth: Theme.Metrics.contextDockMaxWidth,
-            toolbarConfiguration: NativeWorkspaceToolbarConfiguration(coordinator: coordinator)
-        ) {
-            SidebarView(coordinator: coordinator)
-        } workspace: {
-            MainDetailView(
-                coordinator: coordinator,
-                bottomInspectorAutosaveName: Self.bottomInspectorSplitAutosaveName
-            )
-        } inspector: {
-            ContextDockView(coordinator: coordinator)
+        let activeProjectID = coordinator.projectStore.activeProjectID
+        return ZStack {
+            NativeWorkspaceSplitView(
+                isSidebarPresented: sidebarVisibility,
+                isInspectorPresented: contextDockVisibility,
+                autosaveName: Self.workspaceSplitAutosaveName(projectID: activeProjectID),
+                sidebarMinimumWidth: Theme.Metrics.sidebarMinWidth,
+                sidebarIdealWidth: Theme.Metrics.sidebarIdealWidth,
+                sidebarMaximumWidth: Theme.Metrics.sidebarMaxWidth,
+                workspaceMinimumWidth: Theme.Metrics.sessionTableMinWidth,
+                inspectorMinimumWidth: Theme.Metrics.contextDockMinWidth,
+                inspectorIdealWidth: Theme.Metrics.contextDockIdealWidth,
+                inspectorMaximumWidth: Theme.Metrics.contextDockMaxWidth,
+                toolbarConfiguration: NativeWorkspaceToolbarConfiguration(coordinator: coordinator)
+            ) {
+                SidebarView(coordinator: coordinator)
+            } workspace: {
+                MainDetailView(
+                    coordinator: coordinator,
+                    bottomInspectorAutosaveName: Self.bottomInspectorSplitAutosaveName(
+                        projectID: activeProjectID
+                    )
+                )
+                .id(activeProjectID)
+            } inspector: {
+                ContextDockView(coordinator: coordinator)
+            }
+            // Native split autosave names are applied only during construction.
+            // Rebuild the split, not this RootView's launch task, for a new Project.
+            .id(activeProjectID)
+            .disabled(!coordinator.hasHydratedProjects || coordinator.projectTransitionStatus.isPending)
         }
         .ignoresSafeArea(.container, edges: .top)
         .onChange(of: coordinator.workspaces.activeWorkspaceID) {
@@ -72,6 +82,13 @@ struct RootView: View {
         .sheet(isPresented: $coordinator.isProjectRecoveryPresented) {
             ProjectRecoverySheet(coordinator: coordinator)
         }
+        // Changing Projects while a capture runs is an explicit, reversible choice.
+        // Cancel leaves the outgoing Project untouched; Stop and Switch waits for
+        // the helper's final drain, fold and History write before anything moves.
+        .modifier(ProjectTransitionPresentation(
+            coordinator: coordinator,
+            isActive: !coordinator.isProjectManagerPresented && coordinator.projectNameEditorContext == nil
+        ))
         .alert(
             "Project Operation Failed",
             isPresented: Binding(
@@ -113,27 +130,52 @@ struct RootView: View {
         }
     }
 
+    /// Divider positions are part of a Project's layout, so each Project gets its
+    /// own autosave namespace. The native split behavior itself is unchanged.
+    static func workspaceSplitAutosaveName(projectID: UUID) -> String {
+        "\(workspaceSplitAutosaveName).\(projectID.uuidString)"
+    }
+
+    static func bottomInspectorSplitAutosaveName(projectID: UUID) -> String {
+        "\(bottomInspectorSplitAutosaveName).\(projectID.uuidString)"
+    }
+
     // MARK: Private
 
     @State private var showHelperInstall = false
-    /// Sidebar presentation is view-local: the source list is chrome, not workspace
-    /// state, so it is not persisted with the capture/filter/selection model. The
-    /// native toolbar toggle and `View ▸ Show Sidebar` both drive the split, which
-    /// resynchronizes this value through the collapse KVO.
-    @State private var isSidebarPresented = true
+    @State private var sidebarVisibilityByProject: [UUID: Bool] = [:]
+
+    private var sidebarVisibility: Binding<Bool> {
+        let projectID = coordinator.projectStore.activeProjectID
+        let defaults = coordinator.activeProjectDefaults
+        let key = TracexyIdentity.current.defaultsKey("project.sidebarPresented")
+        return Binding(
+            get: { sidebarVisibilityByProject[projectID] ?? defaults.object(forKey: key) as? Bool ?? true },
+            set: { value in
+                guard coordinator.projectStore.activeProjectID == projectID else {
+                    return
+                }
+                sidebarVisibilityByProject[projectID] = value
+                defaults.set(value, forKey: key)
+            }
+        )
+    }
 
     /// Bridges the native inspector split's presentation to workspace state. Routing the
     /// setter through `toggleContextDock()` keeps the existing persistence and animation
     /// semantics, and the equality guard means a native collapse publishes back exactly once.
     private var contextDockVisibility: Binding<Bool> {
-        Binding(
+        let projectID = coordinator.projectStore.activeProjectID
+        return Binding(
             get: {
                 coordinator.activeWorkspace.sidebarSelection == .history
                     ? false
                     : coordinator.isContextDockVisible
             },
             set: { newValue in
-                guard coordinator.activeWorkspace.sidebarSelection != .history else {
+                guard coordinator.projectStore.activeProjectID == projectID,
+                      coordinator.activeWorkspace.sidebarSelection != .history else
+                {
                     return
                 }
                 if coordinator.isContextDockVisible != newValue {
@@ -155,9 +197,14 @@ struct RootView: View {
             return
         }
 
-        let shouldAutoStart = UserDefaults.standard.bool(
+        // Auto-start is a *launch* preference, resolved once against the Project
+        // that was active at launch. Changing Projects later never starts a
+        // capture on its own: capture always begins with a deliberate Start.
+        let shouldAutoStart = coordinator.activeProjectDefaults.bool(
             forKey: SettingsKeys.autoStartCapture
         )
+        let launchProjectID = coordinator.projectStore.activeProjectID
+        let launchGeneration = coordinator.startGeneration
         if MainContentCoordinator.forceDirectCapture {
             if shouldAutoStart {
                 coordinator.startCapture()
@@ -165,6 +212,14 @@ struct RootView: View {
             return
         }
         await coordinator.helper.checkStatus()
+        // A delayed helper reply must never apply the launch Project's consent
+        // to a destination selected while the reply was in flight.
+        guard coordinator.projectStore.activeProjectID == launchProjectID,
+              coordinator.startGeneration == launchGeneration,
+              !coordinator.projectTransitionStatus.isPending else
+        {
+            return
+        }
         if coordinator.helper.status == .notInstalled {
             showHelperInstall = true
         } else if shouldAutoStart {

--- a/Tracexy/Views/Projects/ProjectPresentation.swift
+++ b/Tracexy/Views/Projects/ProjectPresentation.swift
@@ -1,0 +1,618 @@
+import AppKit
+import SwiftUI
+
+// MARK: - ProjectToolbarSelectorMetrics
+
+enum ProjectToolbarSelectorMetrics {
+    static let minimumWidth: CGFloat = 104
+    static let maximumWidth: CGFloat = 240
+    static let nonTextWidth: CGFloat = 64
+
+    static func preferredWidth(
+        for projectName: String,
+        font: NSFont = .systemFont(ofSize: NSFont.systemFontSize)
+    )
+        -> CGFloat
+    {
+        let textWidth = ceil((projectName as NSString).size(withAttributes: [.font: font]).width)
+        return min(maximumWidth, max(minimumWidth, textWidth + nonTextWidth))
+    }
+}
+
+// MARK: - ProjectToolbarSelectorView
+
+struct ProjectToolbarSelectorView: View {
+    // MARK: Internal
+
+    @Bindable var coordinator: MainContentCoordinator
+
+    var body: some View {
+        Menu {
+            ForEach(coordinator.projectStore.projects) { project in
+                Button {
+                    coordinator.switchToProject(id: project.id)
+                } label: {
+                    if project.id == coordinator.projectStore.activeProjectID {
+                        Label(project.name, systemImage: "checkmark")
+                    } else {
+                        Text(project.name)
+                    }
+                }
+                .disabled(!coordinator.projectStore.isMutable)
+            }
+
+            Divider()
+
+            Button("New Project…") {
+                coordinator.presentNewProjectEditor()
+            }
+            .keyboardShortcut("n", modifiers: [.command, .shift])
+            .disabled(!coordinator.projectStore.canCreateProject)
+
+            Button("Rename Project…") {
+                coordinator.presentRenameProjectEditor(id: coordinator.projectStore.activeProjectID)
+            }
+            .disabled(!coordinator.projectStore.isMutable)
+
+            Button("Manage Projects…") {
+                coordinator.isProjectManagerPresented = true
+            }
+
+            if case .failed = coordinator.projectStore.loadState {
+                Divider()
+                Button("Repair Projects…") {
+                    coordinator.isProjectRecoveryPresented = true
+                }
+            }
+        } label: {
+            HStack(spacing: Theme.Metrics.controlSpacing) {
+                Image(systemName: projectStatusSymbol)
+                    .foregroundStyle(projectStatusColor)
+                Text(coordinator.projectStore.activeProject.name)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+                    .layoutPriority(1)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.horizontal, 10)
+            .padding(.vertical, 5)
+            .contentShape(.rect)
+        }
+        .menuIndicator(.visible)
+        .menuStyle(.borderlessButton)
+        .frame(width: preferredWidth, alignment: .leading)
+        .fixedSize(horizontal: true, vertical: false)
+        .help("Active Project: \(coordinator.projectStore.activeProject.name)")
+        .accessibilityLabel("Active Project")
+        .accessibilityValue(coordinator.projectStore.activeProject.name)
+    }
+
+    // MARK: Private
+
+    private var preferredWidth: CGFloat {
+        ProjectToolbarSelectorMetrics.preferredWidth(for: coordinator.projectStore.activeProject.name)
+    }
+
+    private var projectStatusSymbol: String {
+        switch coordinator.projectStore.loadState {
+        case .failed: "folder.badge.questionmark"
+        case .loading: "folder"
+        case .idle,
+             .ready: "folder.fill"
+        }
+    }
+
+    private var projectStatusColor: Color {
+        if case .failed = coordinator.projectStore.loadState {
+            return .orange
+        }
+        return .accentColor
+    }
+}
+
+// MARK: - ProjectNameEditorSheet
+
+struct ProjectNameEditorSheet: View {
+    // MARK: Lifecycle
+
+    init(context: ProjectNameEditorContext, coordinator: MainContentCoordinator) {
+        self.context = context
+        self.coordinator = coordinator
+        _name = State(initialValue: context.initialName)
+    }
+
+    // MARK: Internal
+
+    @Bindable var coordinator: MainContentCoordinator
+
+    let context: ProjectNameEditorContext
+
+    var body: some View {
+        VStack(spacing: 0) {
+            HStack(spacing: Theme.Metrics.spacingL) {
+                Image(systemName: "folder.fill")
+                    .font(.system(size: Theme.Icon.xlarge))
+                    .foregroundStyle(Color.accentColor)
+                    .frame(width: 30)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(context.title)
+                        .font(Theme.Typography.surfaceTitle)
+                    Text("Projects keep workspace filters and layout together.")
+                        .font(Theme.Typography.caption)
+                        .foregroundStyle(.secondary)
+                }
+                Spacer()
+            }
+            .padding(18)
+
+            Divider()
+
+            VStack(alignment: .leading, spacing: Theme.Metrics.controlSpacing) {
+                Text("Project Name")
+                    .font(Theme.Typography.bodyMedium)
+                TextField("For example: Authentication Review", text: $name)
+                    .textFieldStyle(.roundedBorder)
+                    .onChange(of: name) { _, _ in operationErrorMessage = nil }
+                Text(editorMessage)
+                    .font(Theme.Typography.caption)
+                    .foregroundStyle(hasEditorError ? Color.orange : Color.secondary)
+            }
+            .padding(18)
+
+            Divider()
+
+            HStack {
+                Spacer()
+                Button("Cancel", role: .cancel) { dismiss() }
+                    .keyboardShortcut(.cancelAction)
+                Button(context.actionTitle) { submit() }
+                    .keyboardShortcut(.defaultAction)
+                    .tracexyGlassButtonStyle(prominent: true)
+                    .disabled(validationMessage != nil)
+            }
+            .padding(.horizontal, 18)
+            .frame(height: 52)
+        }
+        .frame(width: 460)
+    }
+
+    // MARK: Private
+
+    @Environment(\.dismiss) private var dismiss
+    @State private var name: String
+    @State private var operationErrorMessage: String?
+
+    private var normalizedName: String? {
+        try? ProjectNameNormalization.normalize(name)
+    }
+
+    private var validationMessage: String? {
+        guard let normalizedName else {
+            return "Enter a name without control or invisible formatting characters."
+        }
+        let key = ProjectNameNormalization.uniquenessKey(normalizedName)
+        let excludedID: UUID? = switch context.mode {
+        case .create: nil
+        case let .rename(id): id
+        }
+        if coordinator.projectStore.projects.contains(where: {
+            $0.id != excludedID && ProjectNameNormalization.uniquenessKey($0.name) == key
+        }) {
+            return "A Project with this name already exists."
+        }
+        return nil
+    }
+
+    private var editorMessage: String {
+        validationMessage ?? operationErrorMessage
+            ?? "1–\(ProjectLimits.maximumNameLength) characters. Names must be unique."
+    }
+
+    private var hasEditorError: Bool {
+        validationMessage != nil || operationErrorMessage != nil
+    }
+
+    private func submit() {
+        guard let normalizedName else {
+            return
+        }
+        let succeeded: Bool = switch context.mode {
+        case .create: coordinator.createProject(named: normalizedName) != nil
+        case let .rename(id): coordinator.renameProject(id: id, to: normalizedName)
+        }
+        guard succeeded else {
+            operationErrorMessage = coordinator.projectOperationErrorMessage
+                ?? "The Project could not be updated. Try again."
+            return
+        }
+        dismiss()
+    }
+}
+
+// MARK: - ProjectManagerSheet
+
+struct ProjectManagerSheet: View {
+    // MARK: Lifecycle
+
+    init(coordinator: MainContentCoordinator) {
+        self.coordinator = coordinator
+        _selection = State(initialValue: coordinator.projectStore.activeProjectID)
+    }
+
+    // MARK: Internal
+
+    @Bindable var coordinator: MainContentCoordinator
+
+    var body: some View {
+        VStack(spacing: 0) {
+            HSplitView {
+                projectSidebar
+                    .frame(minWidth: 230, idealWidth: 250, maxWidth: 300)
+                detail
+                    .frame(minWidth: 430, maxWidth: .infinity, maxHeight: .infinity)
+            }
+            Divider()
+            actionBar
+        }
+        .font(Theme.Typography.body)
+        .frame(minWidth: 720, idealWidth: 780, minHeight: 500, idealHeight: 540)
+        .confirmationDialog(
+            "Delete Project?",
+            isPresented: deleteConfirmation,
+            titleVisibility: .visible,
+            presenting: coordinator.projectDeletionRequest
+        ) { request in
+            Button("Delete \(request.projectName)", role: .destructive) {
+                if coordinator.deleteProject(id: request.projectID) {
+                    selection = coordinator.projectStore.activeProjectID
+                }
+                coordinator.projectDeletionRequest = nil
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: { _ in
+            Text(
+                "This removes the Project and its saved workspace configuration. "
+                    + "Current capture data, saved captures, and History are not deleted."
+            )
+        }
+        .sheet(item: $coordinator.projectNameEditorContext) { context in
+            ProjectNameEditorSheet(context: context, coordinator: coordinator)
+        }
+        .onChange(of: coordinator.projectStore.activeProjectID) { _, activeProjectID in
+            selection = activeProjectID
+        }
+    }
+
+    // MARK: Private
+
+    @Environment(\.dismiss) private var dismiss
+    @State private var selection: UUID?
+
+    private var selectedProject: Project? {
+        coordinator.projectStore.projects.first { $0.id == selection }
+    }
+
+    private var canDeleteSelectedProject: Bool {
+        coordinator.projectStore.isMutable
+            && selectedProject != nil
+            && coordinator.projectStore.projects.count > 1
+    }
+
+    private var deleteConfirmation: Binding<Bool> {
+        Binding(
+            get: { coordinator.projectDeletionRequest != nil },
+            set: {
+                if !$0 {
+                    coordinator.projectDeletionRequest = nil
+                }
+            }
+        )
+    }
+
+    private var projectSidebar: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            VStack(alignment: .leading, spacing: 3) {
+                Text("Projects")
+                    .font(Theme.Typography.surfaceTitle)
+                Text("Organize durable workspace views for different investigations.")
+                    .font(Theme.Typography.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            .padding(.horizontal, Theme.Metrics.spacingL)
+            .padding(.vertical, Theme.Metrics.spacingL)
+
+            Divider()
+
+            List(selection: $selection) {
+                ForEach(coordinator.projectStore.projects) { project in
+                    HStack(spacing: Theme.Metrics.spacingM) {
+                        Image(systemName: project.id == coordinator.projectStore.activeProjectID
+                            ? "folder.fill" : "folder")
+                            .foregroundStyle(selection == project.id ? Color.primary : Color.secondary)
+                            .frame(width: 16)
+                        VStack(alignment: .leading, spacing: 1) {
+                            Text(project.name).lineLimit(1).truncationMode(.middle)
+                            Text(workspaceCountText(project.workspaces.count))
+                                .font(Theme.Typography.micro)
+                                .foregroundStyle(.secondary)
+                        }
+                        Spacer(minLength: 4)
+                        if project.id == coordinator.projectStore.activeProjectID {
+                            Image(systemName: "checkmark.circle.fill")
+                                .font(.system(size: Theme.Icon.medium))
+                                .foregroundStyle(selection == project.id ? Color.primary : Color.accentColor)
+                                .help("Active Project")
+                        }
+                    }
+                    .tag(project.id)
+                    .padding(.vertical, 2)
+                    .accessibilityElement(children: .combine)
+                    .accessibilityLabel(project.name)
+                    .accessibilityValue(project.id == coordinator.projectStore.activeProjectID
+                        ? "\(workspaceCountText(project.workspaces.count)), Active Project"
+                        : workspaceCountText(project.workspaces.count))
+                }
+            }
+            .listStyle(.sidebar)
+
+            Divider()
+
+            HStack(spacing: Theme.Metrics.controlSpacing) {
+                addRemoveControl
+                Spacer()
+                Text("\(coordinator.projectStore.projects.count)/\(coordinator.projectStore.maxProjects)")
+                    .font(Theme.Typography.monoMicro)
+                    .foregroundStyle(.secondary)
+                    .accessibilityLabel("Project capacity")
+            }
+            .padding(.horizontal, Theme.Metrics.spacingL)
+            .padding(.vertical, Theme.Metrics.spacingM)
+        }
+        .background(Color(nsColor: .windowBackgroundColor))
+    }
+
+    @ViewBuilder private var detail: some View {
+        if let project = selectedProject {
+            VStack(alignment: .leading, spacing: 0) {
+                HStack(alignment: .center, spacing: Theme.Metrics.controlSpacing) {
+                    VStack(alignment: .leading, spacing: 3) {
+                        Text(project.name)
+                            .font(Theme.Typography.surfaceTitle)
+                            .lineLimit(1)
+                            .truncationMode(.middle)
+                        Text(project.id == coordinator.projectStore.activeProjectID
+                            ? "Active Project" : "Local Project")
+                            .font(Theme.Typography.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                    Spacer()
+                    if project.id != coordinator.projectStore.activeProjectID {
+                        Button("Open Project") {
+                            if coordinator.switchToProject(id: project.id) {
+                                selection = project.id
+                            }
+                        }
+                        .disabled(!coordinator.projectStore.isMutable)
+                    }
+                    Button("Rename…") {
+                        coordinator.presentRenameProjectEditor(id: project.id)
+                    }
+                    .disabled(!coordinator.projectStore.isMutable)
+                }
+                .padding(Theme.Metrics.spacingL)
+
+                Divider()
+
+                VStack(alignment: .leading, spacing: Theme.Metrics.controlSpacing) {
+                    HStack {
+                        Text("Workspaces").font(Theme.Typography.bodyMedium)
+                        Spacer()
+                        Text(workspaceCountText(project.workspaces.count))
+                            .font(Theme.Typography.monoMicro)
+                            .foregroundStyle(.secondary)
+                    }
+
+                    List {
+                        ForEach(project.workspaces) { workspace in
+                            HStack(spacing: Theme.Metrics.spacingM) {
+                                Image(systemName: workspace.isClosable ? "rectangle" : "rectangle.fill")
+                                    .foregroundStyle(.secondary)
+                                    .frame(width: 16)
+                                Text(workspace.title).lineLimit(1).truncationMode(.middle)
+                                Spacer()
+                                if workspace.id == project.activeWorkspaceID {
+                                    Label("Current", systemImage: "checkmark")
+                                        .font(Theme.Typography.micro)
+                                        .foregroundStyle(.secondary)
+                                }
+                            }
+                            .frame(minHeight: Theme.Metrics.rowHeight)
+                        }
+                    }
+                    .listStyle(.inset(alternatesRowBackgrounds: true))
+                    .scrollContentBackground(.hidden)
+                    .background(Color(nsColor: .textBackgroundColor))
+                    .clipShape(RoundedRectangle(cornerRadius: Theme.Metrics.pillCornerRadius))
+                    .overlay {
+                        RoundedRectangle(cornerRadius: Theme.Metrics.pillCornerRadius)
+                            .stroke(Color(nsColor: .separatorColor), lineWidth: 1)
+                    }
+                }
+                .padding(Theme.Metrics.spacingL)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+
+                Divider()
+                Label(
+                    "Projects save workspace names, filters, grouping, and layout. Capture data and History remain app-wide.",
+                    systemImage: "info.circle"
+                )
+                .font(Theme.Typography.caption)
+                .foregroundStyle(.secondary)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(Theme.Metrics.spacingL)
+                .background(Color(nsColor: .controlBackgroundColor).opacity(0.5))
+            }
+        } else {
+            ContentUnavailableView(
+                "Select a Project",
+                systemImage: "folder",
+                description: Text("Choose a Project to view its saved workspaces.")
+            )
+        }
+    }
+
+    private var addRemoveControl: some View {
+        HStack(spacing: 0) {
+            Button {
+                coordinator.presentNewProjectEditor()
+            } label: {
+                Image(systemName: "plus")
+                    .frame(width: 22, height: 22)
+                    .contentShape(.rect)
+            }
+            .buttonStyle(.plain)
+            .keyboardShortcut("n", modifiers: [.command, .shift])
+            .help("New Project")
+            .disabled(!coordinator.projectStore.canCreateProject)
+
+            Rectangle()
+                .fill(Color(nsColor: .separatorColor).opacity(0.7))
+                .frame(width: 1, height: 18)
+
+            Button {
+                if let selectedProject {
+                    coordinator.requestProjectDeletion(selectedProject)
+                }
+            } label: {
+                Image(systemName: "minus")
+                    .frame(width: 22, height: 22)
+                    .contentShape(.rect)
+            }
+            .buttonStyle(.plain)
+            .help("Delete Project")
+            .disabled(!canDeleteSelectedProject)
+        }
+        .padding(.horizontal, 3)
+        .background(Color(nsColor: .controlBackgroundColor))
+        .clipShape(RoundedRectangle(cornerRadius: Theme.Metrics.pillCornerRadius))
+        .overlay {
+            RoundedRectangle(cornerRadius: Theme.Metrics.pillCornerRadius)
+                .stroke(Color(nsColor: .separatorColor), lineWidth: 1)
+        }
+    }
+
+    private var actionBar: some View {
+        HStack(spacing: Theme.Metrics.controlSpacing) {
+            if let warning = coordinator.projectPersistenceWarningMessage {
+                Label(warning, systemImage: "exclamationmark.triangle.fill")
+                    .font(Theme.Typography.caption)
+                    .foregroundStyle(.orange)
+                    .lineLimit(2)
+            } else {
+                Text("Projects are stored locally on this Mac.")
+                    .font(Theme.Typography.caption)
+                    .foregroundStyle(.secondary)
+            }
+            Spacer()
+            Button("Import…") { coordinator.importProjectConfiguration() }
+                .disabled(!coordinator.projectStore.canCreateProject)
+            Button("Export…") {
+                if let selectedProject {
+                    coordinator.exportProjectConfiguration(selectedProject)
+                }
+            }
+            .disabled(selectedProject == nil || !coordinator.projectStore.isMutable)
+            Button("Done") { dismiss() }
+                .keyboardShortcut(.defaultAction)
+                .tracexyGlassButtonStyle()
+        }
+        .padding(.horizontal, Theme.Metrics.spacingL)
+        .padding(.vertical, Theme.Metrics.spacingM)
+        .frame(minHeight: 48)
+    }
+
+    private func workspaceCountText(_ count: Int) -> String {
+        count == 1 ? "1 Workspace" : "\(count) Workspaces"
+    }
+}
+
+// MARK: - ProjectRecoverySheet
+
+struct ProjectRecoverySheet: View {
+    // MARK: Internal
+
+    @Bindable var coordinator: MainContentCoordinator
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            HStack(spacing: Theme.Metrics.spacingL) {
+                Image(systemName: "folder.badge.questionmark")
+                    .font(.system(size: Theme.Icon.xlarge))
+                    .foregroundStyle(.orange)
+                VStack(alignment: .leading, spacing: 3) {
+                    Text("Repair Projects")
+                        .font(Theme.Typography.surfaceTitle)
+                    Text("The Project catalog could not be loaded safely.")
+                        .font(Theme.Typography.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .padding(18)
+
+            Divider()
+
+            VStack(alignment: .leading, spacing: Theme.Metrics.spacingM) {
+                Text(
+                    "Tracexy will not overwrite an unreadable catalog. Retry after fixing the file, "
+                        + "or reset Projects to a new default catalog. Capture and History are unaffected."
+                )
+                .fixedSize(horizontal: false, vertical: true)
+
+                Text(coordinator.projectStore.loadFailureMessage ?? "Unknown Project catalog error")
+                    .font(Theme.Typography.monoSmall)
+                    .textSelection(.enabled)
+                    .padding(Theme.Metrics.spacingM)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .background(Color(nsColor: .textBackgroundColor))
+                    .clipShape(RoundedRectangle(cornerRadius: Theme.Metrics.pillCornerRadius))
+            }
+            .padding(18)
+
+            Divider()
+
+            HStack {
+                Button("Reset…", role: .destructive) { showsResetConfirmation = true }
+                Spacer()
+                Button("Close", role: .cancel) { dismiss() }
+                    .keyboardShortcut(.cancelAction)
+                Button("Retry") { Task { await coordinator.retryProjectCatalogLoad() } }
+                    .keyboardShortcut(.defaultAction)
+                    .tracexyGlassButtonStyle(prominent: true)
+            }
+            .padding(.horizontal, 18)
+            .frame(height: 52)
+        }
+        .frame(width: 540)
+        .confirmationDialog(
+            "Reset Projects?",
+            isPresented: $showsResetConfirmation,
+            titleVisibility: .visible
+        ) {
+            Button("Reset Project Catalog", role: .destructive) {
+                Task { await coordinator.resetProjectCatalog() }
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text(
+                "This replaces Project names and saved workspace configuration. "
+                    + "Current capture data, saved captures, and History are not deleted."
+            )
+        }
+    }
+
+    // MARK: Private
+
+    @Environment(\.dismiss) private var dismiss
+    @State private var showsResetConfirmation = false
+}

--- a/Tracexy/Views/Projects/ProjectPresentation.swift
+++ b/Tracexy/Views/Projects/ProjectPresentation.swift
@@ -94,7 +94,10 @@ struct ProjectToolbarSelectorView: View {
     }
 
     private var projectStatusSymbol: String {
-        switch coordinator.projectStore.loadState {
+        if coordinator.projectTransitionStatus.isPending {
+            return "hourglass"
+        }
+        return switch coordinator.projectStore.loadState {
         case .failed: "folder.badge.questionmark"
         case .loading: "folder"
         case .idle,
@@ -137,7 +140,7 @@ struct ProjectNameEditorSheet: View {
                 VStack(alignment: .leading, spacing: 2) {
                     Text(context.title)
                         .font(Theme.Typography.surfaceTitle)
-                    Text("Projects keep workspace filters and layout together.")
+                    Text("A Project keeps its own sessions, Library, History, and settings.")
                         .font(Theme.Typography.caption)
                         .foregroundStyle(.secondary)
                 }
@@ -217,7 +220,12 @@ struct ProjectNameEditorSheet: View {
             return
         }
         let succeeded: Bool = switch context.mode {
+        // A pending transition means the request was accepted and is waiting for a
+        // running capture to stop and drain, so the sheet closes rather than
+        // reporting a failure that did not happen.
         case .create: coordinator.createProject(named: normalizedName) != nil
+            || coordinator.projectTransitionStatus.isPending
+            || coordinator.pendingProjectSwitchConfirmation != nil
         case let .rename(id): coordinator.renameProject(id: id, to: normalizedName)
         }
         guard succeeded else {
@@ -271,13 +279,18 @@ struct ProjectManagerSheet: View {
             Button("Cancel", role: .cancel) {}
         } message: { _ in
             Text(
-                "This removes the Project and its saved workspace configuration. "
-                    + "Current capture data, saved captures, and History are not deleted."
+                "This removes the Project, its workspace configuration, and any unsaved in-memory sessions and evidence. "
+                    + "Its saved captures and local History stay on disk and are not deleted, "
+                    + "but they will no longer be reachable from Tracexy."
             )
         }
         .sheet(item: $coordinator.projectNameEditorContext) { context in
             ProjectNameEditorSheet(context: context, coordinator: coordinator)
         }
+        .modifier(ProjectTransitionPresentation(
+            coordinator: coordinator,
+            isActive: coordinator.projectNameEditorContext == nil
+        ))
         .onChange(of: coordinator.projectStore.activeProjectID) { _, activeProjectID in
             selection = activeProjectID
         }
@@ -314,7 +327,7 @@ struct ProjectManagerSheet: View {
             VStack(alignment: .leading, spacing: 3) {
                 Text("Projects")
                     .font(Theme.Typography.surfaceTitle)
-                Text("Organize durable workspace views for different investigations.")
+                Text("Keep separate investigations isolated: sessions, Library, History, and settings.")
                     .font(Theme.Typography.caption)
                     .foregroundStyle(.secondary)
                     .fixedSize(horizontal: false, vertical: true)
@@ -444,7 +457,7 @@ struct ProjectManagerSheet: View {
 
                 Divider()
                 Label(
-                    "Projects save workspace names, filters, grouping, and layout. Capture data and History remain app-wide.",
+                    "Each Project keeps its own sessions, saved-capture Library, local History, and capture/privacy settings. Exported Project files carry configuration only.",
                     systemImage: "info.circle"
                 )
                 .font(Theme.Typography.caption)
@@ -565,7 +578,8 @@ struct ProjectRecoverySheet: View {
             VStack(alignment: .leading, spacing: Theme.Metrics.spacingM) {
                 Text(
                     "Tracexy will not overwrite an unreadable catalog. Retry after fixing the file, "
-                        + "or reset Projects to a new default catalog. Capture and History are unaffected."
+                        + "or reset Projects to a new default catalog. Saved capture files and History remain on disk; "
+                        + "resetting discards unsaved in-memory sessions and workspace state."
                 )
                 .fixedSize(horizontal: false, vertical: true)
 
@@ -605,8 +619,9 @@ struct ProjectRecoverySheet: View {
             Button("Cancel", role: .cancel) {}
         } message: {
             Text(
-                "This replaces Project names and saved workspace configuration. "
-                    + "Current capture data, saved captures, and History are not deleted."
+                "This discards unsaved in-memory sessions and evidence, and replaces Project names and workspace configuration with a new default "
+                    + "Project. Saved captures and History stay on disk and are never handed to the "
+                    + "new Project, so no investigation inherits another's data."
             )
         }
     }

--- a/Tracexy/Views/Projects/ProjectPresentationModels.swift
+++ b/Tracexy/Views/Projects/ProjectPresentationModels.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+// MARK: - ProjectNameEditorContext
+
+struct ProjectNameEditorContext: Identifiable, Equatable {
+    enum Mode: Equatable {
+        case create
+        case rename(UUID)
+    }
+
+    let id = UUID()
+    let mode: Mode
+    let initialName: String
+
+    var title: String {
+        switch mode {
+        case .create: String(localized: "New Project")
+        case .rename: String(localized: "Rename Project")
+        }
+    }
+
+    var actionTitle: String {
+        switch mode {
+        case .create: String(localized: "Create")
+        case .rename: String(localized: "Rename")
+        }
+    }
+}
+
+// MARK: - ProjectDeletionRequest
+
+struct ProjectDeletionRequest: Identifiable, Equatable {
+    let projectID: UUID
+    let projectName: String
+
+    var id: UUID {
+        projectID
+    }
+}

--- a/Tracexy/Views/Projects/ProjectTransitionPresentation.swift
+++ b/Tracexy/Views/Projects/ProjectTransitionPresentation.swift
@@ -1,0 +1,53 @@
+import SwiftUI
+
+/// Present lifecycle prompts from the frontmost Project surface, including the
+/// manager sheet. The action retains the presented request across dismissal.
+struct ProjectTransitionPresentation: ViewModifier {
+    let coordinator: MainContentCoordinator
+    var isActive = true
+
+    func body(content: Content) -> some View {
+        content
+            .confirmationDialog(
+                "Stop the capture and change Projects?",
+                isPresented: Binding(
+                    get: { isActive && coordinator.pendingProjectSwitchConfirmation != nil },
+                    set: {
+                        if !$0 {
+                            coordinator.cancelPendingProjectSwitch()
+                        }
+                    }
+                ),
+                titleVisibility: .visible,
+                presenting: coordinator.pendingProjectSwitchConfirmation
+            ) { request in
+                Button("Stop and Switch") {
+                    // SwiftUI may dismiss the presentation binding before the
+                    // action fires. Keep the immutable request shown to the user.
+                    coordinator.pendingProjectSwitchConfirmation = request
+                    coordinator.confirmPendingProjectSwitch()
+                }
+                Button("Cancel", role: .cancel) { coordinator.cancelPendingProjectSwitch() }
+            } message: { request in
+                Text(
+                    "“\(request.outgoingProjectName)” is capturing. Tracexy will stop it, wait for the "
+                        + "final packets and its History entry, then open “\(request.destinationDescription)”. "
+                        + "Switching preserves its captured data. Deleting a Project discards its unsaved sessions."
+                )
+            }
+            .alert(
+                "Project Change Didn’t Finish",
+                isPresented: Binding(
+                    get: { isActive && coordinator.projectTransitionStatus.failureMessage != nil },
+                    set: { _ in }
+                )
+            ) {
+                if coordinator.retryableProjectTransition != nil {
+                    Button("Try Again") { coordinator.retryProjectTransition() }
+                }
+                Button("Stay Here", role: .cancel) { coordinator.dismissProjectTransitionFailure() }
+            } message: {
+                Text(coordinator.projectTransitionStatus.failureMessage ?? "")
+            }
+    }
+}

--- a/Tracexy/Views/Settings/GeneralSettingsView.swift
+++ b/Tracexy/Views/Settings/GeneralSettingsView.swift
@@ -5,6 +5,27 @@ import SwiftUI
 /// Appearance, default landing view, byte units, and launch behavior.
 /// Appearance and Default view take effect immediately; the rest persist.
 struct GeneralSettingsView: View {
+    // MARK: Lifecycle
+
+    init(applicationDefaults: UserDefaults = .standard) {
+        _appearance = AppStorage(
+            wrappedValue: AppAppearance.system.rawValue,
+            SettingsKeys.appearance,
+            store: applicationDefaults
+        )
+        _byteUnits = AppStorage(
+            wrappedValue: ByteUnits.binary.rawValue,
+            SettingsKeys.byteUnits,
+            store: applicationDefaults
+        )
+        _confirmQuit = AppStorage(
+            wrappedValue: true,
+            SettingsKeys.confirmQuitWhileCapturing,
+            store: applicationDefaults
+        )
+        _restoreWorkspace = AppStorage(wrappedValue: true, SettingsKeys.restoreWorkspace, store: applicationDefaults)
+    }
+
     // MARK: Internal
 
     var body: some View {
@@ -55,11 +76,15 @@ struct GeneralSettingsView: View {
 
     // MARK: Private
 
-    @AppStorage(SettingsKeys.appearance) private var appearance = AppAppearance.system.rawValue
+    /// Appearance, byte units, quit confirmation and workspace restoration describe
+    /// the application, so they stay in the shared domain explicitly. "Default
+    /// view" is a per-Project layout preference and follows the injected store.
+    @AppStorage(SettingsKeys.appearance, store: .standard) private var appearance = AppAppearance.system.rawValue
+    @AppStorage(SettingsKeys.byteUnits, store: .standard) private var byteUnits = ByteUnits.binary.rawValue
+    @AppStorage(SettingsKeys.confirmQuitWhileCapturing, store: .standard) private var confirmQuit = true
+    @AppStorage(SettingsKeys.restoreWorkspace, store: .standard) private var restoreWorkspace = true
+
     @AppStorage(SettingsKeys.defaultView) private var defaultView = DefaultView.sessions.rawValue
-    @AppStorage(SettingsKeys.byteUnits) private var byteUnits = ByteUnits.binary.rawValue
-    @AppStorage(SettingsKeys.confirmQuitWhileCapturing) private var confirmQuit = true
-    @AppStorage(SettingsKeys.restoreWorkspace) private var restoreWorkspace = true
 
     private let metrics = SettingsDisplayMetrics.standard
 }

--- a/Tracexy/Views/Settings/PrivacySettingsView.swift
+++ b/Tracexy/Views/Settings/PrivacySettingsView.swift
@@ -9,10 +9,13 @@ struct PrivacySettingsView: View {
     // MARK: Lifecycle
 
     init(
+        applicationDefaults: UserDefaults = .standard,
         historyRetentionError: String? = nil,
         isHistoryDemoMode: Bool = false,
         onAutoClearChange: @escaping (AutoClear) -> Void = { _ in }
     ) {
+        _localOnly = AppStorage(wrappedValue: true, SettingsKeys.localOnly, store: applicationDefaults)
+        _shareAnalytics = AppStorage(wrappedValue: false, SettingsKeys.shareAnalytics, store: applicationDefaults)
         self.historyRetentionError = historyRetentionError
         self.isHistoryDemoMode = isHistoryDemoMode
         self.onAutoClearChange = onAutoClearChange
@@ -110,12 +113,17 @@ struct PrivacySettingsView: View {
 
     // MARK: Private
 
+    // Export protections and History Auto-clear are per-Project: one investigation
+    // may need masked, redacted exports and a short retention window while another
+    // keeps everything. "Local only" and analytics describe the application and
+    // stay in the shared domain explicitly.
     @AppStorage(SettingsKeys.redactBodies) private var redactBodies = true
     @AppStorage(SettingsKeys.stripCredentials) private var stripCredentials = true
     @AppStorage(SettingsKeys.maskIPs) private var maskIPs = false
-    @AppStorage(SettingsKeys.localOnly) private var localOnly = true
     @AppStorage(SettingsKeys.autoClear) private var autoClear = AutoClear.never.rawValue
-    @AppStorage(SettingsKeys.shareAnalytics) private var shareAnalytics = false
+
+    @AppStorage(SettingsKeys.localOnly, store: .standard) private var localOnly = true
+    @AppStorage(SettingsKeys.shareAnalytics, store: .standard) private var shareAnalytics = false
 
     private let historyRetentionError: String?
     private let isHistoryDemoMode: Bool

--- a/Tracexy/Views/Settings/SettingsView.swift
+++ b/Tracexy/Views/Settings/SettingsView.swift
@@ -9,11 +9,22 @@ struct SettingsView: View {
 
     init(
         updater: AppUpdater,
+        applicationDefaults: UserDefaults = .standard,
+        activeProjectName: String? = nil,
+        isProjectReady: Bool = true,
         historyRetentionError: String? = nil,
         isHistoryDemoMode: Bool = false,
         onAutoClearChange: @escaping (AutoClear) -> Void = { _ in }
     ) {
         self.updater = updater
+        self.applicationDefaults = applicationDefaults
+        _selectedTab = AppStorage(
+            wrappedValue: SettingsTab.general.rawValue,
+            SettingsKeys.selectedSettingsTab,
+            store: applicationDefaults
+        )
+        self.activeProjectName = activeProjectName
+        self.isProjectReady = isProjectReady
         self.historyRetentionError = historyRetentionError
         self.isHistoryDemoMode = isHistoryDemoMode
         self.onAutoClearChange = onAutoClearChange
@@ -40,8 +51,10 @@ struct SettingsView: View {
             .navigationTitle("Settings")
         } detail: {
             selectedPane
+                .disabled(isProjectScopedPane && !isProjectReady)
                 .font(metrics.font())
                 .navigationTitle(selection.wrappedValue.title)
+                .navigationSubtitle(paneSubtitle)
         }
         .frame(
             minWidth: metrics.windowMinWidth,
@@ -55,9 +68,15 @@ struct SettingsView: View {
 
     // MARK: Private
 
-    @AppStorage(SettingsKeys.selectedSettingsTab) private var selectedTab = SettingsTab.general.rawValue
+    /// Which pane is open is an application preference, not a Project one, so it
+    /// names `.standard` explicitly and is unaffected by the per-Project store.
+    @AppStorage(SettingsKeys.selectedSettingsTab, store: .standard)
+    private var selectedTab = SettingsTab.general.rawValue
 
     private let updater: AppUpdater
+    private let applicationDefaults: UserDefaults
+    private let activeProjectName: String?
+    private let isProjectReady: Bool
     private let historyRetentionError: String?
     private let isHistoryDemoMode: Bool
     private let onAutoClearChange: (AutoClear) -> Void
@@ -70,12 +89,33 @@ struct SettingsView: View {
         )
     }
 
+    /// Name the Project whose preferences the pane is editing, so a per-Project
+    /// setting is never mistaken for an app-wide one.
+    private var paneSubtitle: String {
+        guard let activeProjectName, isProjectScopedPane else {
+            return ""
+        }
+        return String(localized: "Project: \(activeProjectName)")
+    }
+
+    private var isProjectScopedPane: Bool {
+        switch selection.wrappedValue {
+        case .capture,
+             .general,
+             .privacy: true
+        case .helper,
+             .mcp,
+             .updates: false
+        }
+    }
+
     @ViewBuilder private var selectedPane: some View {
         switch selection.wrappedValue {
-        case .general: GeneralSettingsView()
+        case .general: GeneralSettingsView(applicationDefaults: applicationDefaults)
         case .capture: CaptureSettingsView()
         case .helper: HelperSettingsView()
         case .privacy: PrivacySettingsView(
+                applicationDefaults: applicationDefaults,
                 historyRetentionError: historyRetentionError,
                 isHistoryDemoMode: isHistoryDemoMode,
                 onAutoClearChange: onAutoClearChange

--- a/TracexyTests/Core/Storage/PortableProjectCodecTests.swift
+++ b/TracexyTests/Core/Storage/PortableProjectCodecTests.swift
@@ -1,0 +1,82 @@
+import Foundation
+import Testing
+@testable import Tracexy
+
+@Suite("Portable project codec")
+struct PortableProjectCodecTests {
+    // MARK: Internal
+
+    @Test("Round trip remains configuration-only and regenerates every identity")
+    func roundTripRegeneratesIdentity() throws {
+        let rule = ProjectFilterRuleSnapshot(value: "private.example")
+        let workspace = ProjectWorkspaceSnapshot(
+            title: "Review",
+            filterText: "dns",
+            filterRules: [rule]
+        )
+        let project = Project(
+            name: "Portable",
+            workspaces: [workspace],
+            activeWorkspaceID: workspace.id
+        )
+
+        let data = try PortableProjectCodec.encode(project)
+        let json = try #require(String(data: data, encoding: .utf8))
+        for forbidden in ["capture", "payload", "filePath", "history", "selectedSession"] {
+            #expect(!json.localizedCaseInsensitiveContains(forbidden))
+        }
+
+        let imported = try PortableProjectCodec.decode(data, now: Date(timeIntervalSince1970: 9))
+        #expect(imported.id != project.id)
+        #expect(imported.workspaces[0].id != workspace.id)
+        #expect(imported.workspaces[0].filterRules[0].id != rule.id)
+        #expect(imported.activeWorkspaceID == imported.workspaces[0].id)
+        #expect(imported.name == "Portable")
+        #expect(imported.createdAt == Date(timeIntervalSince1970: 9))
+    }
+
+    @Test("Oversized portable input is rejected before JSON decoding")
+    func oversizedInputRejected() {
+        let data = Data(count: ProjectLimits.maximumPortableProjectBytes + 1)
+        #expect(throws: PortableProjectCodecError.documentTooLarge(
+            limit: ProjectLimits.maximumPortableProjectBytes
+        )) {
+            _ = try PortableProjectCodec.decode(data)
+        }
+    }
+
+    @Test("Document IO writes privately, reads bounded data and rejects symlinks")
+    func safeDocumentIO() throws {
+        let directory = Self.temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let workspace = ProjectWorkspaceSnapshot(title: "Live", isClosable: false)
+        let project = Project(
+            name: "Exported",
+            workspaces: [workspace],
+            activeWorkspaceID: workspace.id
+        )
+        let url = directory.appendingPathComponent("Exported.tracexyproject")
+        try PortableProjectDocumentIO.write(project, to: url)
+        #expect(try PortableProjectDocumentIO.read(from: url).name == "Exported")
+
+        let attributes = try FileManager.default.attributesOfItem(atPath: url.path)
+        #expect((attributes[.posixPermissions] as? NSNumber)?.intValue == 0o600)
+
+        let link = directory.appendingPathComponent("Alias.tracexyproject")
+        try FileManager.default.createSymbolicLink(at: link, withDestinationURL: url)
+        #expect(throws: PortableProjectCodecError.documentIsSymbolicLink) {
+            _ = try PortableProjectDocumentIO.read(from: link)
+        }
+        #expect(throws: PortableProjectCodecError.documentIsSymbolicLink) {
+            try PortableProjectDocumentIO.write(project, to: link)
+        }
+    }
+
+    // MARK: Private
+
+    private static func temporaryDirectory() -> URL {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent("portable-project-\(UUID().uuidString)", isDirectory: true)
+    }
+}

--- a/TracexyTests/Core/Storage/ProjectCatalogRepositoryTests.swift
+++ b/TracexyTests/Core/Storage/ProjectCatalogRepositoryTests.swift
@@ -1,0 +1,112 @@
+import Darwin
+import Foundation
+import Testing
+@testable import Tracexy
+
+@Suite("JSON project catalog repository")
+struct ProjectCatalogRepositoryTests {
+    // MARK: Internal
+
+    @Test("A missing catalog is seeded privately and reloads normalized v1 data")
+    func missingFileSeed() async throws {
+        let directory = Self.temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let repository = JSONProjectCatalogRepository(directoryURL: directory)
+        var seed = ProjectCatalog.defaultCatalog(now: Date(timeIntervalSince1970: 123))
+        seed.projects[0].name = "  My Project  "
+
+        let loaded = try await repository.load(seed: seed)
+        #expect(loaded.projects[0].name == "My Project")
+        let fileURL = directory.appendingPathComponent("projects.json")
+        #expect(FileManager.default.fileExists(atPath: fileURL.path))
+        let attributes = try FileManager.default.attributesOfItem(atPath: fileURL.path)
+        let permissions = attributes[.posixPermissions] as? NSNumber
+        #expect(permissions?.intValue == 0o600)
+    }
+
+    @Test("Save uses a stale-revision guard")
+    func staleRevisionGuard() async throws {
+        let directory = Self.temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let first = JSONProjectCatalogRepository(directoryURL: directory)
+        let second = JSONProjectCatalogRepository(directoryURL: directory)
+        let seed = ProjectCatalog.defaultCatalog()
+        let loaded = try await first.load(seed: seed)
+
+        var update = loaded
+        update.revision = 1
+        update.projects[0].name = "First Writer"
+        try await first.save(update, expectedRevision: 0)
+
+        var stale = loaded
+        stale.revision = 1
+        stale.projects[0].name = "Stale Writer"
+        await #expect(throws: ProjectCatalogRepositoryError.staleRevision(expected: 0, actual: 1)) {
+            try await second.save(stale, expectedRevision: 0)
+        }
+    }
+
+    @Test("Catalog symlinks are rejected without following their target")
+    func symlinkRejected() async throws {
+        let directory = Self.temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let target = directory.appendingPathComponent("target.json")
+        try Data("{}".utf8).write(to: target)
+        let link = directory.appendingPathComponent("projects.json")
+        try FileManager.default.createSymbolicLink(at: link, withDestinationURL: target)
+
+        let repository = JSONProjectCatalogRepository(directoryURL: directory)
+        await #expect(throws: ProjectCatalogRepositoryError.catalogIsSymbolicLink) {
+            try await repository.load(seed: .defaultCatalog())
+        }
+    }
+
+    @Test("Reset preserves the prior regular file as a recovery backup")
+    func resetCreatesRecoveryBackup() async throws {
+        let directory = Self.temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let fileURL = directory.appendingPathComponent("projects.json")
+        try Data("malformed".utf8).write(to: fileURL)
+
+        let repository = JSONProjectCatalogRepository(directoryURL: directory)
+        var reset = ProjectCatalog.defaultCatalog()
+        reset.revision = 1
+        _ = try await repository.reset(to: reset)
+
+        let names = try FileManager.default.contentsOfDirectory(atPath: directory.path)
+        #expect(names.contains(where: { $0.hasPrefix("projects.recovery-") }))
+        #expect(try await repository.load(seed: .defaultCatalog()).revision == 1)
+    }
+
+    @Test("Oversized regular catalogs fail before decoding")
+    func oversizedCatalogRejected() async throws {
+        let directory = Self.temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let fileURL = directory.appendingPathComponent("projects.json")
+        let descriptor = open(fileURL.path, O_CREAT | O_WRONLY, S_IRUSR | S_IWUSR)
+        #expect(descriptor >= 0)
+        defer {
+            if descriptor >= 0 {
+                close(descriptor)
+            }
+        }
+        #expect(ftruncate(descriptor, off_t(ProjectLimits.maximumCatalogBytes + 1)) == 0)
+
+        let repository = JSONProjectCatalogRepository(directoryURL: directory)
+        await #expect(throws: ProjectCatalogRepositoryError.catalogTooLarge(
+            limit: ProjectLimits.maximumCatalogBytes
+        )) {
+            try await repository.load(seed: .defaultCatalog())
+        }
+    }
+
+    // MARK: Private
+
+    private static func temporaryDirectory() -> URL {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent("project-repository-\(UUID().uuidString)", isDirectory: true)
+    }
+}

--- a/TracexyTests/Models/Projects/ProjectModelsTests.swift
+++ b/TracexyTests/Models/Projects/ProjectModelsTests.swift
@@ -1,0 +1,108 @@
+import Foundation
+import Testing
+@testable import Tracexy
+
+@Suite("Project catalog domain")
+struct ProjectModelsTests {
+    // MARK: Internal
+
+    @Test("Names normalize canonically and fold accents, width and case for uniqueness")
+    func unicodeNormalizationAndUniqueness() throws {
+        #expect(try ProjectNameNormalization.normalize("  Cafe\u{301}  ") == "Café")
+
+        let first = Self.project(name: "Résumé")
+        let second = Self.project(name: "ＲＥＳＵＭＥ")
+        let catalog = ProjectCatalog(projects: [first, second], activeProjectID: first.id)
+        #expect(throws: ProjectCatalogValidationError.self) {
+            _ = try catalog.normalizedValidated()
+        }
+    }
+
+    @Test("Unsafe Unicode format controls are rejected while join controls remain valid")
+    func unsafeUnicodeIsRejected() throws {
+        #expect(throws: ProjectNameNormalizationError.containsControlCharacter) {
+            _ = try ProjectNameNormalization.normalize("Visible\u{202E}hidden")
+        }
+        #expect(try ProjectNameNormalization.normalize("می\u{200C}روم") == "می\u{200C}روم")
+    }
+
+    @Test("Workspace configuration round-trips without selection or investigation state")
+    @MainActor
+    func workspaceRoundTripExcludesEphemeralState() {
+        let workspace = WorkspaceState(title: "DNS Review")
+        workspace.navigatorMode = .focus
+        workspace.sidebarSelection = .dns
+        workspace.inspectorLayout = .bottom
+        workspace.contextDockTab = .aiAssistant
+        workspace.sessionGrouping = .host
+        workspace.filterText = "example.test"
+        workspace.categoryFilters = [.dns, .errors]
+        workspace.filterRules = [
+            SessionFilterRule(field: .host, filterOperator: .contains, value: "example"),
+        ]
+        workspace.selectedSessionID = UUID()
+        workspace.acceptedInvestigationDraft = InvestigationQueryDraft()
+
+        let snapshot = ProjectWorkspaceSnapshot(capturing: workspace)
+        let restored = snapshot.hydrateWorkspaceState(
+            maxFilterRules: 64,
+            allowsAutomaticInspectorReveal: false
+        )
+
+        #expect(restored.id == workspace.id)
+        #expect(restored.navigatorMode == .focus)
+        #expect(restored.sidebarSelection == .dns)
+        #expect(restored.inspectorLayout == .bottom)
+        #expect(restored.contextDockTab == .aiAssistant)
+        #expect(restored.sessionGrouping == .host)
+        #expect(restored.categoryFilters == [.dns, .errors])
+        #expect(restored.selectedSessionID == nil)
+        #expect(restored.acceptedInvestigationDraft == nil)
+    }
+
+    @Test("Unknown raw discriminators hydrate with conservative UI fallbacks")
+    @MainActor
+    func unknownRawValuesFallBackSafely() {
+        let snapshot = ProjectWorkspaceSnapshot(
+            title: "Imported",
+            sidebarSelection: "future-view",
+            navigatorMode: "future-mode",
+            inspectorTab: "future-tab",
+            inspectorLayout: "future-layout",
+            contextDockTab: "future-dock",
+            sessionGrouping: "future-grouping",
+            searchField: "future-field",
+            categoryFilters: ["dns", "future-category"],
+            filterRules: [
+                ProjectFilterRuleSnapshot(
+                    connector: "future-connector",
+                    field: "future-rule-field",
+                    filterOperator: "future-operator",
+                    value: "kept"
+                ),
+            ]
+        )
+        let workspace = snapshot.hydrateWorkspaceState(
+            maxFilterRules: 64,
+            allowsAutomaticInspectorReveal: nil
+        )
+        #expect(workspace.sidebarSelection == .sessions)
+        #expect(workspace.navigatorMode == .browse)
+        #expect(workspace.inspectorTab == .timeline)
+        #expect(workspace.inspectorLayout == .hidden)
+        #expect(workspace.contextDockTab == .details)
+        #expect(workspace.sessionGrouping == .none)
+        #expect(workspace.searchField == .allFields)
+        #expect(workspace.categoryFilters == [.dns])
+        #expect(workspace.filterRules[0].connector == .and)
+        #expect(workspace.filterRules[0].field == .host)
+        #expect(workspace.filterRules[0].filterOperator == .contains)
+    }
+
+    // MARK: Private
+
+    private static func project(name: String) -> Project {
+        let workspace = ProjectWorkspaceSnapshot(title: "Live", isClosable: false)
+        return Project(name: name, workspaces: [workspace], activeWorkspaceID: workspace.id)
+    }
+}

--- a/TracexyTests/Models/Projects/ProjectStoreTests.swift
+++ b/TracexyTests/Models/Projects/ProjectStoreTests.swift
@@ -1,0 +1,98 @@
+import Foundation
+import Testing
+@testable import Tracexy
+
+@Suite("ProjectStore")
+@MainActor
+struct ProjectStoreTests {
+    // MARK: Internal
+
+    @Test("Create, select, rename and delete keep one active bounded catalog")
+    func mutations() throws {
+        let store = ProjectStore(maxProjects: 3, maxWorkspacesPerProject: 2)
+        let originalID = store.activeProjectID
+        let created = try store.createProject(name: "  Research  ")
+        #expect(store.activeProjectID == created.id)
+        #expect(created.name == "Research")
+
+        try store.renameProject(id: created.id, to: "Audit")
+        #expect(store.activeProject.name == "Audit")
+        try store.selectProject(id: originalID)
+        try store.deleteProject(id: created.id)
+        #expect(store.projects.count == 1)
+        #expect(store.activeProjectID == originalID)
+        #expect(throws: ProjectMutationError.cannotDeleteFinalProject) {
+            try store.deleteProject(id: originalID)
+        }
+    }
+
+    @Test("Folded duplicate names and project capacity fail typed")
+    func duplicateAndCapacity() throws {
+        let store = ProjectStore(maxProjects: 2, maxWorkspacesPerProject: 2)
+        _ = try store.createProject(name: "Résumé")
+        #expect(throws: ProjectMutationError.duplicateName) {
+            try store.renameProject(id: store.projects[0].id, to: "RESUME")
+        }
+        #expect(throws: ProjectMutationError.capacityReached(limit: 2)) {
+            try store.createProject(name: "Third")
+        }
+    }
+
+    @Test("Workspace replacement enforces the injected and structural bounds")
+    func workspaceBounds() throws {
+        let store = ProjectStore(maxProjects: 2, maxWorkspacesPerProject: 2)
+        let workspaces = (0 ..< 3).map { ProjectWorkspaceSnapshot(title: "Tab \($0)") }
+        #expect(throws: ProjectMutationError.workspaceCapacityReached(limit: 2)) {
+            try store.updateActiveProjectWorkspaces(workspaces, activeWorkspaceID: workspaces[0].id)
+        }
+    }
+
+    @Test("Disk-backed mutations serialize and survive a reopen")
+    func persistenceRoundTrip() async throws {
+        let directory = Self.temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let repository = JSONProjectCatalogRepository(directoryURL: directory)
+        let store = ProjectStore(
+            maxProjects: 4,
+            maxWorkspacesPerProject: 4,
+            repository: repository
+        )
+        await store.loadPersistedCatalog()
+        let created = try store.createProject(name: "Persisted")
+        await store.waitForPendingPersistence()
+        #expect(store.persistenceState == .saved)
+
+        let reopened = ProjectStore(
+            maxProjects: 4,
+            maxWorkspacesPerProject: 4,
+            repository: JSONProjectCatalogRepository(directoryURL: directory)
+        )
+        await reopened.loadPersistedCatalog()
+        #expect(reopened.projects.contains(where: { $0.id == created.id }))
+        #expect(reopened.activeProjectID == created.id)
+    }
+
+    @Test("Import always regenerates identities and activates without overwriting")
+    func importRegeneratesIdentities() throws {
+        let store = ProjectStore(maxProjects: 4, maxWorkspacesPerProject: 4)
+        let workspace = ProjectWorkspaceSnapshot(title: "Imported Tab")
+        let source = Project(
+            id: store.activeProjectID,
+            name: "Imported",
+            workspaces: [workspace],
+            activeWorkspaceID: workspace.id
+        )
+        let imported = try store.importProject(source)
+        #expect(imported.id != source.id)
+        #expect(imported.workspaces[0].id != workspace.id)
+        #expect(store.activeProjectID == imported.id)
+        #expect(store.projects.count == 2)
+    }
+
+    // MARK: Private
+
+    private static func temporaryDirectory() -> URL {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent("project-store-\(UUID().uuidString)", isDirectory: true)
+    }
+}

--- a/TracexyTests/Models/Settings/AppPolicyTests.swift
+++ b/TracexyTests/Models/Settings/AppPolicyTests.swift
@@ -7,6 +7,7 @@ import Testing
 /// A policy built per-test, so a test states its own limits instead of
 /// inheriting whatever the shipping baseline happens to be today.
 private struct TestPolicy: AppPolicy {
+    var maxProjects = 3
     var maxWorkspaceTabs = 8
     var maxFocusSets = 5
     var maxPinnedHosts = 5
@@ -17,6 +18,11 @@ private struct TestPolicy: AppPolicy {
 
 @Suite("App policy defaults")
 struct AppPolicyDefaultsTests {
+    @Test("The shipping baseline caps local projects at three")
+    func defaultProjectCap() {
+        #expect(DefaultAppPolicy().maxProjects == 3)
+    }
+
     @Test("The shipping baseline caps advanced filter rules at 12")
     func defaultSessionFilterRuleCap() {
         #expect(DefaultAppPolicy().maxSessionFilterRules == 12)
@@ -122,8 +128,9 @@ struct WorkspaceStorePolicyTests {
 struct CoordinatorPolicyTests {
     @Test("The injected policy decides the tab cap and the focus gate's limits")
     func injectedPolicyIsPlumbedThrough() {
-        let policy = TestPolicy(maxWorkspaceTabs: 2, maxFocusSets: 1, maxPinnedHosts: 4)
+        let policy = TestPolicy(maxProjects: 2, maxWorkspaceTabs: 2, maxFocusSets: 1, maxPinnedHosts: 4)
         let coordinator = MainContentCoordinator(policy: policy)
+        #expect(coordinator.projectStore.maxProjects == 2)
         #expect(coordinator.workspaces.maxWorkspaces == 2)
         #expect(coordinator.focusGate.maxFocusSets == 1)
         #expect(coordinator.focusGate.maxPinnedHosts == 4)

--- a/TracexyTests/Models/Settings/AppPolicyTests.swift
+++ b/TracexyTests/Models/Settings/AppPolicyTests.swift
@@ -137,24 +137,21 @@ struct CoordinatorPolicyTests {
     }
 
     @Test("Saving past the focus-set cap changes nothing and says why")
-    func refusedSaveIsExplained() {
-        // Focus sets persist to the app's shared defaults, so the cap is set
-        // relative to whatever is already stored and the additions are undone
-        // afterwards. Otherwise running the suite would leave sets behind.
-        let coordinator = MainContentCoordinator(policy: TestPolicy())
-        let stored = coordinator.focusSets.count
-        let capped = MainContentCoordinator(policy: TestPolicy(maxFocusSets: stored + 1))
+    func refusedSaveIsExplained() async {
+        let environment = ProjectIsolationEnvironment(name: "focus-cap")
+        defer { environment.tearDown() }
+        let capped = environment.makeCoordinator(policy: TestPolicy(maxFocusSets: 1))
+        await capped.hydrateProjectsOnLaunch()
 
         let accepted = FocusSet(name: "accepted", rules: [])
         let refused = FocusSet(name: "refused", rules: [])
-        defer { capped.deleteFocusSet(accepted) }
 
         capped.saveFocusSet(accepted)
-        #expect(capped.focusSets.count == stored + 1)
+        #expect(capped.focusSets.count == 1)
         #expect(capped.policyNotice == nil)
 
         capped.saveFocusSet(refused)
-        #expect(capped.focusSets.count == stored + 1)
+        #expect(capped.focusSets.count == 1)
         #expect(!capped.focusSets.contains { $0.id == refused.id })
         #expect(capped.policyNotice != nil)
         #expect(!capped.canAddFocusSet)

--- a/TracexyTests/Support/ProjectIsolationEnvironment.swift
+++ b/TracexyTests/Support/ProjectIsolationEnvironment.swift
@@ -1,0 +1,195 @@
+import Foundation
+@testable import Tracexy
+
+// MARK: - RecordingProjectDataProvider
+
+/// A test provider that roots every Project's History database, capture Library,
+/// live spool and preferences suite inside one throwaway directory / defaults
+/// namespace, and records what it handed out so a test can tear all of it down.
+///
+/// It can also be told to refuse a Project's settings suite, which is how the
+/// "storage failure stays fail-closed" behavior is exercised without corrupting a
+/// real defaults domain.
+@MainActor
+final class RecordingProjectDataProvider: ProjectDataProviding {
+    // MARK: Lifecycle
+
+    init(root: URL, suitePrefix: String) {
+        self.root = root
+        self.suitePrefix = suitePrefix
+        base = DefaultProjectDataProvider(
+            applicationSupportRoot: root.appendingPathComponent("Support", isDirectory: true),
+            cacheRoot: root.appendingPathComponent("Caches", isDirectory: true),
+            settingsSuitePrefix: suitePrefix,
+            // Never read the developer's real preferences while seeding.
+            legacySettingsSource: nil
+        )
+    }
+
+    // MARK: Internal
+
+    let root: URL
+    let suitePrefix: String
+
+    /// Projects whose settings suite construction must fail.
+    var failingSettingsProjectIDs: Set<UUID> = []
+    /// When true, any Project that has not already been issued a suite is refused.
+    var failsSettingsForNewProjects = false
+    private(set) var issuedSuiteNames: Set<String> = []
+    private(set) var issuedLocations: [UUID: ProjectDataLocation] = [:]
+
+    func location(forProject projectID: UUID, isLegacyOwner: Bool) -> ProjectDataLocation {
+        let location = base.location(forProject: projectID, isLegacyOwner: isLegacyOwner)
+        issuedLocations[projectID] = location
+        return location
+    }
+
+    func makeSessionStore(at location: ProjectDataLocation) async -> HistoryStoreFactory.Outcome {
+        await base.makeSessionStore(at: location)
+    }
+
+    func makeLiveCaptureSpool(at location: ProjectDataLocation) -> LiveCaptureSpool {
+        base.makeLiveCaptureSpool(at: location)
+    }
+
+    func makeSettingsDefaults(at location: ProjectDataLocation) -> UserDefaults? {
+        guard !failingSettingsProjectIDs.contains(location.projectID) else {
+            return nil
+        }
+        guard !failsSettingsForNewProjects
+            || issuedSuiteNames.contains(location.settingsSuiteName) else
+        {
+            return nil
+        }
+        guard let defaults = base.makeSettingsDefaults(at: location) else {
+            return nil
+        }
+        issuedSuiteNames.insert(location.settingsSuiteName)
+        return defaults
+    }
+
+    func prepareCapturesDirectory(at location: ProjectDataLocation) async -> URL? {
+        await base.prepareCapturesDirectory(at: location)
+    }
+
+    // MARK: Private
+
+    private let base: DefaultProjectDataProvider
+}
+
+// MARK: - ControllableCatalogRepositoryError
+
+nonisolated enum ControllableCatalogRepositoryError: Error, Equatable {
+    case saveRefused
+}
+
+// MARK: - ControllableProjectCatalogRepository
+
+/// An in-memory catalog repository whose durable write can be refused on demand,
+/// so a catalog-save failure is exercised without touching or corrupting a file.
+///
+/// The refusal is keyed on the candidate's shape rather than on a call count, so a
+/// test can fail exactly the transition's own write and leave the preceding
+/// workspace flush alone.
+actor ControllableProjectCatalogRepository: ProjectCatalogPersisting {
+    // MARK: Lifecycle
+
+    init(refusingSaveWithProjectCount: Int? = nil) {
+        refusedProjectCount = refusingSaveWithProjectCount
+    }
+
+    // MARK: Internal
+
+    private(set) var savedCatalog: ProjectCatalog?
+    private(set) var refusedSaveCount = 0
+
+    func refuseSaveWithProjectCount(_ count: Int?) {
+        refusedProjectCount = count
+    }
+
+    func load(seed: ProjectCatalog) async throws -> ProjectCatalog {
+        savedCatalog ?? seed
+    }
+
+    func save(_ catalog: ProjectCatalog, expectedRevision _: UInt64) async throws {
+        if let refusedProjectCount, catalog.projects.count == refusedProjectCount {
+            refusedSaveCount += 1
+            throw ControllableCatalogRepositoryError.saveRefused
+        }
+        savedCatalog = catalog
+    }
+
+    func reset(to catalog: ProjectCatalog) async throws -> ProjectCatalog {
+        savedCatalog = catalog
+        return catalog
+    }
+
+    // MARK: Private
+
+    private var refusedProjectCount: Int?
+}
+
+// MARK: - ProjectIsolationEnvironment
+
+/// One isolated Projects world for a test: a temporary storage root, a throwaway
+/// defaults namespace, and (optionally) a real on-disk catalog so "relaunch"
+/// behavior can be exercised.
+@MainActor
+final class ProjectIsolationEnvironment {
+    // MARK: Lifecycle
+
+    init(name: String = "projects", persistsCatalog: Bool = false) {
+        let token = UUID().uuidString
+        root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tracexy-\(name)-\(token)", isDirectory: true)
+        suitePrefix = "com.amunx.tracexy.tests.\(token)"
+        bootSuiteName = "\(suitePrefix).boot"
+        self.persistsCatalog = persistsCatalog
+        provider = RecordingProjectDataProvider(root: root, suitePrefix: suitePrefix)
+    }
+
+    // MARK: Internal
+
+    let root: URL
+    let suitePrefix: String
+    let bootSuiteName: String
+    let provider: RecordingProjectDataProvider
+
+    /// Overrides catalog persistence for this environment. Set it before calling
+    /// ``makeCoordinator(policy:)`` to exercise a write that fails.
+    var catalogRepository: (any ProjectCatalogPersisting)?
+
+    var catalogDirectory: URL {
+        root.appendingPathComponent("Catalog", isDirectory: true)
+    }
+
+    /// Build a coordinator whose every storage and preference reference lives
+    /// inside this environment. Nothing here can reach a production path or the
+    /// shared defaults domain.
+    func makeCoordinator(policy: (any AppPolicy)? = nil) -> MainContentCoordinator {
+        let repository: (any ProjectCatalogPersisting)? = catalogRepository
+            ?? (persistsCatalog ? JSONProjectCatalogRepository(directoryURL: catalogDirectory) : nil)
+        let bootDefaults = UserDefaults(suiteName: bootSuiteName)
+        let coordinator = MainContentCoordinator(
+            policy: policy,
+            projectRepository: repository,
+            projectDataProvider: provider,
+            settingsDefaults: bootDefaults
+        )
+        coordinator.projectTransitionDrainTimeout = .milliseconds(200)
+        return coordinator
+    }
+
+    /// Remove every defaults suite and temporary file this environment created.
+    func tearDown() {
+        for name in provider.issuedSuiteNames {
+            UserDefaults.standard.removePersistentDomain(forName: name)
+        }
+        UserDefaults.standard.removePersistentDomain(forName: bootSuiteName)
+        try? FileManager.default.removeItem(at: root)
+    }
+
+    // MARK: Private
+
+    private let persistsCatalog: Bool
+}

--- a/TracexyTests/ViewModels/EvidenceNavigationActivationTests.swift
+++ b/TracexyTests/ViewModels/EvidenceNavigationActivationTests.swift
@@ -16,7 +16,7 @@ struct EvidenceNavigationActivationTests {
 
     @Test("Selecting a session publishes its projection; a new selection supersedes it")
     func projectionPublishesAndSupersedes() async throws {
-        let environment = try makeEnvironment()
+        let environment = try await makeEnvironment()
         defer { environment.teardown() }
         let coordinator = environment.coordinator
         try await openConnectionCapture(coordinator, in: environment.directory)
@@ -36,7 +36,7 @@ struct EvidenceNavigationActivationTests {
 
     @Test("A late projection cannot publish across a session/workspace/generation guard")
     func projectionGuardsRejectStalePublication() async throws {
-        let environment = try makeEnvironment()
+        let environment = try await makeEnvironment()
         defer { environment.teardown() }
         let coordinator = environment.coordinator
         try await openConnectionCapture(coordinator, in: environment.directory)
@@ -69,7 +69,7 @@ struct EvidenceNavigationActivationTests {
 
     @Test("A saved cited frame reads and decodes exactly the cited bytes")
     func savedCitedFrameSucceeds() async throws {
-        let environment = try makeEnvironment()
+        let environment = try await makeEnvironment()
         defer { environment.teardown() }
         let coordinator = environment.coordinator
         try await openConnectionCapture(coordinator, in: environment.directory)
@@ -92,7 +92,7 @@ struct EvidenceNavigationActivationTests {
 
     @Test("A forged source token fails the saved cited-frame read with neutral copy")
     func savedCitedFrameWrongTokenFails() async throws {
-        let environment = try makeEnvironment()
+        let environment = try await makeEnvironment()
         defer { environment.teardown() }
         let coordinator = environment.coordinator
         try await openConnectionCapture(coordinator, in: environment.directory)
@@ -116,7 +116,7 @@ struct EvidenceNavigationActivationTests {
 
     @Test("A nil locator is an explicit unavailable state and triggers no read")
     func nilLocatorIsUnavailable() async throws {
-        let environment = try makeEnvironment()
+        let environment = try await makeEnvironment()
         defer { environment.teardown() }
         let coordinator = environment.coordinator
         try await openConnectionCapture(coordinator, in: environment.directory)
@@ -133,7 +133,7 @@ struct EvidenceNavigationActivationTests {
 
     @Test("A current-epoch active-live spool read resolves exactly one frame")
     func liveCitedFrameSucceeds() async throws {
-        let environment = try makeEnvironment()
+        let environment = try await makeEnvironment()
         defer { environment.teardown() }
         let coordinator = environment.coordinator
         let frames = ReplayCorpus.tcpConnectionCapturedFrames()
@@ -167,7 +167,7 @@ struct EvidenceNavigationActivationTests {
 
     @Test("A stopped-live generation still resolves a citation from its finalized spool")
     func stoppedLiveCitedFrameSucceeds() async throws {
-        let environment = try makeEnvironment()
+        let environment = try await makeEnvironment()
         defer { environment.teardown() }
         let coordinator = environment.coordinator
         let frames = ReplayCorpus.tcpConnectionCapturedFrames()
@@ -203,7 +203,7 @@ struct EvidenceNavigationActivationTests {
 
     @Test("A locator from a superseded live spool fails without reading another frame")
     func liveCitedFrameStaleSourceFails() async throws {
-        let environment = try makeEnvironment()
+        let environment = try await makeEnvironment()
         defer { environment.teardown() }
         let coordinator = environment.coordinator
         let frames = ReplayCorpus.tcpConnectionCapturedFrames()
@@ -239,7 +239,7 @@ struct EvidenceNavigationActivationTests {
 
     @Test("Selection and capture boundaries retire the cited frame and projection")
     func boundariesRetireEvidenceNavigation() async throws {
-        let environment = try makeEnvironment()
+        let environment = try await makeEnvironment()
         defer { environment.teardown() }
         let coordinator = environment.coordinator
         try await openConnectionCapture(coordinator, in: environment.directory)
@@ -305,19 +305,14 @@ struct EvidenceNavigationActivationTests {
         )
     }
 
-    private func makeEnvironment(function: String = #function) throws -> Environment {
-        let suiteName = "com.amunx.tracexy.evidence-nav.\(function).\(UUID().uuidString)"
-        let defaults = try #require(UserDefaults(suiteName: suiteName))
-        let directory = URL(fileURLWithPath: NSTemporaryDirectory())
-            .appendingPathComponent("tracexy-evidence-nav-\(UUID().uuidString)", isDirectory: true)
+    private func makeEnvironment(function: String = #function) async throws -> Environment {
+        let isolation = ProjectIsolationEnvironment(name: function)
+        let coordinator = isolation.makeCoordinator()
+        await coordinator.hydrateProjectsOnLaunch()
+        let directory = isolation.root.appendingPathComponent("Fixtures", isDirectory: true)
         try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
-        let coordinator = MainContentCoordinator(
-            layoutPreferences: WorkspaceLayoutPreferences(defaults: defaults),
-            liveCaptureSpool: LiveCaptureSpool(directory: directory.appendingPathComponent("spool"))
-        )
         return Environment(coordinator: coordinator, directory: directory) {
-            defaults.removePersistentDomain(forName: suiteName)
-            try? FileManager.default.removeItem(at: directory)
+            isolation.tearDown()
         }
     }
 

--- a/TracexyTests/ViewModels/FollowStreamActivationTests.swift
+++ b/TracexyTests/ViewModels/FollowStreamActivationTests.swift
@@ -9,7 +9,7 @@ struct FollowStreamActivationTests {
 
     @Test("Saved capture follows the selected TCP tuple from its identity-checked source")
     func savedCaptureActivation() async throws {
-        let environment = try makeEnvironment()
+        let environment = try await makeEnvironment()
         defer { environment.teardown() }
         let frames = ReplayCorpus.tcpConnectionCapturedFrames()
         let capture = try writeCapture(named: "saved-follow", frames: frames, in: environment.directory)
@@ -38,7 +38,7 @@ struct FollowStreamActivationTests {
 
     @Test("Stopped live capture copies a finalized spool before following")
     func stoppedLiveActivation() async throws {
-        let environment = try makeEnvironment()
+        let environment = try await makeEnvironment()
         defer { environment.teardown() }
         let coordinator = environment.coordinator
         let frames = ReplayCorpus.tcpConnectionCapturedFrames()
@@ -81,7 +81,7 @@ struct FollowStreamActivationTests {
 
     @Test("Active capture rejects Follow Stream without scanning the growing spool")
     func activeCaptureIsUnavailable() async throws {
-        let environment = try makeEnvironment()
+        let environment = try await makeEnvironment()
         defer { environment.teardown() }
         let coordinator = environment.coordinator
         let frames = ReplayCorpus.tcpConnectionCapturedFrames()
@@ -104,7 +104,7 @@ struct FollowStreamActivationTests {
 
     @Test("Selection change retires previously loaded raw stream bytes")
     func selectionChangeClearsResult() async throws {
-        let environment = try makeEnvironment()
+        let environment = try await makeEnvironment()
         defer { environment.teardown() }
         let coordinator = environment.coordinator
         let frames = ReplayCorpus.tcpConnectionCapturedFrames()
@@ -137,18 +137,14 @@ struct FollowStreamActivationTests {
         let teardown: () -> Void
     }
 
-    private func makeEnvironment(function: String = #function) throws -> Environment {
-        let suiteName = "com.amunx.tracexy.follow-stream.\(function).\(UUID().uuidString)"
-        let defaults = try #require(UserDefaults(suiteName: suiteName))
-        let directory = URL(fileURLWithPath: NSTemporaryDirectory())
-            .appendingPathComponent("tracexy-follow-stream-\(UUID().uuidString)", isDirectory: true)
+    private func makeEnvironment(function: String = #function) async throws -> Environment {
+        let isolation = ProjectIsolationEnvironment(name: function)
+        let coordinator = isolation.makeCoordinator()
+        await coordinator.hydrateProjectsOnLaunch()
+        let directory = isolation.root.appendingPathComponent("Fixtures", isDirectory: true)
         try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
-        let coordinator = MainContentCoordinator(
-            layoutPreferences: WorkspaceLayoutPreferences(defaults: defaults)
-        )
         return Environment(coordinator: coordinator, directory: directory) {
-            defaults.removePersistentDomain(forName: suiteName)
-            try? FileManager.default.removeItem(at: directory)
+            isolation.tearDown()
         }
     }
 

--- a/TracexyTests/ViewModels/HistoryIntegrationTests.swift
+++ b/TracexyTests/ViewModels/HistoryIntegrationTests.swift
@@ -340,7 +340,7 @@ struct HistoryIntegrationTests {
 
     @Test("Opening a saved capture persists exactly one saved, complete capture")
     func savedTerminalMapping() async throws {
-        let environment = try Self.makeSavedEnvironment()
+        let environment = try await Self.makeSavedEnvironment()
         defer { environment.teardown() }
         let frames = ReplayCorpus.tcpConnectionCapturedFrames()
         let capture = try Self.writeCapture(named: "saved", frames: frames, in: environment.directory)
@@ -358,7 +358,7 @@ struct HistoryIntegrationTests {
 
     @Test("Reopening the same file is a distinct History event")
     func reopenIsDistinctEvent() async throws {
-        let environment = try Self.makeSavedEnvironment()
+        let environment = try await Self.makeSavedEnvironment()
         defer { environment.teardown() }
         let frames = ReplayCorpus.tcpConnectionCapturedFrames()
         let capture = try Self.writeCapture(named: "reopen", frames: frames, in: environment.directory)
@@ -378,7 +378,7 @@ struct HistoryIntegrationTests {
 
     @Test("A truncated tail maps to incomplete completeness")
     func savedTruncatedCompleteness() async throws {
-        let environment = try Self.makeSavedEnvironment()
+        let environment = try await Self.makeSavedEnvironment()
         defer { environment.teardown() }
         let frames = ReplayCorpus.tcpConnectionCapturedFrames()
         let capture = try Self.writeCapture(named: "truncated", frames: frames, in: environment.directory)
@@ -399,7 +399,7 @@ struct HistoryIntegrationTests {
 
     @Test("An empty saved capture uses the finite deterministic fallback instant")
     func emptySavedFallback() async throws {
-        let environment = try Self.makeSavedEnvironment()
+        let environment = try await Self.makeSavedEnvironment()
         defer { environment.teardown() }
         let capture = try Self.writeCapture(named: "empty", frames: [], in: environment.directory)
 
@@ -618,20 +618,15 @@ struct HistoryIntegrationTests {
         await coordinator.waitForHistory()
     }
 
-    private static func makeSavedEnvironment(function: String = #function) throws -> SavedEnvironment {
-        let suiteName = "com.amunx.tracexy.history.\(function).\(UUID().uuidString)"
-        let defaults = try #require(UserDefaults(suiteName: suiteName))
-        let directory = URL(fileURLWithPath: NSTemporaryDirectory())
-            .appendingPathComponent("tracexy-history-\(UUID().uuidString)", isDirectory: true)
+    private static func makeSavedEnvironment(function: String = #function) async throws -> SavedEnvironment {
+        let isolation = ProjectIsolationEnvironment(name: function)
+        let coordinator = isolation.makeCoordinator()
+        await coordinator.hydrateProjectsOnLaunch()
+        let store = try #require(coordinator.sessionStore)
+        let directory = isolation.root.appendingPathComponent("Fixtures", isDirectory: true)
         try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
-        let store = try SessionStore()
-        let coordinator = MainContentCoordinator(
-            layoutPreferences: WorkspaceLayoutPreferences(defaults: defaults),
-            sessionStore: store
-        )
         return SavedEnvironment(coordinator: coordinator, store: store, directory: directory) {
-            defaults.removePersistentDomain(forName: suiteName)
-            try? FileManager.default.removeItem(at: directory)
+            isolation.tearDown()
         }
     }
 

--- a/TracexyTests/ViewModels/InvestigationQueryActivationTests.swift
+++ b/TracexyTests/ViewModels/InvestigationQueryActivationTests.swift
@@ -157,11 +157,9 @@ struct InvestigationQueryActivationTests {
     }
 
     private func makeLoadedCoordinator(function: String = #function) async throws -> Environment {
-        let suiteName = "com.amunx.tracexy.query-tests.\(function).\(UUID().uuidString)"
-        let defaults = try #require(UserDefaults(suiteName: suiteName))
-        let coordinator = MainContentCoordinator(
-            layoutPreferences: WorkspaceLayoutPreferences(defaults: defaults)
-        )
+        let isolation = ProjectIsolationEnvironment(name: function)
+        let coordinator = isolation.makeCoordinator()
+        await coordinator.hydrateProjectsOnLaunch()
         let directory = URL(fileURLWithPath: NSTemporaryDirectory())
             .appendingPathComponent("tracexy-query-tests-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
@@ -176,7 +174,7 @@ struct InvestigationQueryActivationTests {
         try #require(!coordinator.sessions.isEmpty)
 
         return Environment(coordinator: coordinator) {
-            defaults.removePersistentDomain(forName: suiteName)
+            isolation.tearDown()
             try? FileManager.default.removeItem(at: directory)
         }
     }

--- a/TracexyTests/ViewModels/ProjectAdversarialFlowTests.swift
+++ b/TracexyTests/ViewModels/ProjectAdversarialFlowTests.swift
@@ -1,0 +1,397 @@
+import Foundation
+import Testing
+@testable import Tracexy
+
+// MARK: - AdversarialGate
+
+/// A deterministic continuation gate. It parks an asynchronous operation exactly
+/// where a competing action must be attempted, so every race in this suite is
+/// exercised by ordering rather than by sleeping.
+private actor AdversarialGate {
+    // MARK: Internal
+
+    func pause() async {
+        entered = true
+        entryWaiter?.resume()
+        entryWaiter = nil
+        await withCheckedContinuation { releaseWaiter = $0 }
+    }
+
+    func waitForEntry() async {
+        if !entered {
+            await withCheckedContinuation { entryWaiter = $0 }
+        }
+    }
+
+    func release() {
+        releaseWaiter?.resume()
+        releaseWaiter = nil
+    }
+
+    // MARK: Private
+
+    private var entered = false
+    private var entryWaiter: CheckedContinuation<Void, Never>?
+    private var releaseWaiter: CheckedContinuation<Void, Never>?
+}
+
+// MARK: - ProjectAdversarialFlowTests
+
+/// Adversarial Project/capture-source lifecycle flows: an accepted Save or export
+/// competing with Clear/Start/Open/Trash, a queued engine reset outliving the
+/// Project that owns its spool, a failed transition's selection-scoped evidence,
+/// and a real synthetic A → B → A → B round trip.
+///
+/// Every coordinator is built on an isolated storage root and defaults namespace,
+/// every capture is a real synthetic file, and no test installs a helper, touches
+/// the network, presents a panel, or sleeps for a race.
+@MainActor
+@Suite("Project adversarial flows")
+struct ProjectAdversarialFlowTests {
+    // MARK: Internal
+
+    @Test("An accepted save owns its source until it finishes")
+    func saveHoldFreezesDestructiveSourceMutations() async throws {
+        let environment = ProjectIsolationEnvironment(name: "adversarial-save-hold")
+        defer { environment.tearDown() }
+        let coordinator = environment.makeCoordinator()
+        await coordinator.hydrateProjectsOnLaunch()
+
+        let directory = try #require(coordinator.capturesDirectory())
+        let library = try Self.fixture(named: "library", frames: SampleCapture.frames(now: Self.epoch), in: directory)
+        coordinator.refreshSavedCaptures()
+
+        let frames = SampleCapture.frames(now: Self.epoch)
+        let spool = coordinator.liveCaptureSpool
+        try await spool.reset(epoch: coordinator.startGeneration)
+        _ = try await spool.append(frames, defaultLinkType: LinkType.ethernet, epoch: coordinator.startGeneration)
+        coordinator.retainedFrames.append(contentsOf: frames)
+        coordinator.sessions = SessionBuilder.build(from: frames, linkType: LinkType.ethernet)
+
+        let gate = AdversarialGate()
+        // Released on every exit path — including a failed expectation — so the
+        // save can always finish and the temporary storage can always be removed.
+        defer { let pending = gate
+            Task { await pending.release() }
+        }
+        coordinator.captureSaveOperation = CaptureSaveOperation { source, ownedSpool, destination in
+            await gate.pause()
+            try await CaptureSaveOperation.copy.run(source, ownedSpool, destination)
+        }
+        coordinator.saveCurrentCapture()
+        await gate.waitForEntry()
+        let save = coordinator.pendingCaptureIOTask
+        let generation = coordinator.startGeneration
+        let sessionIDs = coordinator.sessions.map(\.id)
+        #expect(coordinator.isCaptureSourceHeld)
+
+        // Start would mint a new generation and reset the very spool being copied.
+        #expect(coordinator.captureStartBlockedMessage != nil)
+        coordinator.startCapture()
+        #expect(!coordinator.isStarting)
+        #expect(coordinator.startGeneration == generation)
+        // Clear resets the same spool.
+        coordinator.clearSessions()
+        #expect(coordinator.sessions.map(\.id) == sessionIDs)
+        #expect(coordinator.startGeneration == generation)
+        // Adopting another saved capture resets it too.
+        coordinator.openSavedCapture(library)
+        #expect(!coordinator.isOpeningSavedCapture)
+        #expect(coordinator.captureError != nil)
+        // Trashing removes a Library file the save may be reading or writing beside.
+        #expect(throws: CaptureMutationError.self) { try coordinator.moveSavedCaptureToTrash(library) }
+        do {
+            try coordinator.moveSavedCaptureToTrash(library)
+            Issue.record("A busy source must not be removed")
+        } catch {
+            #expect(error.localizedDescription == coordinator.captureSourceHoldMessage)
+        }
+        #expect(FileManager.default.fileExists(atPath: library.url.path))
+
+        await gate.release()
+        await save?.value
+
+        // The complete capture reached the Library, byte for byte.
+        #expect(!coordinator.isCaptureSourceHeld)
+        #expect(coordinator.captureStartBlockedMessage == nil)
+        #expect(coordinator.captureError == nil)
+        let saved = try #require(coordinator.savedCaptures.first { $0.name.hasPrefix("Capture ") })
+        let written = try CaptureFileReader.read(contentsOf: saved.url)
+        #expect(written.frames.map(\.bytes) == frames.map(\.bytes))
+        // The gate is gone, so the source is mutable again.
+        coordinator.clearSessions()
+        #expect(coordinator.sessions.isEmpty)
+        #expect(coordinator.startGeneration != generation)
+        await coordinator.ingestChain?.value
+    }
+
+    @Test("An in-flight export owns its source across the modal window, with no privacy bypass")
+    func exportHoldFreezesSourceMutationsWithoutPrivacyBypass() async throws {
+        let environment = ProjectIsolationEnvironment(name: "adversarial-export-hold")
+        defer { environment.tearDown() }
+        let coordinator = environment.makeCoordinator()
+        await coordinator.hydrateProjectsOnLaunch()
+
+        let directory = try #require(coordinator.capturesDirectory())
+        let frames = SampleCapture.frames(now: Self.epoch)
+        let library = try Self.fixture(named: "library", frames: frames, in: directory)
+        coordinator.refreshSavedCaptures()
+        coordinator.retainedFrames.append(contentsOf: frames)
+        coordinator.sessions = SessionBuilder.build(from: frames, linkType: LinkType.ethernet)
+        let generation = coordinator.startGeneration
+        let sessionIDs = coordinator.sessions.map(\.id)
+
+        // This is the exact hold `exportSession` now takes *before* it presents the
+        // raw-capture acknowledgement, so it covers that reentrant modal too. No
+        // panel or alert is presented here.
+        coordinator.setSessionExporting(true)
+        defer { coordinator.setSessionExporting(false) }
+        #expect(coordinator.isCaptureSourceHeld)
+        #expect(!coordinator.canExport())
+        #expect(coordinator.captureStartBlockedMessage != nil)
+        coordinator.startCapture()
+        #expect(!coordinator.isStarting)
+        #expect(coordinator.startGeneration == generation)
+        coordinator.clearSessions()
+        #expect(coordinator.sessions.map(\.id) == sessionIDs)
+        #expect(coordinator.startGeneration == generation)
+        coordinator.openSavedCapture(library)
+        #expect(!coordinator.isOpeningSavedCapture)
+        #expect(throws: CaptureMutationError.self) { try coordinator.moveSavedCaptureToTrash(library) }
+
+        // Holding the source earlier does not relax the acknowledgement itself: a
+        // protected configuration still refuses a raw format without confirmation.
+        let protected = SessionExportPrivacyPolicy(
+            redactPayloadBodies: true,
+            stripCredentials: true,
+            maskIPAddresses: true
+        )
+        #expect(MainContentCoordinator.resolvedExportPrivacyPolicy(
+            for: .pcap, configuredPrivacy: protected, didConfirmRawExport: false
+        ) == nil)
+        #expect(MainContentCoordinator.resolvedExportPrivacyPolicy(
+            for: .pcap, configuredPrivacy: protected, didConfirmRawExport: true
+        ) == SessionExportPrivacyPolicy.none)
+
+        coordinator.setSessionExporting(false)
+        #expect(!coordinator.isCaptureSourceHeld)
+        #expect(coordinator.captureStartBlockedMessage == nil)
+        await coordinator.ingestChain?.value
+    }
+
+    @Test("A queued engine reset that fails after a Project change reports into its own Project")
+    func queuedEngineResetCannotPublishIntoAnotherProject() async throws {
+        let environment = ProjectIsolationEnvironment(name: "adversarial-stale-reset")
+        defer { environment.tearDown() }
+        let coordinator = environment.makeCoordinator()
+        await coordinator.hydrateProjectsOnLaunch()
+        let projectA = coordinator.projectStore.activeProjectID
+
+        // A spool that cannot prepare a file: its directory's parent is a regular
+        // file, so `reset` fails deterministically without any timing.
+        try FileManager.default.createDirectory(at: environment.root, withIntermediateDirectories: true)
+        let blocker = environment.root.appendingPathComponent("blocked")
+        try Data([0]).write(to: blocker)
+        coordinator.liveCaptureSpool = LiveCaptureSpool(
+            directory: blocker.appendingPathComponent("Spool", isDirectory: true)
+        )
+
+        let gate = AdversarialGate()
+        defer { let pending = gate
+            Task { await pending.release() }
+        }
+        coordinator.ingestChain = Task { @MainActor in await gate.pause() }
+        coordinator.resetSessionEngineForSavedCapture(token: coordinator.startGeneration)
+        let queuedReset = coordinator.ingestChain
+        await gate.waitForEntry()
+
+        // The Project changes while the reset is still queued behind the gate.
+        let projectB = try #require(await Self.created(coordinator, named: "Bravo"))
+        #expect(coordinator.projectStore.activeProjectID == projectB.id)
+
+        await gate.release()
+        await queuedReset?.value
+        // The failure describes A's spool, so B — which is on screen — is untouched.
+        #expect(coordinator.captureError == nil)
+
+        #expect(await Self.switched(coordinator, to: projectA))
+        #expect(coordinator.captureError != nil)
+    }
+
+    @Test("A failed transition rebuilds the outgoing selection's evidence without losing its state")
+    func failedTransitionRebuildsSavedEvidenceForTheOutgoingSelection() async throws {
+        let environment = ProjectIsolationEnvironment(name: "adversarial-failed-evidence")
+        defer { environment.tearDown() }
+        let coordinator = environment.makeCoordinator()
+        await coordinator.hydrateProjectsOnLaunch()
+
+        let directory = try #require(coordinator.capturesDirectory())
+        let capture = try Self.fixture(named: "alpha", frames: SampleCapture.frames(now: Self.epoch), in: directory)
+        coordinator.refreshSavedCaptures()
+        coordinator.openSavedCapture(capture)
+        await coordinator.waitForSavedCaptureOpen()
+        await coordinator.waitForHistory()
+        await coordinator.ingestChain?.value
+
+        let selected = try #require(coordinator.sessions.first { coordinator.savedCaptureEvidence[$0.id] != nil })
+        coordinator.select(selected)
+        await coordinator.waitForSelectedSavedCaptureEvidence()
+        await coordinator.evidenceProjection.task?.value
+        let bytes = coordinator.evidenceBytes(for: selected)
+        #expect(!bytes.isEmpty)
+        #expect(coordinator.evidenceProjection.selection != nil)
+        let sessionIDs = coordinator.sessions.map(\.id)
+        let snapshotIDs = coordinator.investigationSnapshot.sessions.map(\.id)
+        coordinator.activeWorkspace.filterText = "handshake"
+
+        // The destination's private settings store cannot be opened, so the
+        // transition fails after the outgoing evidence work was already retired.
+        environment.provider.failsSettingsForNewProjects = true
+        #expect(coordinator.createProject(named: "Unavailable") != nil)
+        #expect(await !coordinator.waitForProjectTransition())
+        await coordinator.waitForSelectedSavedCaptureEvidence()
+        await coordinator.evidenceProjection.task?.value
+
+        #expect(coordinator.projectTransitionStatus.failureMessage != nil)
+        #expect(coordinator.activeWorkspace.selectedSessionID == selected.id)
+        #expect(coordinator.evidenceProjection.selection != nil)
+        #expect(coordinator.evidenceBytes(for: selected) == bytes)
+        // Nothing else about the still-active Project moved.
+        #expect(coordinator.sessions.map(\.id) == sessionIDs)
+        #expect(coordinator.investigationSnapshot.sessions.map(\.id) == snapshotIDs)
+        #expect(coordinator.isViewingSavedCapture)
+        #expect(coordinator.activeSavedCapture == capture)
+        #expect(coordinator.activeWorkspace.filterText == "handshake")
+        #expect(coordinator.historyCaptures.count == 1)
+    }
+
+    @Test("A real A → B → A → B flow keeps each Project's configuration, evidence and History its own")
+    func syntheticRoundTripKeepsEveryProjectIntact() async throws {
+        let environment = ProjectIsolationEnvironment(name: "adversarial-roundtrip")
+        defer { environment.tearDown() }
+        let coordinator = environment.makeCoordinator()
+        await coordinator.hydrateProjectsOnLaunch()
+
+        // Project A: a real synthetic capture, its own settings, spool and History.
+        let projectA = coordinator.projectStore.activeProjectID
+        let framesA = SampleCapture.frames(now: Self.epoch)
+        let directoryA = try #require(coordinator.capturesDirectory())
+        let captureA = try Self.fixture(named: "alpha", frames: framesA, in: directoryA)
+        let defaultsA = coordinator.activeProjectDefaults
+        defaultsA.set(CaptureFilterMode.custom.rawValue, forKey: SettingsKeys.captureFilterMode)
+        defaultsA.set("tcp port 443", forKey: SettingsKeys.bpfExpression)
+        defaultsA.set(true, forKey: SettingsKeys.maskIPs)
+        coordinator.refreshSavedCaptures()
+        coordinator.openSavedCapture(captureA)
+        await coordinator.waitForSavedCaptureOpen()
+        await coordinator.waitForHistory()
+        await coordinator.ingestChain?.value
+        let spoolA = coordinator.liveCaptureSpool
+        try await spoolA.reset(epoch: coordinator.startGeneration)
+        _ = try await spoolA.append(framesA, defaultLinkType: LinkType.ethernet, epoch: coordinator.startGeneration)
+        let selectedA = try #require(coordinator.sessions.first { coordinator.savedCaptureEvidence[$0.id] != nil })
+        coordinator.select(selectedA)
+        await coordinator.waitForSelectedSavedCaptureEvidence()
+        let bytesA = coordinator.evidenceBytes(for: selectedA)
+        let hostsA = Set(coordinator.sessions.map(\.host))
+        #expect(!bytesA.isEmpty)
+        #expect(coordinator.historyCaptures.count == 1)
+
+        // Project B: different bytes, different settings, its own everything.
+        let projectB = try #require(await Self.created(coordinator, named: "Bravo"))
+        #expect(coordinator.sessions.isEmpty)
+        #expect(coordinator.savedCaptures.isEmpty)
+        #expect(coordinator.liveCaptureSpool !== spoolA)
+        coordinator.refreshHistory()
+        await coordinator.waitForHistory()
+        #expect(coordinator.historyCaptures.isEmpty)
+
+        let framesB = Array(SampleCapture.frames(now: Self.epoch).prefix(3))
+        let directoryB = try #require(coordinator.capturesDirectory())
+        #expect(directoryB != directoryA)
+        let captureB = try Self.fixture(named: "bravo", frames: framesB, in: directoryB)
+        coordinator.activeProjectDefaults.set(20_000, forKey: SettingsKeys.retainPackets)
+        coordinator.refreshSavedCaptures()
+        coordinator.openSavedCapture(captureB)
+        await coordinator.waitForSavedCaptureOpen()
+        await coordinator.waitForHistory()
+        await coordinator.ingestChain?.value
+        let spoolB = coordinator.liveCaptureSpool
+        try await spoolB.reset(epoch: coordinator.startGeneration)
+        _ = try await spoolB.append(framesB, defaultLinkType: LinkType.ethernet, epoch: coordinator.startGeneration)
+        let hostsB = Set(coordinator.sessions.map(\.host))
+        #expect(hostsB != hostsA)
+        #expect(coordinator.historyCaptures.count == 1)
+
+        // Back to A: its configuration, selection, evidence bytes, Library, History
+        // and parked spool are exactly as they were, and nothing of B's is visible.
+        // Repeat the round trip to expose stale generations and state accumulating
+        // across several park/adopt cycles, not only a one-time initialization.
+        for _ in 0 ..< 12 {
+            #expect(await Self.switched(coordinator, to: projectA))
+            #expect(Set(coordinator.sessions.map(\.host)) == hostsA)
+            #expect(coordinator.isViewingSavedCapture)
+            #expect(coordinator.activeSavedCapture == captureA)
+            #expect(coordinator.activeWorkspace.selectedSessionID == selectedA.id)
+            #expect(coordinator.readinessCaptureConfiguration.bpf == "tcp port 443")
+            #expect(coordinator.readinessRetentionCapacity == CaptureSettingsResolver.defaultRetainPackets)
+            #expect(PrivacySettingsResolver.exportPolicy(defaults: coordinator.activeProjectDefaults).maskIPAddresses)
+            #expect(coordinator.savedCaptures.map(\.name) == ["alpha"])
+            #expect(coordinator.liveCaptureSpool === spoolA)
+            let parkedA = try await coordinator.liveCaptureSpool.capture()
+            #expect(parkedA.frames.map(\.bytes) == framesA.map(\.bytes))
+            await coordinator.evidenceProjection.task?.value
+            #expect(coordinator.evidenceProjection.selection != nil)
+            #expect(coordinator.evidenceBytes(for: selectedA) == bytesA)
+            coordinator.refreshHistory()
+            await coordinator.waitForHistory()
+            #expect(coordinator.historyCaptures.count == 1)
+
+            // And back to B: the same must hold from the other side.
+            #expect(await Self.switched(coordinator, to: projectB.id))
+            #expect(Set(coordinator.sessions.map(\.host)) == hostsB)
+            #expect(coordinator.activeSavedCapture == captureB)
+            #expect(coordinator.savedCaptures.map(\.name) == ["bravo"])
+            #expect(coordinator.readinessCaptureConfiguration.bpf == nil)
+            #expect(coordinator.readinessRetentionCapacity == 20_000)
+            #expect(!PrivacySettingsResolver.exportPolicy(defaults: coordinator.activeProjectDefaults).maskIPAddresses)
+            #expect(coordinator.liveCaptureSpool === spoolB)
+            let parkedB = try await coordinator.liveCaptureSpool.capture()
+            #expect(parkedB.frames.map(\.bytes) == framesB.map(\.bytes))
+            coordinator.refreshHistory()
+            await coordinator.waitForHistory()
+            #expect(coordinator.historyCaptures.count == 1)
+        }
+    }
+
+    // MARK: Private
+
+    private static let epoch = Date(timeIntervalSince1970: 1_700_000_000)
+
+    /// A real synthetic capture file inside the given Project's Library folder.
+    private static func fixture(named name: String, frames: [CapturedFrame], in directory: URL) throws -> SavedCapture {
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let url = directory.appendingPathComponent("\(name).pcap")
+        try PcapWriter.write(linkType: LinkType.ethernet, frames: frames, to: url)
+        let byteCount = try url.resourceValues(forKeys: [.fileSizeKey]).fileSize ?? 0
+        return SavedCapture(url: url, name: name, date: Date(), byteCount: byteCount)
+    }
+
+    /// Start a switch and await the durable completion the change requires.
+    private static func switched(_ coordinator: MainContentCoordinator, to id: UUID) async -> Bool {
+        guard coordinator.switchToProject(id: id) else {
+            return false
+        }
+        return await coordinator.waitForProjectTransition()
+    }
+
+    /// Start a creation and await its durable completion.
+    private static func created(_ coordinator: MainContentCoordinator, named name: String) async -> Project? {
+        guard let project = coordinator.createProject(named: name),
+              await coordinator.waitForProjectTransition() else
+        {
+            return nil
+        }
+        return project
+    }
+}

--- a/TracexyTests/ViewModels/ProjectAsyncBoundaryTests.swift
+++ b/TracexyTests/ViewModels/ProjectAsyncBoundaryTests.swift
@@ -1,0 +1,264 @@
+import Foundation
+import Testing
+@testable import Tracexy
+
+// MARK: - ProjectLoaderGate
+
+private actor ProjectLoaderGate {
+    // MARK: Internal
+
+    func pause() async {
+        entered = true
+        entryWaiter?.resume()
+        entryWaiter = nil
+        await withCheckedContinuation { releaseWaiter = $0 }
+    }
+
+    func waitForEntry() async {
+        if !entered {
+            await withCheckedContinuation { entryWaiter = $0 }
+        }
+    }
+
+    func release() {
+        releaseWaiter?.resume()
+        releaseWaiter = nil
+    }
+
+    // MARK: Private
+
+    private var entered = false
+    private var entryWaiter: CheckedContinuation<Void, Never>?
+    private var releaseWaiter: CheckedContinuation<Void, Never>?
+}
+
+// MARK: - ProjectOperationCounter
+
+private actor ProjectOperationCounter {
+    // MARK: Internal
+
+    func next() -> Int {
+        value += 1
+        return value
+    }
+
+    // MARK: Private
+
+    private var value = 0
+}
+
+// MARK: - ProjectAsyncBoundaryTests
+
+@MainActor
+@Suite("Project asynchronous boundaries")
+struct ProjectAsyncBoundaryTests {
+    // MARK: Internal
+
+    @Test("Two queued saves retain their final task and stay in the originating Library")
+    func queuedSavesStayOwnedUntilBothFinish() async throws {
+        let environment = ProjectIsolationEnvironment(name: "queued-saves")
+        defer { environment.tearDown() }
+        let coordinator = environment.makeCoordinator()
+        await coordinator.hydrateProjectsOnLaunch()
+        let capture = try fixture(in: environment)
+        coordinator.openSavedCapture(capture)
+        await coordinator.waitForSavedCaptureOpen()
+        await coordinator.waitForHistory()
+        let directoryA = try #require(coordinator.capturesDirectory())
+        let first = ProjectLoaderGate()
+        let second = ProjectLoaderGate()
+        let counter = ProjectOperationCounter()
+        coordinator.captureSaveOperation = CaptureSaveOperation { source, spool, destination in
+            if await counter.next() == 1 {
+                await first.pause()
+            } else {
+                await second.pause()
+            }
+            try await CaptureSaveOperation.copy.run(source, spool, destination)
+        }
+        coordinator.saveCurrentCapture()
+        await first.waitForEntry()
+        coordinator.saveCurrentCapture()
+        await first.release()
+        await second.waitForEntry()
+        // The first completion must not erase the handle of the second save.
+        #expect(coordinator.pendingCaptureIOTask != nil)
+        _ = coordinator.createProject(named: "Bravo")
+        #expect(coordinator.projectTransitionStatus.isPending)
+        await second.release()
+        #expect(await coordinator.waitForProjectTransition())
+        #expect(coordinator.pendingCaptureIOTask == nil)
+        #expect(coordinator.savedCaptures.isEmpty)
+        let saved = try FileManager.default.contentsOfDirectory(at: directoryA, includingPropertiesForKeys: nil)
+        #expect(saved.filter { $0.pathExtension == "pcap" }.count == 2)
+        for url in saved where url.pathExtension == "pcap" {
+            #expect(try Data(contentsOf: url) == Data(contentsOf: capture.url))
+        }
+    }
+
+    @Test("Reset prepares resources before discarding any Project runtime")
+    func resetFailurePreservesRuntimeAndSuccessRetiresOwnership() async throws {
+        let environment = ProjectIsolationEnvironment(name: "reset-preflight")
+        defer { environment.tearDown() }
+        let coordinator = environment.makeCoordinator()
+        await coordinator.hydrateProjectsOnLaunch()
+        let capture = try fixture(in: environment)
+        coordinator.openSavedCapture(capture)
+        await coordinator.waitForSavedCaptureOpen()
+        await coordinator.waitForHistory()
+        let original = coordinator.activeRuntime
+        let projectA = coordinator.projectStore.activeProjectID
+        let sessionIDs = coordinator.sessions.map(\.id)
+        environment.provider.failsSettingsForNewProjects = true
+        await coordinator.resetProjectCatalog()
+        #expect(coordinator.projectStore.activeProjectID == projectA)
+        #expect(coordinator.activeRuntime === original)
+        #expect(coordinator.sessions.map(\.id) == sessionIDs)
+        #expect(coordinator.projectTransitionStatus.failureMessage != nil)
+        environment.provider.failsSettingsForNewProjects = false
+        await coordinator.resetProjectCatalog()
+        #expect(coordinator.projectStore.activeProjectID != projectA)
+        #expect(coordinator.projectStore.legacyDataOwnerProjectID == projectA)
+        #expect(coordinator.sessions.isEmpty)
+        #expect(coordinator.activeRuntime !== original)
+        #expect(coordinator.sessionStore !== original.sessionStore)
+        #expect(FileManager.default.fileExists(atPath: capture.url.path))
+    }
+
+    @Test("A refused inactive deletion retains its runtime and does not stop the active capture")
+    func inactiveDeleteIsDurableWithoutStoppingCapture() async {
+        let environment = ProjectIsolationEnvironment(name: "inactive-delete")
+        defer { environment.tearDown() }
+        let repository = ControllableProjectCatalogRepository()
+        environment.catalogRepository = repository
+        let coordinator = environment.makeCoordinator()
+        await coordinator.hydrateProjectsOnLaunch()
+        let projectA = coordinator.projectStore.activeProjectID
+        let runtimeA = coordinator.activeRuntime
+        _ = coordinator.createProject(named: "Bravo")
+        #expect(await coordinator.waitForProjectTransition())
+        coordinator.isCapturing = true // State-only: no backend was started.
+        defer { coordinator.isCapturing = false }
+        await repository.refuseSaveWithProjectCount(1)
+        #expect(coordinator.deleteProject(id: projectA))
+        #expect(await !(coordinator.waitForProjectTransition()))
+        #expect(coordinator.projectStore.projects.contains { $0.id == projectA })
+        #expect(coordinator.projectRuntimes[projectA] === runtimeA)
+        #expect(coordinator.isCapturing)
+        #expect(coordinator.pendingProjectSwitchConfirmation == nil)
+        await repository.refuseSaveWithProjectCount(nil)
+        coordinator.retryProjectTransition()
+        #expect(await coordinator.waitForProjectTransition())
+        #expect(!coordinator.projectStore.projects.contains { $0.id == projectA })
+        #expect(coordinator.isCapturing)
+    }
+
+    @Test("A slow saved loader is retired before a Project transition can await storage")
+    func delayedLoaderCannotPublishAcrossProjects() async throws {
+        let environment = ProjectIsolationEnvironment(name: "delayed-loader")
+        defer { environment.tearDown() }
+        let coordinator = environment.makeCoordinator()
+        await coordinator.hydrateProjectsOnLaunch()
+        let capture = try fixture(in: environment)
+        let result = try await Task.detached {
+            try SavedCaptureStreamLoader(contentsOf: capture.url).load()
+        }.value
+        let gate = ProjectLoaderGate()
+        coordinator.savedCaptureLoadOperation = SavedCaptureLoadOperation { _, _, progress in
+            await gate.pause()
+            // Deliberately ignore cancellation and even send late progress.
+            // The coordinator must retire both callbacks, not trust the worker.
+            progress(result.finalProgress)
+            return result
+        }
+        coordinator.openSavedCapture(capture)
+        await gate.waitForEntry()
+        let oldLoad = coordinator.savedCaptureOpenTask
+        let oldRequest = coordinator.savedCaptureOpenRequestID
+        let projectA = coordinator.projectStore.activeProjectID
+        let projectB = coordinator.createProject(named: "Bravo")
+        #expect(projectB != nil)
+        #expect(!coordinator.isOpeningSavedCapture)
+        #expect(coordinator.savedCaptureOpenRequestID > oldRequest)
+        #expect(await coordinator.waitForProjectTransition())
+        await gate.release()
+        await oldLoad?.value
+        await coordinator.waitForHistory()
+        #expect(coordinator.projectStore.activeProjectID == projectB?.id)
+        #expect(coordinator.sessions.isEmpty)
+        #expect(coordinator.savedCaptureEvidence.isEmpty)
+        #expect(coordinator.activeSavedCapture == nil)
+        #expect(coordinator.savedCaptureOpenProgress == nil)
+        #expect(coordinator.historyCaptures.isEmpty)
+        #expect(coordinator.switchToProject(id: projectA))
+        #expect(await coordinator.waitForProjectTransition())
+        #expect(coordinator.sessions.isEmpty)
+    }
+
+    @Test("Saved open waits for the owed helper tail, not just the current ingest task")
+    func savedOpenWaitsForExactDrain() async throws {
+        let environment = ProjectIsolationEnvironment(name: "saved-drain")
+        defer { environment.tearDown() }
+        let coordinator = environment.makeCoordinator()
+        await coordinator.hydrateProjectsOnLaunch()
+        let capture = try fixture(in: environment)
+        let token = coordinator.startGeneration
+        coordinator.beginFinalCaptureDrain(stoppedToken: token)
+        coordinator.openSavedCapture(capture)
+        #expect(coordinator.isOpeningSavedCapture)
+        #expect(coordinator.savedCaptureBoundaryTask == nil)
+        #expect(coordinator.savedCaptureOpenTask == nil)
+        coordinator.completeFinalCaptureDrain(stoppedToken: token)
+        coordinator.resumePendingSavedCaptureOpenAfterLiveDrain()
+        await coordinator.waitForSavedCaptureOpen()
+        await coordinator.waitForHistory()
+        #expect(coordinator.activeSavedCapture == capture)
+        #expect(!coordinator.sessions.isEmpty)
+    }
+
+    @Test("An unconfirmed final drain fails the transition; explicit retry remains possible")
+    func failedDrainDoesNotActivateDestination() async {
+        let environment = ProjectIsolationEnvironment(name: "failed-drain")
+        defer { environment.tearDown() }
+        let coordinator = environment.makeCoordinator()
+        await coordinator.hydrateProjectsOnLaunch()
+        let projectA = coordinator.projectStore.activeProjectID
+        let token = coordinator.startGeneration
+        coordinator.beginFinalCaptureDrain(stoppedToken: token)
+        _ = coordinator.createProject(named: "Bravo")
+        coordinator.completeFinalCaptureDrain(stoppedToken: token, succeeded: false)
+        // A completion before the transition task registers its waiter must not
+        // disappear: the accepted operation remembers its failure outcome.
+        #expect(await !(coordinator.waitForProjectTransition()))
+        #expect(coordinator.projectStore.activeProjectID == projectA)
+        #expect(coordinator.projectStore.projects.count == 1)
+        coordinator.retryProjectTransition()
+        #expect(await coordinator.waitForProjectTransition())
+        #expect(coordinator.projectStore.activeProject.name == "Bravo")
+    }
+
+    @Test("A stale Library row cannot delete a capture owned by another Project")
+    func staleLibraryActionCannotCrossProjects() async throws {
+        let environment = ProjectIsolationEnvironment(name: "stale-library")
+        defer { environment.tearDown() }
+        let coordinator = environment.makeCoordinator()
+        await coordinator.hydrateProjectsOnLaunch()
+        let directory = try #require(coordinator.capturesDirectory())
+        let capture = try fixture(in: environment, directory: directory)
+        _ = coordinator.createProject(named: "Bravo")
+        #expect(await coordinator.waitForProjectTransition())
+        #expect(throws: CocoaError.self) { try coordinator.moveSavedCaptureToTrash(capture) }
+        #expect(FileManager.default.fileExists(atPath: capture.url.path))
+    }
+
+    // MARK: Private
+
+    private func fixture(in environment: ProjectIsolationEnvironment, directory: URL? = nil) throws -> SavedCapture {
+        let folder = directory ?? environment.root
+        try FileManager.default.createDirectory(at: folder, withIntermediateDirectories: true)
+        let url = folder.appendingPathComponent("synthetic.pcap")
+        try PcapWriter.write(linkType: LinkType.ethernet, frames: SampleCapture.frames(now: Date()), to: url)
+        let size = try url.resourceValues(forKeys: [.fileSizeKey]).fileSize ?? 0
+        return SavedCapture(url: url, name: "synthetic", date: Date(), byteCount: size)
+    }
+}

--- a/TracexyTests/ViewModels/ProjectChallengeTests.swift
+++ b/TracexyTests/ViewModels/ProjectChallengeTests.swift
@@ -1,0 +1,142 @@
+import Foundation
+import Testing
+@testable import Tracexy
+
+// MARK: - ChallengeSaveGate
+
+private actor ChallengeSaveGate {
+    // MARK: Internal
+
+    func pause() async {
+        entered = true
+        entry?.resume()
+        entry = nil
+        await withCheckedContinuation { releaseContinuation = $0 }
+    }
+
+    func waitForEntry() async {
+        if !entered {
+            await withCheckedContinuation { entry = $0 }
+        }
+    }
+
+    func release() {
+        releaseContinuation?.resume()
+        releaseContinuation = nil
+    }
+
+    // MARK: Private
+
+    private var entered = false
+    private var entry: CheckedContinuation<Void, Never>?
+    private var releaseContinuation: CheckedContinuation<Void, Never>?
+}
+
+// MARK: - ProjectChallengeTests
+
+@MainActor
+@Suite("Project adversarial lifecycle")
+struct ProjectChallengeTests {
+    @Test("An old successful stop completion cannot release a reset still finalizing its prefix")
+    func resetRejectsOldCompletionBeforePrefixFinalization() async {
+        let environment = ProjectIsolationEnvironment(name: "challenge-reset-late-completion")
+        defer { environment.tearDown() }
+        let coordinator = environment.makeCoordinator()
+        await coordinator.hydrateProjectsOnLaunch()
+        let token = coordinator.startGeneration
+        let operation = coordinator.beginFinalCaptureDrain(stoppedToken: token, captureToken: token)
+        let gate = ChallengeSaveGate()
+        coordinator.ingestChain = Task { await gate.pause() }
+        await gate.waitForEntry()
+        coordinator.prepareForDestructiveHelperReset()
+        // The old callback arrives after reset accepted responsibility for the
+        // prefix but before that prefix's fold/publication has finished.
+        coordinator.completeFinalCaptureDrain(stoppedToken: token)
+        #expect(coordinator.isFinalDrainPending)
+        await gate.release()
+        await coordinator.ingestChain?.value
+        #expect(await !coordinator.waitForFinalCaptureDrain(timeout: .milliseconds(200), operationID: operation))
+        #expect(!coordinator.isFinalDrainPending)
+    }
+
+    @Test("A failed Project transition restores the outgoing selected evidence projection")
+    func failedTransitionKeepsSelectedEvidenceUsable() async throws {
+        let environment = ProjectIsolationEnvironment(name: "challenge-failed-evidence")
+        defer { environment.tearDown() }
+        let coordinator = environment.makeCoordinator()
+        await coordinator.hydrateProjectsOnLaunch()
+        let frames = SampleCapture.frames(now: Date())
+        let sessions = SessionBuilder.build(from: frames, linkType: LinkType.ethernet)
+        coordinator.sessions = sessions
+        let session = try #require(sessions.first)
+        coordinator.select(session)
+        await coordinator.evidenceProjection.task?.value
+        #expect(coordinator.evidenceProjection.selection != nil)
+        environment.provider.failsSettingsForNewProjects = true
+        _ = coordinator.createProject(named: "Unavailable")
+        #expect(await !coordinator.waitForProjectTransition())
+        await coordinator.evidenceProjection.task?.value
+        #expect(coordinator.activeWorkspace.selectedSessionID == session.id)
+        #expect(coordinator.evidenceProjection.selection != nil)
+    }
+
+    @Test("An in-flight session export owns its capture source until completion")
+    func sourceMutationsRefusedDuringSessionExport() async {
+        let environment = ProjectIsolationEnvironment(name: "challenge-export-source")
+        defer { environment.tearDown() }
+        let coordinator = environment.makeCoordinator()
+        await coordinator.hydrateProjectsOnLaunch()
+        let token = coordinator.startGeneration
+        coordinator.setSessionExporting(true)
+        defer { coordinator.setSessionExporting(false) }
+        #expect(coordinator.captureStartBlockedMessage != nil)
+        coordinator.clearSessions()
+        #expect(coordinator.startGeneration == token)
+        await coordinator.ingestChain?.value
+    }
+
+    @Test("Start cannot supersede a stopped capture that still owes its final tail")
+    func startBlockedDuringOwedDrain() async {
+        let environment = ProjectIsolationEnvironment(name: "challenge-start-drain")
+        defer { environment.tearDown() }
+        let coordinator = environment.makeCoordinator()
+        await coordinator.hydrateProjectsOnLaunch()
+        let token = coordinator.startGeneration
+        coordinator.beginFinalCaptureDrain(stoppedToken: token)
+        // Inspect the same guard used by startCapture without starting a real backend.
+        #expect(coordinator.captureStartBlockedMessage != nil)
+        coordinator.completeFinalCaptureDrain(stoppedToken: token)
+        #expect(coordinator.captureStartBlockedMessage == nil)
+    }
+
+    @Test("An accepted live save retains its source through a competing Clear action")
+    func clearCannotResetPendingSaveSource() async throws {
+        let environment = ProjectIsolationEnvironment(name: "challenge-save-clear")
+        defer { environment.tearDown() }
+        let coordinator = environment.makeCoordinator()
+        await coordinator.hydrateProjectsOnLaunch()
+        let frames = SampleCapture.frames(now: Date())
+        let spool = coordinator.liveCaptureSpool
+        try await spool.reset(epoch: coordinator.startGeneration)
+        try await spool.append(frames, defaultLinkType: LinkType.ethernet, epoch: coordinator.startGeneration)
+        coordinator.retainedFrames.append(contentsOf: frames)
+        let gate = ChallengeSaveGate()
+        coordinator.captureSaveOperation = CaptureSaveOperation { source, ownedSpool, destination in
+            await gate.pause()
+            try await CaptureSaveOperation.copy.run(source, ownedSpool, destination)
+        }
+        coordinator.saveCurrentCapture()
+        await gate.waitForEntry()
+        let save = coordinator.pendingCaptureIOTask
+        coordinator.clearSessions()
+        await coordinator.ingestChain?.value
+        await gate.release()
+        await save?.value
+        #expect(coordinator.captureError == nil)
+        #expect(coordinator.savedCaptures.count == 1)
+        if let saved = coordinator.savedCaptures.first {
+            let result = try CaptureFileReader.read(contentsOf: saved.url)
+            #expect(result.frames.map(\.bytes) == frames.map(\.bytes))
+        }
+    }
+}

--- a/TracexyTests/ViewModels/ProjectCoordinationTests.swift
+++ b/TracexyTests/ViewModels/ProjectCoordinationTests.swift
@@ -1,0 +1,65 @@
+import Foundation
+import Testing
+@testable import Tracexy
+
+@MainActor
+@Suite("Project workspace coordination")
+struct ProjectCoordinationTests {
+    @Test("Switching projects restores each workspace configuration")
+    func switchingRestoresWorkspaceConfiguration() async throws {
+        let coordinator = MainContentCoordinator()
+        await coordinator.hydrateProjectsOnLaunch()
+
+        let firstProjectID = coordinator.projectStore.activeProjectID
+        coordinator.workspaces.activeWorkspace.filterText = "api.example"
+        coordinator.workspaces.activeWorkspace.sessionGrouping = .host
+        coordinator.workspaces.activeWorkspace.sidebarSelection = .tls
+        #expect(coordinator.flushProjectWorkspaceSnapshot())
+
+        let secondProject = try #require(coordinator.createProject(named: "Authentication"))
+        #expect(coordinator.workspaces.activeWorkspace.filterText.isEmpty)
+        coordinator.workspaces.activeWorkspace.filterText = "handshake"
+        coordinator.workspaces.activeWorkspace.sessionGrouping = .process
+        #expect(coordinator.flushProjectWorkspaceSnapshot())
+
+        #expect(coordinator.switchToProject(id: firstProjectID))
+        #expect(coordinator.workspaces.activeWorkspace.filterText == "api.example")
+        #expect(coordinator.workspaces.activeWorkspace.sessionGrouping == .host)
+        #expect(coordinator.workspaces.activeWorkspace.sidebarSelection == .tls)
+
+        #expect(coordinator.switchToProject(id: secondProject.id))
+        #expect(coordinator.workspaces.activeWorkspace.filterText == "handshake")
+        #expect(coordinator.workspaces.activeWorkspace.sessionGrouping == .process)
+    }
+
+    @Test("Capture-local selection is not persisted into a project")
+    func transientSelectionIsExcluded() async throws {
+        let coordinator = MainContentCoordinator()
+        await coordinator.hydrateProjectsOnLaunch()
+
+        let firstProjectID = coordinator.projectStore.activeProjectID
+        coordinator.workspaces.activeWorkspace.selectedSessionID = UUID()
+        #expect(coordinator.flushProjectWorkspaceSnapshot())
+
+        _ = try #require(coordinator.createProject(named: "Second"))
+        #expect(coordinator.switchToProject(id: firstProjectID))
+        #expect(coordinator.workspaces.activeWorkspace.selectedSessionID == nil)
+    }
+
+    @Test("Deleting the active project falls back without deleting the final project")
+    func activeDeletionFallsBack() async throws {
+        let coordinator = MainContentCoordinator()
+        await coordinator.hydrateProjectsOnLaunch()
+
+        let originalID = coordinator.projectStore.activeProjectID
+        let project = try #require(coordinator.createProject(named: "Temporary"))
+        #expect(coordinator.renameProject(id: project.id, to: "Renamed"))
+        #expect(coordinator.projectStore.activeProject.name == "Renamed")
+
+        #expect(coordinator.deleteProject(id: project.id))
+        #expect(coordinator.projectStore.activeProjectID == originalID)
+        #expect(coordinator.projectStore.projects.count == 1)
+        #expect(!coordinator.deleteProject(id: originalID))
+        #expect(coordinator.lastProjectOperationError == .cannotDeleteFinalProject)
+    }
+}

--- a/TracexyTests/ViewModels/ProjectCoordinationTests.swift
+++ b/TracexyTests/ViewModels/ProjectCoordinationTests.swift
@@ -5,9 +5,13 @@ import Testing
 @MainActor
 @Suite("Project workspace coordination")
 struct ProjectCoordinationTests {
+    // MARK: Internal
+
     @Test("Switching projects restores each workspace configuration")
     func switchingRestoresWorkspaceConfiguration() async throws {
-        let coordinator = MainContentCoordinator()
+        let environment = ProjectIsolationEnvironment(name: "coordination")
+        defer { environment.tearDown() }
+        let coordinator = environment.makeCoordinator()
         await coordinator.hydrateProjectsOnLaunch()
 
         let firstProjectID = coordinator.projectStore.activeProjectID
@@ -16,50 +20,92 @@ struct ProjectCoordinationTests {
         coordinator.workspaces.activeWorkspace.sidebarSelection = .tls
         #expect(coordinator.flushProjectWorkspaceSnapshot())
 
-        let secondProject = try #require(coordinator.createProject(named: "Authentication"))
+        let secondProject = try #require(await Self.created(coordinator, named: "Authentication"))
         #expect(coordinator.workspaces.activeWorkspace.filterText.isEmpty)
         coordinator.workspaces.activeWorkspace.filterText = "handshake"
         coordinator.workspaces.activeWorkspace.sessionGrouping = .process
         #expect(coordinator.flushProjectWorkspaceSnapshot())
 
-        #expect(coordinator.switchToProject(id: firstProjectID))
+        #expect(await Self.switched(coordinator, to: firstProjectID))
         #expect(coordinator.workspaces.activeWorkspace.filterText == "api.example")
         #expect(coordinator.workspaces.activeWorkspace.sessionGrouping == .host)
         #expect(coordinator.workspaces.activeWorkspace.sidebarSelection == .tls)
 
-        #expect(coordinator.switchToProject(id: secondProject.id))
+        #expect(await Self.switched(coordinator, to: secondProject.id))
         #expect(coordinator.workspaces.activeWorkspace.filterText == "handshake")
         #expect(coordinator.workspaces.activeWorkspace.sessionGrouping == .process)
     }
 
-    @Test("Capture-local selection is not persisted into a project")
-    func transientSelectionIsExcluded() async throws {
-        let coordinator = MainContentCoordinator()
+    /// Selection is still excluded from the *portable* snapshot — a Project file
+    /// must never carry a capture-local session id. It does, however, survive a
+    /// switch inside one app session, because a parked Project keeps its real
+    /// workspace instance rather than being rehydrated from that snapshot.
+    @Test("Capture-local selection stays out of the portable snapshot but survives a switch")
+    func transientSelectionIsExcludedFromTheSnapshot() async throws {
+        let environment = ProjectIsolationEnvironment(name: "selection-snapshot")
+        defer { environment.tearDown() }
+        let coordinator = environment.makeCoordinator()
         await coordinator.hydrateProjectsOnLaunch()
 
         let firstProjectID = coordinator.projectStore.activeProjectID
-        coordinator.workspaces.activeWorkspace.selectedSessionID = UUID()
+        let selectedID = UUID()
+        coordinator.workspaces.activeWorkspace.selectedSessionID = selectedID
         #expect(coordinator.flushProjectWorkspaceSnapshot())
 
-        _ = try #require(coordinator.createProject(named: "Second"))
-        #expect(coordinator.switchToProject(id: firstProjectID))
+        let snapshot = try #require(coordinator.projectStore.activeProject.workspaces.first)
+        let encoded = try JSONEncoder().encode(snapshot)
+        let json = try #require(String(data: encoded, encoding: .utf8))
+        #expect(!json.contains(selectedID.uuidString))
+
+        _ = try #require(await Self.created(coordinator, named: "Second"))
         #expect(coordinator.workspaces.activeWorkspace.selectedSessionID == nil)
+
+        #expect(await Self.switched(coordinator, to: firstProjectID))
+        #expect(coordinator.workspaces.activeWorkspace.selectedSessionID == selectedID)
     }
 
     @Test("Deleting the active project falls back without deleting the final project")
     func activeDeletionFallsBack() async throws {
-        let coordinator = MainContentCoordinator()
+        let environment = ProjectIsolationEnvironment(name: "deletion")
+        defer { environment.tearDown() }
+        let coordinator = environment.makeCoordinator()
         await coordinator.hydrateProjectsOnLaunch()
 
         let originalID = coordinator.projectStore.activeProjectID
-        let project = try #require(coordinator.createProject(named: "Temporary"))
+        let project = try #require(await Self.created(coordinator, named: "Temporary"))
         #expect(coordinator.renameProject(id: project.id, to: "Renamed"))
         #expect(coordinator.projectStore.activeProject.name == "Renamed")
 
         #expect(coordinator.deleteProject(id: project.id))
+        #expect(await coordinator.waitForProjectTransition())
         #expect(coordinator.projectStore.activeProjectID == originalID)
         #expect(coordinator.projectStore.projects.count == 1)
         #expect(!coordinator.deleteProject(id: originalID))
         #expect(coordinator.lastProjectOperationError == .cannotDeleteFinalProject)
+    }
+
+    // MARK: Private
+
+    /// A Project change is durable-first and therefore asynchronous: starting one
+    /// only means it was accepted and validated.
+    private static func switched(_ coordinator: MainContentCoordinator, to id: UUID) async -> Bool {
+        guard coordinator.switchToProject(id: id) else {
+            return false
+        }
+        return await coordinator.waitForProjectTransition()
+    }
+
+    private static func created(
+        _ coordinator: MainContentCoordinator,
+        named name: String
+    )
+        async -> Project?
+    {
+        guard let project = coordinator.createProject(named: name),
+              await coordinator.waitForProjectTransition() else
+        {
+            return nil
+        }
+        return project
     }
 }

--- a/TracexyTests/ViewModels/ProjectHistoryResumeTests.swift
+++ b/TracexyTests/ViewModels/ProjectHistoryResumeTests.swift
@@ -1,0 +1,283 @@
+import Foundation
+import Testing
+@testable import Tracexy
+
+// MARK: - ProjectHistoryResumeTests
+
+/// A Project change cancels the outgoing Project's in-flight History reads, so its
+/// bucket parks `.loading` with no reader behind it. Nothing on the History surface
+/// would ever start one again — its `task` reads only from `.idle`, and it
+/// auto-selects a capture only when nothing is selected — so a restored Project
+/// would sit on a spinner forever.
+///
+/// These tests interrupt exactly the state a cancelled *first-page* read leaves
+/// behind, round-trip the Project, and assert the surface reaches real data. They
+/// never sleep for a race: every read is awaited through
+/// ``MainContentCoordinator/waitForHistory()``, and every Project change through
+/// ``MainContentCoordinator/waitForProjectTransition()``. Every store, spool and
+/// preferences suite lives inside one throwaway environment.
+@MainActor
+@Suite("Project History read resumption")
+struct ProjectHistoryResumeTests {
+    // MARK: Internal
+
+    @Test("A failed resumed capture read does not strand its cancelled session reader")
+    func failedCaptureResumeSettlesSessionPaneAndRetries() async throws {
+        let environment = ProjectIsolationEnvironment(name: "history-resume-failure")
+        defer { environment.tearDown() }
+        let coordinator = environment.makeCoordinator()
+        await coordinator.hydrateProjectsOnLaunch()
+        let projectA = coordinator.projectStore.activeProjectID
+        let url = environment.root.appendingPathComponent("ReadFailure.sqlite")
+        let store = try SessionStore(configuration: .init(location: .file(url)))
+        coordinator.sessionStore = store
+        let capture = Self.capture(startedAt: 1_000, endedAt: 1_100)
+        try await store.replaceCapture(capture, sessions: [Self.session(host: "a.example")])
+        coordinator.selectedHistoryCaptureID = capture.captureID
+        Self.interruptFirstCapturePage(of: coordinator)
+        Self.interruptFirstSessionPage(of: coordinator)
+        // Reversible schema fault in this test's own database, never production.
+        let fault = try SQLiteDatabase(path: url.path, readOnly: false)
+        defer { fault.close() }
+        try fault.execute("ALTER TABLE captures RENAME TO temporarily_unreadable_captures;")
+        _ = try #require(await Self.created(coordinator, named: "Bravo"))
+        #expect(await Self.switched(coordinator, to: projectA))
+        await coordinator.waitForHistory()
+        if case .failed = coordinator.historyAvailability {} else {
+            Issue.record("The temporary schema fault must fail the capture read")
+        }
+        #expect(coordinator.historySessionTask == nil)
+        #expect(coordinator.historySessionsAvailability != .loading)
+        try fault.execute("ALTER TABLE temporarily_unreadable_captures RENAME TO captures;")
+        coordinator.retryHistory()
+        await coordinator.waitForHistory()
+        #expect(coordinator.historyAvailability == .loaded)
+        #expect(coordinator.historySessionsAvailability == .loaded)
+        #expect(coordinator.historySessions.map(\.host) == ["a.example"])
+    }
+
+    @Test("An interrupted first capture page is re-read when its Project comes back")
+    func interruptedCapturePageResumesOnRestore() async throws {
+        let environment = ProjectIsolationEnvironment(name: "history-resume-captures")
+        defer { environment.tearDown() }
+        let coordinator = environment.makeCoordinator()
+        await coordinator.hydrateProjectsOnLaunch()
+
+        let projectA = coordinator.projectStore.activeProjectID
+        let store = try #require(coordinator.sessionStore)
+        let capture = Self.capture(startedAt: 1_000, endedAt: 1_100)
+        try await store.replaceCapture(capture, sessions: [Self.session(host: "a.example")])
+        Self.interruptFirstCapturePage(of: coordinator)
+
+        let projectB = try #require(await Self.created(coordinator, named: "Bravo"))
+        // B owns its own store and its own read state: it never inherits A's
+        // interrupted read.
+        #expect(coordinator.historyAvailability == .idle)
+        #expect(coordinator.historyCaptures.isEmpty)
+
+        #expect(await Self.switched(coordinator, to: projectA))
+        await coordinator.waitForHistory()
+
+        #expect(coordinator.historyAvailability == .loaded)
+        #expect(coordinator.historyCaptures.map(\.id) == [capture.captureID])
+        #expect(Self.captureSurface(of: coordinator) == .content)
+        // A refreshed first page with no surviving selection leaves the selection to
+        // the surface, so the session pane is empty-by-selection, not a spinner.
+        #expect(coordinator.selectedHistoryCaptureID == nil)
+        #expect(Self.sessionSurface(of: coordinator) == .noSelection)
+
+        // B is untouched by A's resumed read.
+        #expect(await Self.switched(coordinator, to: projectB.id))
+        #expect(coordinator.historyAvailability == .idle)
+        #expect(coordinator.historyCaptures.isEmpty)
+    }
+
+    @Test("An interrupted first session page is re-read against its own restored store")
+    func interruptedSessionPageResumesOnRestore() async throws {
+        let environment = ProjectIsolationEnvironment(name: "history-resume-sessions")
+        defer { environment.tearDown() }
+        let coordinator = environment.makeCoordinator()
+        await coordinator.hydrateProjectsOnLaunch()
+
+        let projectA = coordinator.projectStore.activeProjectID
+        let store = try #require(coordinator.sessionStore)
+        let capture = Self.capture(startedAt: 1_000, endedAt: 1_100)
+        try await store.replaceCapture(capture, sessions: [Self.session(host: "a.example")])
+
+        coordinator.refreshHistory()
+        await coordinator.waitForHistory()
+        coordinator.selectHistoryCapture(capture.captureID)
+        await coordinator.waitForHistory()
+        #expect(coordinator.historyAvailability == .loaded)
+        #expect(coordinator.historySessionsAvailability == .loaded)
+
+        // Only the selected capture's page read is interrupted. The capture list
+        // stays loaded and keeps its selection, which is exactly the case a demotion
+        // to `.idle` would strand: the surface re-selects nothing, so nobody reads.
+        Self.interruptFirstSessionPage(of: coordinator)
+        #expect(coordinator.historyAvailability == .loaded)
+        #expect(Self.sessionSurface(of: coordinator) == .loading)
+
+        let projectB = try #require(await Self.created(coordinator, named: "Bravo"))
+        #expect(coordinator.historySessionsAvailability == .idle)
+        #expect(coordinator.selectedHistoryCaptureID == nil)
+
+        #expect(await Self.switched(coordinator, to: projectA))
+        await coordinator.waitForHistory()
+
+        #expect(coordinator.selectedHistoryCaptureID == capture.captureID)
+        #expect(coordinator.historySessionsAvailability == .loaded)
+        #expect(coordinator.historySessions.map(\.host) == ["a.example"])
+        #expect(Self.sessionSurface(of: coordinator) == .content)
+        // The already-loaded capture page was preserved, not re-read.
+        #expect(coordinator.historyCaptures.map(\.id) == [capture.captureID])
+
+        #expect(await Self.switched(coordinator, to: projectB.id))
+        #expect(coordinator.historySessions.isEmpty)
+        #expect(coordinator.selectedHistoryCaptureID == nil)
+    }
+
+    /// `loadMore` appends behind `.loaded`, so an interrupted page *append* is not a
+    /// stranded first page. Restoring must leave the loaded rows and the cursor
+    /// exactly as they were rather than restarting the list from the newest page.
+    @Test("An interrupted page append keeps its loaded rows and cursor")
+    func interruptedPageAppendIsNotRestarted() async throws {
+        let environment = ProjectIsolationEnvironment(name: "history-resume-paging")
+        defer { environment.tearDown() }
+        let coordinator = environment.makeCoordinator()
+        await coordinator.hydrateProjectsOnLaunch()
+
+        let projectA = coordinator.projectStore.activeProjectID
+        let store = try #require(coordinator.sessionStore)
+        let newest = Self.capture(startedAt: 3_000, endedAt: 3_100)
+        let middle = Self.capture(startedAt: 2_000, endedAt: 2_100)
+        let oldest = Self.capture(startedAt: 1_000, endedAt: 1_100)
+        for capture in [oldest, middle, newest] {
+            try await store.replaceCapture(capture, sessions: [])
+        }
+
+        coordinator.refreshHistory()
+        await coordinator.waitForHistory()
+        #expect(coordinator.historyCaptures.count == 3)
+
+        // A page append that was in flight when the Project changed: availability
+        // stays `.loaded`, and the rows and cursor already accepted are the ones the
+        // restored Project must come back to.
+        let loaded = Array(coordinator.historyCaptures.prefix(2))
+        let cursor = HistoryCaptureCursor(endedAt: middle.endedAt, captureID: middle.captureID)
+        coordinator.historyTask?.cancel()
+        coordinator.historyTask = nil
+        coordinator.historyRequestID &+= 1
+        coordinator.historyCaptures = loaded
+        coordinator.historyCaptureCursor = cursor
+
+        _ = try #require(await Self.created(coordinator, named: "Bravo"))
+        #expect(await Self.switched(coordinator, to: projectA))
+        await coordinator.waitForHistory()
+
+        #expect(coordinator.historyAvailability == .loaded)
+        #expect(coordinator.historyCaptures.map(\.id) == loaded.map(\.id))
+        #expect(coordinator.historyCaptureCursor == cursor)
+
+        // Paging still resumes from that exact cursor rather than a re-read list.
+        coordinator.loadMoreHistoryCaptures()
+        await coordinator.waitForHistory()
+        #expect(coordinator.historyCaptures.map(\.id) == [newest.captureID, middle.captureID, oldest.captureID])
+    }
+
+    // MARK: Private
+
+    // MARK: Interruption fixtures
+
+    /// Exactly what a Project change leaves behind for a first capture page:
+    /// ``MainContentCoordinator/invalidateOutgoingProjectWork()`` cancels the read
+    /// and retires its request id, so `.loading` is parked with no reader.
+    private static func interruptFirstCapturePage(of coordinator: MainContentCoordinator) {
+        coordinator.historyTask?.cancel()
+        coordinator.historyTask = nil
+        coordinator.historyRequestID &+= 1
+        coordinator.historyAvailability = .loading
+        coordinator.historyCaptures = []
+        coordinator.historyCaptureCursor = nil
+    }
+
+    /// The same, for the selected capture's first session page.
+    private static func interruptFirstSessionPage(of coordinator: MainContentCoordinator) {
+        coordinator.historySessionTask?.cancel()
+        coordinator.historySessionTask = nil
+        coordinator.historySessionRequestID &+= 1
+        coordinator.historySessionsAvailability = .loading
+        coordinator.historySessions = []
+        coordinator.historySessionCursor = nil
+    }
+
+    // MARK: Surface state
+
+    private static func captureSurface(of coordinator: MainContentCoordinator) -> HistoryCaptureSurfaceState {
+        HistoryCaptureSurfaceState.resolve(
+            availability: coordinator.historyAvailability,
+            captureCount: coordinator.historyCaptures.count,
+            unavailableReason: coordinator.historyError
+        )
+    }
+
+    private static func sessionSurface(of coordinator: MainContentCoordinator) -> HistorySessionSurfaceState {
+        HistorySessionSurfaceState.resolve(
+            selectedCaptureID: coordinator.selectedHistoryCaptureID,
+            availability: coordinator.historySessionsAvailability,
+            sessionCount: coordinator.historySessions.count
+        )
+    }
+
+    // MARK: Project fixtures
+
+    private static func switched(_ coordinator: MainContentCoordinator, to id: UUID) async -> Bool {
+        guard coordinator.switchToProject(id: id) else {
+            return false
+        }
+        return await coordinator.waitForProjectTransition()
+    }
+
+    private static func created(
+        _ coordinator: MainContentCoordinator,
+        named name: String
+    )
+        async -> Project?
+    {
+        guard let project = coordinator.createProject(named: name),
+              await coordinator.waitForProjectTransition() else
+        {
+            return nil
+        }
+        return project
+    }
+
+    // MARK: Record fixtures
+
+    private static func capture(startedAt: Double, endedAt: Double) -> HistoryCaptureRecord {
+        HistoryCaptureRecord(
+            captureID: UUID(),
+            startedAt: startedAt,
+            endedAt: endedAt,
+            sourceKind: .live,
+            completeness: .complete
+        )
+    }
+
+    private static func session(host: String) -> HistorySessionRecord {
+        HistorySessionRecord(
+            sessionID: UUID(),
+            startTime: 1_000,
+            duration: 5,
+            processName: "curl",
+            host: host,
+            sourceEndpoint: "10.0.0.1:5000",
+            destinationEndpoint: "93.184.216.34:443",
+            protocols: ["tcp", "tls"],
+            status: .ok,
+            latencyMilliseconds: 12.5,
+            bytesUp: 100,
+            bytesDown: 200
+        )
+    }
+}

--- a/TracexyTests/ViewModels/ProjectIsolationTests.swift
+++ b/TracexyTests/ViewModels/ProjectIsolationTests.swift
@@ -1,0 +1,758 @@
+import Foundation
+import Testing
+@testable import Tracexy
+
+// MARK: - ProjectIsolationTests
+
+/// Behavior tests for complete Project isolation. Every coordinator here is built
+/// on an isolated storage root and defaults namespace, so no assertion depends on
+/// (or disturbs) a production path or the shared `UserDefaults` domain.
+///
+/// A Project change is durable-first and therefore asynchronous: starting one only
+/// means it was accepted and validated. Every test awaits
+/// ``MainContentCoordinator/waitForProjectTransition()`` before asserting on the
+/// destination, because that is the moment the catalog was written and the runtime
+/// published.
+@MainActor
+@Suite("Project isolation")
+struct ProjectIsolationTests {
+    // MARK: Internal
+
+    // MARK: Sessions, evidence and the live spool
+
+    @Test("Each Project keeps its own sessions across A → B → A")
+    func sessionsAreProjectScoped() async throws {
+        let environment = ProjectIsolationEnvironment(name: "sessions")
+        defer { environment.tearDown() }
+        let coordinator = environment.makeCoordinator()
+        await coordinator.hydrateProjectsOnLaunch()
+
+        let projectA = coordinator.projectStore.activeProjectID
+        let sessionA = Self.summary(host: "a.example")
+        coordinator.sessions = [sessionA]
+
+        let projectB = try #require(await Self.created(coordinator, named: "Second"))
+        #expect(coordinator.sessions.isEmpty)
+        let sessionB = Self.summary(host: "b.example")
+        coordinator.sessions = [sessionB]
+
+        #expect(await Self.switched(coordinator, to: projectA))
+        #expect(coordinator.sessions.map(\.host) == ["a.example"])
+
+        #expect(await Self.switched(coordinator, to: projectB.id))
+        #expect(coordinator.sessions.map(\.host) == ["b.example"])
+    }
+
+    @Test("Selection and structured query drafts survive a round trip")
+    func selectionAndQueryDraftsAreRestored() async throws {
+        let environment = ProjectIsolationEnvironment(name: "selection")
+        defer { environment.tearDown() }
+        let coordinator = environment.makeCoordinator()
+        await coordinator.hydrateProjectsOnLaunch()
+
+        let projectA = coordinator.projectStore.activeProjectID
+        let session = Self.summary(host: "selected.example")
+        coordinator.sessions = [session]
+        coordinator.workspaces.activeWorkspace.selectedSessionID = session.id
+        coordinator.workspaces.activeWorkspace.filterText = "handshake"
+
+        let projectB = try #require(await Self.created(coordinator, named: "Second"))
+        #expect(coordinator.workspaces.activeWorkspace.selectedSessionID == nil)
+        #expect(coordinator.workspaces.activeWorkspace.filterText.isEmpty)
+
+        #expect(await Self.switched(coordinator, to: projectA))
+        // Runtime selection is preserved because the Project keeps its real
+        // workspace instance; it is not rehydrated from the portable snapshot.
+        #expect(coordinator.workspaces.activeWorkspace.selectedSessionID == session.id)
+        #expect(coordinator.workspaces.activeWorkspace.filterText == "handshake")
+        #expect(projectB.id != projectA)
+    }
+
+    /// The Project boundary is not a capture boundary. A parked Project keeps the
+    /// *structured* Investigation state its workspaces own — the editable draft and
+    /// the accepted query with its matched rows — because that is user work, not
+    /// capture-local state that a new source invalidates.
+    @Test("Structured Investigation drafts and accepted results survive a round trip")
+    func investigationDraftsAndResultsSurviveAProjectRoundTrip() async throws {
+        let environment = ProjectIsolationEnvironment(name: "investigation")
+        defer { environment.tearDown() }
+        let coordinator = environment.makeCoordinator()
+        await coordinator.hydrateProjectsOnLaunch()
+
+        let projectA = coordinator.projectStore.activeProjectID
+        let matching = Self.summary(host: "auth.example")
+        let other = Self.summary(host: "cdn.example")
+        coordinator.sessions = [matching, other]
+        coordinator.adoptInvestigation(InvestigationSnapshot(
+            sessions: [matching, other],
+            connections: .empty,
+            datagramEvidence: .empty,
+            tlsEvidence: .empty,
+            connectionAnalysis: .empty,
+            datagramAnalysis: .empty
+        ))
+
+        let workspaceA = coordinator.workspaces.activeWorkspace
+        let draft = InvestigationQueryDraft(
+            combination: .all,
+            rows: [InvestigationQueryDraftRow(predicate: .hostContains("auth"))]
+        )
+        coordinator.applyInvestigationQuery(draft, in: workspaceA)
+        await coordinator.waitForInvestigationQuery(in: workspaceA)
+        #expect(workspaceA.acceptedInvestigationDraft == draft)
+        #expect(workspaceA.investigationMatchedSessionIDs == [matching.id])
+
+        let projectB = try #require(await Self.created(coordinator, named: "Second"))
+        // B starts genuinely empty; nothing of A's query leaked into it.
+        #expect(coordinator.workspaces.activeWorkspace.acceptedInvestigationDraft == nil)
+        #expect(coordinator.workspaces.activeWorkspace.investigationMatchedSessionIDs.isEmpty)
+
+        #expect(await Self.switched(coordinator, to: projectA))
+        let restored = coordinator.workspaces.activeWorkspace
+        #expect(restored.investigationDraft == draft)
+        #expect(restored.acceptedInvestigationDraft == draft)
+        #expect(restored.investigationMatchedSessionIDs == [matching.id])
+        await coordinator.waitForInvestigationQuery(in: restored)
+        #expect(!restored.isEvaluatingInvestigationQuery)
+        #expect(projectB.id != projectA)
+    }
+
+    @Test("Clearing capture data in B leaves A's sessions and spool intact")
+    func clearingBLeavesAIntact() async throws {
+        let environment = ProjectIsolationEnvironment(name: "clear")
+        defer { environment.tearDown() }
+        let coordinator = environment.makeCoordinator()
+        await coordinator.hydrateProjectsOnLaunch()
+
+        let projectA = coordinator.projectStore.activeProjectID
+        coordinator.sessions = [Self.summary(host: "a.example")]
+        let spoolA = coordinator.liveCaptureSpool
+        try await spoolA.reset(epoch: 1)
+        _ = try await spoolA.append(
+            [Self.frame(payload: 0xA1)],
+            defaultLinkType: LinkType.ethernet,
+            epoch: 1
+        )
+
+        let projectB = try #require(await Self.created(coordinator, named: "Second"))
+        #expect(coordinator.liveCaptureSpool !== spoolA)
+        coordinator.sessions = [Self.summary(host: "b.example")]
+        // A start/reset boundary in B must not touch A's evidence.
+        coordinator.clearSessions()
+        await coordinator.ingestChain?.value
+
+        #expect(await Self.switched(coordinator, to: projectA))
+        #expect(coordinator.sessions.map(\.host) == ["a.example"])
+        let recovered = try await coordinator.liveCaptureSpool.capture()
+        #expect(recovered.frames.count == 1)
+        #expect(recovered.frames.first?.bytes.first == 0xA1)
+        #expect(projectB.id != projectA)
+    }
+
+    // MARK: Settings
+
+    @Test("Capture, privacy and retention settings are per Project")
+    func settingsArePerProject() async throws {
+        let environment = ProjectIsolationEnvironment(name: "settings")
+        defer { environment.tearDown() }
+        let coordinator = environment.makeCoordinator()
+        await coordinator.hydrateProjectsOnLaunch()
+
+        let projectA = coordinator.projectStore.activeProjectID
+        let defaultsA = coordinator.activeProjectDefaults
+        defaultsA.set(CaptureFilterMode.custom.rawValue, forKey: SettingsKeys.captureFilterMode)
+        defaultsA.set("tcp port 443", forKey: SettingsKeys.bpfExpression)
+        defaultsA.set(50_000, forKey: SettingsKeys.retainPackets)
+        defaultsA.set(true, forKey: SettingsKeys.maskIPs)
+        defaultsA.set(AutoClear.hour1.rawValue, forKey: SettingsKeys.autoClear)
+        coordinator.configureHistoryAutoClear(.hour1)
+        await coordinator.waitForHistory()
+
+        let projectB = try #require(await Self.created(coordinator, named: "Second"))
+        let defaultsB = coordinator.activeProjectDefaults
+        #expect(defaultsB !== defaultsA)
+        // A brand-new Project starts from safe defaults, and never falls through
+        // to another Project's — or the shared domain's — values.
+        #expect(coordinator.readinessCaptureConfiguration.bpf == nil)
+        #expect(coordinator.readinessRetentionCapacity == CaptureSettingsResolver.defaultRetainPackets)
+        #expect(!PrivacySettingsResolver.exportPolicy(defaults: defaultsB).maskIPAddresses)
+        #expect(HistoryRetentionSettingsResolver.autoClear(defaults: defaultsB) == .never)
+        #expect(coordinator.historyAutoClear == .never)
+        // While stopped, readiness describes the *active* Project's current
+        // defaults. No configuration retained from a capture that ran in another
+        // Project may keep describing a source here.
+        #expect(!coordinator.isCapturing)
+        let expectedConfiguration = CaptureSettingsResolver.configuration(
+            interface: coordinator.captureInterface,
+            defaults: defaultsB
+        )
+        let actualConfiguration = coordinator.readinessCaptureConfiguration
+        #expect(actualConfiguration.interface == expectedConfiguration.interface)
+        #expect(actualConfiguration.snapLength == expectedConfiguration.snapLength)
+        #expect(actualConfiguration.promiscuous == expectedConfiguration.promiscuous)
+        #expect(actualConfiguration.bpf == expectedConfiguration.bpf)
+
+        #expect(await Self.switched(coordinator, to: projectA))
+        #expect(coordinator.readinessCaptureConfiguration.bpf == "tcp port 443")
+        #expect(coordinator.readinessRetentionCapacity == 50_000)
+        #expect(PrivacySettingsResolver.exportPolicy(defaults: coordinator.activeProjectDefaults).maskIPAddresses)
+        #expect(coordinator.historyAutoClear == .hour1)
+        #expect(projectB.id != projectA)
+    }
+
+    @Test("Pins, Focus Sets, muted noise and hidden sources are per Project")
+    func libraryPreferencesArePerProject() async throws {
+        let environment = ProjectIsolationEnvironment(name: "prefs")
+        defer { environment.tearDown() }
+        let coordinator = environment.makeCoordinator()
+        await coordinator.hydrateProjectsOnLaunch()
+
+        let projectA = coordinator.projectStore.activeProjectID
+        coordinator.togglePinHost("pinned.example")
+        coordinator.saveFocusSet(FocusSet(name: "Auth", rules: [SessionFilterRule()]))
+        coordinator.toggleMuteHost("noisy.example")
+        coordinator.hideSourceApp("Finder")
+
+        _ = try #require(await Self.created(coordinator, named: "Second"))
+        #expect(coordinator.pinnedHosts.isEmpty)
+        #expect(coordinator.focusSets.isEmpty)
+        #expect(coordinator.mutedHosts.isEmpty)
+        #expect(coordinator.hiddenSourceApps.isEmpty)
+
+        #expect(await Self.switched(coordinator, to: projectA))
+        #expect(coordinator.pinnedHosts == ["pinned.example"])
+        #expect(coordinator.focusSets.map(\.name) == ["Auth"])
+        #expect(coordinator.mutedHosts.contains("noisy.example"))
+        #expect(coordinator.hiddenSourceApps.contains("Finder"))
+    }
+
+    // MARK: History and the saved-capture Library
+
+    @Test("History writes, reads and Clear stay inside one Project")
+    func historyIsPerProject() async throws {
+        let environment = ProjectIsolationEnvironment(name: "history")
+        defer { environment.tearDown() }
+        let coordinator = environment.makeCoordinator()
+        await coordinator.hydrateProjectsOnLaunch()
+
+        let projectA = coordinator.projectStore.activeProjectID
+        let storeA = try #require(coordinator.sessionStore)
+        Self.writeTerminalCapture(into: coordinator, host: "a.example")
+        await coordinator.waitForHistory()
+        #expect(coordinator.historyCaptures.count == 1)
+
+        let projectB = try #require(await Self.created(coordinator, named: "Second"))
+        let storeB = try #require(coordinator.sessionStore)
+        #expect(storeB !== storeA)
+        coordinator.refreshHistory()
+        await coordinator.waitForHistory()
+        #expect(coordinator.historyCaptures.isEmpty)
+
+        Self.writeTerminalCapture(into: coordinator, host: "b.example")
+        await coordinator.waitForHistory()
+        #expect(coordinator.historyCaptures.count == 1)
+
+        // Clearing B's History must not delete A's row.
+        coordinator.clearAllHistory()
+        await coordinator.waitForHistory()
+        #expect(coordinator.historyCaptures.isEmpty)
+
+        #expect(await Self.switched(coordinator, to: projectA))
+        coordinator.refreshHistory()
+        await coordinator.waitForHistory()
+        #expect(coordinator.historyCaptures.count == 1)
+        let retainedCaptureID = try #require(coordinator.historyCaptures.first?.id)
+        let sessions = try await storeA.sessions(captureID: retainedCaptureID, after: nil, limit: 10)
+        #expect(sessions.sessions.first?.host == "a.example")
+        #expect(projectB.id != projectA)
+    }
+
+    @Test("Each Project has its own managed capture Library folder")
+    func savedCaptureLibraryIsPerProject() async throws {
+        let environment = ProjectIsolationEnvironment(name: "library")
+        defer { environment.tearDown() }
+        let coordinator = environment.makeCoordinator()
+        await coordinator.hydrateProjectsOnLaunch()
+
+        let projectA = coordinator.projectStore.activeProjectID
+        let directoryA = try #require(coordinator.capturesDirectory())
+        try Data([0]).write(to: directoryA.appendingPathComponent("Capture A.pcapng"))
+        coordinator.refreshSavedCaptures()
+        #expect(coordinator.savedCaptures.map(\.name) == ["Capture A"])
+
+        _ = try #require(await Self.created(coordinator, named: "Second"))
+        let directoryB = try #require(coordinator.capturesDirectory())
+        #expect(directoryB != directoryA)
+        #expect(coordinator.savedCaptures.isEmpty)
+
+        #expect(await Self.switched(coordinator, to: projectA))
+        #expect(coordinator.savedCaptures.map(\.name) == ["Capture A"])
+    }
+
+    /// Before hydration the runtime carries no Project identity, so it must not
+    /// resolve — let alone create or scan — any capture Library. Doing so would
+    /// touch the pre-Projects folder before its owner is durably bound.
+    @Test("No capture Library is resolved or scanned before Projects hydrate")
+    func libraryIsNotScannedBeforeHydration() async {
+        let environment = ProjectIsolationEnvironment(name: "bootlibrary")
+        defer { environment.tearDown() }
+        let coordinator = environment.makeCoordinator()
+
+        #expect(coordinator.capturesDirectory() == nil)
+        #expect(coordinator.savedCaptures.isEmpty)
+        coordinator.refreshSavedCaptures()
+        #expect(coordinator.savedCaptures.isEmpty)
+
+        await coordinator.hydrateProjectsOnLaunch()
+        #expect(coordinator.capturesDirectory() != nil)
+    }
+
+    // MARK: Legacy ownership
+
+    @Test("A v1 catalog assigns one stable legacy owner that survives relaunch")
+    func legacyOwnerIsAssignedOnceAndSurvivesRelaunch() async throws {
+        let environment = ProjectIsolationEnvironment(name: "legacy", persistsCatalog: true)
+        defer { environment.tearDown() }
+
+        let first = environment.makeCoordinator()
+        await first.hydrateProjectsOnLaunch()
+        let owner = try #require(first.projectStore.legacyDataOwnerProjectID)
+        #expect(owner == first.projectStore.activeProjectID)
+        let legacyHistoryURL = try #require(first.activeRuntime.location?.historyDatabaseURL)
+        #expect(!legacyHistoryURL.path.contains("Projects/"))
+
+        // A second Project must not be given the pre-Projects locations.
+        let second = try #require(await Self.created(first, named: "Second"))
+        let scopedHistoryURL = try #require(first.activeRuntime.location?.historyDatabaseURL)
+        #expect(scopedHistoryURL.path.contains(second.id.uuidString))
+        await first.flushProjectStateForTermination()
+
+        // "Relaunch": a fresh coordinator over the same on-disk catalog.
+        let relaunched = environment.makeCoordinator()
+        await relaunched.hydrateProjectsOnLaunch()
+        #expect(relaunched.projectStore.legacyDataOwnerProjectID == owner)
+        #expect(relaunched.projectStore.activeProjectID == second.id)
+
+        // Deleting the owner must not hand the legacy data to anyone else.
+        #expect(relaunched.deleteProject(id: owner))
+        #expect(await relaunched.waitForProjectTransition())
+        #expect(relaunched.projectStore.legacyDataOwnerProjectID == owner)
+        #expect(!relaunched.projectStore.projects.contains { $0.id == owner })
+    }
+
+    @Test("A Project whose settings store fails keeps the outgoing Project active")
+    func settingsFailureStaysFailClosed() async throws {
+        let environment = ProjectIsolationEnvironment(name: "failclosed")
+        defer { environment.tearDown() }
+        let coordinator = environment.makeCoordinator()
+        await coordinator.hydrateProjectsOnLaunch()
+
+        let projectA = coordinator.projectStore.activeProjectID
+        let owner = coordinator.projectStore.legacyDataOwnerProjectID
+        let sessionA = Self.summary(host: "a.example")
+        coordinator.sessions = [sessionA]
+
+        // Refuse storage for any new Project: creation must not silently succeed.
+        environment.provider.failsSettingsForNewProjects = true
+        let candidate = try #require(coordinator.createProject(named: "Second"))
+        let started = await coordinator.waitForProjectTransition()
+        #expect(!started)
+
+        #expect(coordinator.projectStore.activeProjectID == projectA)
+        #expect(coordinator.activeRuntime.projectID == projectA)
+        #expect(coordinator.sessions.map(\.host) == ["a.example"])
+        #expect(coordinator.projectTransitionStatus.failureMessage != nil)
+        // The unusable Project was never published, so there is nothing to roll
+        // back out of the catalog.
+        #expect(coordinator.projectStore.projects.count == 1)
+        #expect(!coordinator.projectStore.projects.contains { $0.id == candidate.id })
+        // A failed transition must never reassign the pre-Projects data.
+        #expect(coordinator.projectStore.legacyDataOwnerProjectID == owner)
+        // The catalog is unfrozen again, so the app is not wedged.
+        #expect(coordinator.projectStore.isMutable)
+    }
+
+    /// The destination of an active-Project deletion is resolved *before* the
+    /// deletion is published. A destination whose storage cannot be opened must
+    /// therefore leave both Projects in the catalog — the old path deleted first
+    /// and then had nothing left to fall back to.
+    @Test("An active delete whose destination cannot be prepared deletes nothing")
+    func activeDeleteWithUnpreparableDestinationDeletesNothing() async throws {
+        let environment = ProjectIsolationEnvironment(name: "deletefail", persistsCatalog: true)
+        defer { environment.tearDown() }
+
+        let first = environment.makeCoordinator()
+        await first.hydrateProjectsOnLaunch()
+        let projectA = first.projectStore.activeProjectID
+        let projectB = try #require(await Self.created(first, named: "Second"))
+        await first.flushProjectStateForTermination()
+
+        // Relaunch with B active, so A has no runtime bucket in this app session.
+        let relaunched = environment.makeCoordinator()
+        await relaunched.hydrateProjectsOnLaunch()
+        #expect(relaunched.projectStore.activeProjectID == projectB.id)
+
+        // A's storage is refused, so deleting B has nowhere safe to land.
+        environment.provider.failingSettingsProjectIDs = [projectA]
+        #expect(relaunched.deleteProject(id: projectB.id))
+        let deleted = await relaunched.waitForProjectTransition()
+        #expect(!deleted)
+
+        #expect(relaunched.projectStore.activeProjectID == projectB.id)
+        #expect(relaunched.projectStore.projects.count == 2)
+        #expect(relaunched.projectStore.projects.contains { $0.id == projectB.id })
+        #expect(relaunched.projectStore.projects.contains { $0.id == projectA })
+        #expect(relaunched.projectTransitionStatus.failureMessage != nil)
+        #expect(relaunched.retryableProjectTransition != nil)
+        #expect(relaunched.projectStore.isMutable)
+    }
+
+    /// A catalog change is published only after it has been written. A refused
+    /// write leaves the user on the Project they were on, with the catalog intact
+    /// and the change retryable.
+    @Test("A refused catalog write publishes nothing and stays retryable")
+    func refusedCatalogWritePublishesNothing() async throws {
+        let environment = ProjectIsolationEnvironment(name: "catalogsave")
+        defer { environment.tearDown() }
+        // Refuse exactly the two-Project candidate: the create transition's own
+        // write, never the single-Project workspace flush ahead of it.
+        let repository = ControllableProjectCatalogRepository(refusingSaveWithProjectCount: 2)
+        environment.catalogRepository = repository
+        let coordinator = environment.makeCoordinator()
+        await coordinator.hydrateProjectsOnLaunch()
+
+        let projectA = coordinator.projectStore.activeProjectID
+        coordinator.sessions = [Self.summary(host: "a.example")]
+
+        _ = try #require(coordinator.createProject(named: "Second"))
+        let committed = await coordinator.waitForProjectTransition()
+        #expect(!committed)
+        let refusals = await repository.refusedSaveCount
+        #expect(refusals == 1)
+        #expect(coordinator.projectStore.activeProjectID == projectA)
+        #expect(coordinator.projectStore.projects.count == 1)
+        #expect(coordinator.sessions.map(\.host) == ["a.example"])
+        #expect(coordinator.projectTransitionStatus.failureMessage != nil)
+        #expect(coordinator.retryableProjectTransition != nil)
+
+        // Nothing diverged from disk, so the store stays mutable and the retry is
+        // a real retry rather than a wedged catalog.
+        #expect(coordinator.projectStore.isMutable)
+        await repository.refuseSaveWithProjectCount(nil)
+        coordinator.retryProjectTransition()
+        #expect(await coordinator.waitForProjectTransition())
+        #expect(coordinator.projectStore.projects.count == 2)
+        #expect(coordinator.projectStore.activeProjectID != projectA)
+        #expect(coordinator.sessions.isEmpty)
+
+        #expect(await Self.switched(coordinator, to: projectA))
+        #expect(coordinator.sessions.map(\.host) == ["a.example"])
+    }
+
+    // MARK: The one lifecycle path
+
+    @Test("Switching while capturing asks first; Cancel leaves the Project untouched")
+    func capturingSwitchRequiresConfirmation() async throws {
+        let environment = ProjectIsolationEnvironment(name: "confirm")
+        defer { environment.tearDown() }
+        let coordinator = environment.makeCoordinator()
+        await coordinator.hydrateProjectsOnLaunch()
+
+        let projectA = coordinator.projectStore.activeProjectID
+        let projectB = try #require(await Self.created(coordinator, named: "Second"))
+        #expect(await Self.switched(coordinator, to: projectA))
+        coordinator.sessions = [Self.summary(host: "a.example")]
+        coordinator.isCapturing = true
+
+        #expect(!coordinator.switchToProject(id: projectB.id))
+        #expect(coordinator.pendingProjectSwitchConfirmation != nil)
+        #expect(coordinator.projectStore.activeProjectID == projectA)
+
+        coordinator.cancelPendingProjectSwitch()
+        #expect(coordinator.pendingProjectSwitchConfirmation == nil)
+        #expect(coordinator.projectStore.activeProjectID == projectA)
+        #expect(coordinator.isCapturing)
+        #expect(coordinator.sessions.count == 1)
+    }
+
+    @Test("Confirming waits for an already-stopping capture before the Project changes")
+    func confirmedSwitchDrainsFirst() async throws {
+        let environment = ProjectIsolationEnvironment(name: "drain")
+        defer { environment.tearDown() }
+        let coordinator = environment.makeCoordinator()
+        await coordinator.hydrateProjectsOnLaunch()
+
+        let projectA = coordinator.projectStore.activeProjectID
+        let projectB = try #require(await Self.created(coordinator, named: "Second"))
+        #expect(await Self.switched(coordinator, to: projectA))
+        coordinator.sessions = [Self.summary(host: "a.example")]
+        coordinator.isCapturing = true
+
+        #expect(!coordinator.switchToProject(id: projectB.id))
+        // Model Stop reaching the backend while the confirmation was open. No
+        // real helper or capture device is touched by this deterministic test.
+        coordinator.isCapturing = false
+        coordinator.startGeneration &+= 1
+        coordinator.beginFinalCaptureDrain(stoppedToken: coordinator.startGeneration)
+        coordinator.confirmPendingProjectSwitch()
+        // The transition is parked on the capture's final drain: nothing has moved.
+        #expect(coordinator.projectTransitionStatus.isPending)
+        #expect(coordinator.projectStore.activeProjectID == projectA)
+        await Task.yield()
+        // Stand in for the helper's final batch folding and publishing.
+        coordinator.completeFinalCaptureDrain(stoppedToken: coordinator.startGeneration)
+        let finished = await coordinator.waitForProjectTransition()
+        #expect(finished)
+
+        #expect(!coordinator.isCapturing)
+        #expect(!coordinator.isFinalDrainPending)
+        #expect(coordinator.projectStore.activeProjectID == projectB.id)
+        #expect(coordinator.sessions.isEmpty)
+
+        #expect(await Self.switched(coordinator, to: projectA))
+        #expect(coordinator.sessions.map(\.host) == ["a.example"])
+    }
+
+    /// A completion carrying a superseded stopped generation is not this stop's
+    /// boundary, so it releases nothing. Releasing every parked waiter on any
+    /// completion would let a transition swap the spool mid-drain.
+    @Test("A stale final-drain completion does not release the parked transition")
+    func staleFinalDrainCompletionReleasesNothing() async throws {
+        let environment = ProjectIsolationEnvironment(name: "stale")
+        defer { environment.tearDown() }
+        let coordinator = environment.makeCoordinator()
+        // The boundary here is released by hand, never by the bounded wait.
+        coordinator.projectTransitionDrainTimeout = .seconds(30)
+        await coordinator.hydrateProjectsOnLaunch()
+
+        let projectA = coordinator.projectStore.activeProjectID
+        let projectB = try #require(await Self.created(coordinator, named: "Second"))
+        #expect(await Self.switched(coordinator, to: projectA))
+        coordinator.sessions = [Self.summary(host: "a.example")]
+
+        // A stop that still owes an exact final batch, without touching the helper.
+        let stoppedToken = coordinator.startGeneration &+ 1
+        coordinator.beginFinalCaptureDrain(stoppedToken: stoppedToken)
+        #expect(coordinator.isFinalDrainPending)
+
+        #expect(coordinator.switchToProject(id: projectB.id))
+        await Task.yield()
+        #expect(coordinator.projectTransitionStatus.isPending)
+
+        // A superseded capture's completion must not resume this boundary.
+        coordinator.completeFinalCaptureDrain(stoppedToken: stoppedToken &- 1)
+        await Task.yield()
+        #expect(coordinator.isFinalDrainPending)
+        #expect(coordinator.projectTransitionStatus.isPending)
+        #expect(coordinator.projectStore.activeProjectID == projectA)
+
+        // The exact boundary does.
+        coordinator.completeFinalCaptureDrain(stoppedToken: stoppedToken)
+        #expect(await coordinator.waitForProjectTransition())
+        #expect(!coordinator.isFinalDrainPending)
+        #expect(coordinator.projectStore.activeProjectID == projectB.id)
+    }
+
+    @Test("A drain that never completes stays on the outgoing Project and offers a retry")
+    func drainTimeoutKeepsOutgoingProject() async throws {
+        let environment = ProjectIsolationEnvironment(name: "timeout")
+        defer { environment.tearDown() }
+        let coordinator = environment.makeCoordinator()
+        await coordinator.hydrateProjectsOnLaunch()
+
+        let projectA = coordinator.projectStore.activeProjectID
+        let projectB = try #require(await Self.created(coordinator, named: "Second"))
+        #expect(await Self.switched(coordinator, to: projectA))
+        coordinator.sessions = [Self.summary(host: "a.example")]
+        // A stop that is already owed a final helper batch which never arrives.
+        coordinator.beginFinalCaptureDrain(stoppedToken: coordinator.startGeneration)
+
+        #expect(coordinator.switchToProject(id: projectB.id))
+        let finished = await coordinator.waitForProjectTransition()
+        #expect(!finished)
+        #expect(coordinator.projectStore.activeProjectID == projectA)
+        #expect(coordinator.sessions.map(\.host) == ["a.example"])
+        #expect(coordinator.projectTransitionStatus.failureMessage != nil)
+        #expect(coordinator.retryableProjectTransition != nil)
+        // The catalog is unfrozen, so the retry below is not blocked by the freeze.
+        #expect(coordinator.projectStore.isMutable)
+    }
+
+    /// The timed-out transition stays on the outgoing Project, but the stop still
+    /// owes the same boundary. A retry must park on *that* boundary rather than
+    /// opening a second one that a stale completion could satisfy.
+    @Test("Retrying a timed-out transition awaits the same drain boundary")
+    func retryAwaitsTheSameDrainBoundary() async throws {
+        let environment = ProjectIsolationEnvironment(name: "retrydrain")
+        defer { environment.tearDown() }
+        let coordinator = environment.makeCoordinator()
+        await coordinator.hydrateProjectsOnLaunch()
+
+        let projectA = coordinator.projectStore.activeProjectID
+        let projectB = try #require(await Self.created(coordinator, named: "Second"))
+        #expect(await Self.switched(coordinator, to: projectA))
+        let stoppedToken = coordinator.startGeneration &+ 1
+        coordinator.beginFinalCaptureDrain(stoppedToken: stoppedToken)
+
+        #expect(coordinator.switchToProject(id: projectB.id))
+        let timedOut = await coordinator.waitForProjectTransition()
+        #expect(!timedOut)
+        #expect(coordinator.isFinalDrainPending)
+
+        // The retry parks on the *same* owed boundary, so it is released by hand.
+        coordinator.projectTransitionDrainTimeout = .seconds(30)
+        coordinator.retryProjectTransition()
+        await Task.yield()
+        #expect(coordinator.projectTransitionStatus.isPending)
+        #expect(coordinator.projectStore.activeProjectID == projectA)
+
+        coordinator.completeFinalCaptureDrain(stoppedToken: stoppedToken)
+        #expect(await coordinator.waitForProjectTransition())
+        #expect(coordinator.projectStore.activeProjectID == projectB.id)
+        #expect(!coordinator.isFinalDrainPending)
+    }
+
+    @Test("Capture start is refused while a Project transition is pending")
+    func captureStartIsBlockedDuringTransition() async {
+        let environment = ProjectIsolationEnvironment(name: "startblock")
+        defer { environment.tearDown() }
+        let coordinator = environment.makeCoordinator()
+
+        // Before hydration the runtime is unbound, so intake is refused outright.
+        #expect(coordinator.captureStartBlockedMessage != nil)
+        coordinator.startCapture()
+        #expect(!coordinator.isStarting)
+        #expect(coordinator.captureError != nil)
+
+        await coordinator.hydrateProjectsOnLaunch()
+        #expect(coordinator.captureStartBlockedMessage == nil)
+
+        // A stop that still owes a final batch defers the transition, and no
+        // capture may begin inside that window.
+        coordinator.beginFinalCaptureDrain(stoppedToken: coordinator.startGeneration)
+        #expect(coordinator.createProject(named: "Second") != nil)
+        #expect(coordinator.projectTransitionStatus.isPending)
+        #expect(coordinator.captureStartBlockedMessage != nil)
+        coordinator.startCapture()
+        #expect(!coordinator.isStarting)
+        _ = await coordinator.waitForProjectTransition()
+    }
+
+    @Test("Deleting the active Project uses the same boundary and preserves its data")
+    func deletingActiveProjectUsesTheSameBoundary() async throws {
+        let environment = ProjectIsolationEnvironment(name: "delete")
+        defer { environment.tearDown() }
+        let coordinator = environment.makeCoordinator()
+        await coordinator.hydrateProjectsOnLaunch()
+
+        let projectA = coordinator.projectStore.activeProjectID
+        coordinator.sessions = [Self.summary(host: "a.example")]
+        let projectB = try #require(await Self.created(coordinator, named: "Second"))
+        let directoryB = try #require(coordinator.capturesDirectory())
+        try Data([0]).write(to: directoryB.appendingPathComponent("Capture B.pcapng"))
+
+        #expect(coordinator.deleteProject(id: projectB.id))
+        #expect(await coordinator.waitForProjectTransition())
+        #expect(coordinator.projectStore.activeProjectID == projectA)
+        #expect(coordinator.sessions.map(\.host) == ["a.example"])
+        // The deleted Project's captures are preserved on disk, not removed.
+        #expect(FileManager.default.fileExists(
+            atPath: directoryB.appendingPathComponent("Capture B.pcapng").path
+        ))
+    }
+
+    @Test("A History write started in A lands in A even when a switch follows immediately")
+    func delayedHistoryWriteLandsInItsOwnProject() async throws {
+        let environment = ProjectIsolationEnvironment(name: "delayedhistory")
+        defer { environment.tearDown() }
+        let coordinator = environment.makeCoordinator()
+        await coordinator.hydrateProjectsOnLaunch()
+
+        let projectA = coordinator.projectStore.activeProjectID
+        let storeA = try #require(coordinator.sessionStore)
+        Self.writeTerminalCapture(into: coordinator, host: "a.example")
+        // Change Projects without awaiting the write. The pending terminal write
+        // defers the transition, so it must land against A's own database.
+        _ = try #require(coordinator.createProject(named: "Second"))
+        #expect(coordinator.projectTransitionStatus.isPending)
+        let finished = await coordinator.waitForProjectTransition()
+        #expect(finished)
+        let storeB = try #require(coordinator.sessionStore)
+        #expect(coordinator.projectStore.activeProjectID != projectA)
+
+        let inA = try await storeA.captures(after: nil, limit: 10)
+        let inB = try await storeB.captures(after: nil, limit: 10)
+        #expect(inA.captures.count == 1)
+        #expect(inB.captures.isEmpty)
+    }
+
+    // MARK: Private
+
+    // MARK: Transition helpers
+
+    /// Start a switch and await the durable completion the change now requires.
+    private static func switched(_ coordinator: MainContentCoordinator, to id: UUID) async -> Bool {
+        guard coordinator.switchToProject(id: id) else {
+            return false
+        }
+        return await coordinator.waitForProjectTransition()
+    }
+
+    /// Start a creation and await its durable completion, returning the Project
+    /// only when it actually became active.
+    private static func created(
+        _ coordinator: MainContentCoordinator,
+        named name: String
+    )
+        async -> Project?
+    {
+        guard let project = coordinator.createProject(named: name),
+              await coordinator.waitForProjectTransition() else
+        {
+            return nil
+        }
+        return project
+    }
+
+    // MARK: Fixtures
+
+    private static func summary(host: String) -> SessionSummary {
+        SessionSummary(
+            id: UUID(),
+            startTime: Date(timeIntervalSince1970: 1_000),
+            duration: 5,
+            processName: "curl",
+            host: host,
+            sourceEndpoint: "10.0.0.1:5000",
+            destinationEndpoint: "93.184.216.34:443",
+            protocolStack: [.tcp, .tls],
+            status: .ok,
+            latencyMilliseconds: 12.5,
+            bytesUp: 100,
+            bytesDown: 200
+        )
+    }
+
+    private static func frame(payload: UInt8) -> CapturedFrame {
+        CapturedFrame(
+            bytes: [payload] + [UInt8](repeating: 0, count: 63),
+            timestamp: Date(timeIntervalSince1970: 1_000),
+            originalLength: 64,
+            linkType: LinkType.ethernet
+        )
+    }
+
+    private static func writeTerminalCapture(into coordinator: MainContentCoordinator, host: String) {
+        coordinator.frozenHistoryLifetime = FrozenHistoryLifetime(
+            captureID: UUID(),
+            startedAt: Date(timeIntervalSince1970: 1),
+            endedAt: Date(timeIntervalSince1970: 2),
+            stoppedGeneration: coordinator.startGeneration
+        )
+        coordinator.persistTerminalLiveHistory(
+            sessions: [summary(host: host)],
+            stoppedGeneration: coordinator.startGeneration,
+            completeness: .complete
+        )
+    }
+}

--- a/TracexyTests/ViewModels/ProjectRecoveryBoundaryTests.swift
+++ b/TracexyTests/ViewModels/ProjectRecoveryBoundaryTests.swift
@@ -1,0 +1,261 @@
+import Foundation
+import Testing
+@testable import Tracexy
+
+// MARK: - ProjectRecoveryBoundaryTests
+
+/// The explicit destructive helper reset (Settings → Helper → Force Reset)
+/// destroys the XPC connection a running or stopping capture depends on, so the
+/// final drain that capture owes can never be completed by a reply. These tests
+/// drive the *app-side* hook only: no helper is installed, no privileged operation
+/// runs, no device is opened and no network traffic is captured. Everything is a
+/// synthetic engine epoch, a real file-backed spool inside a throwaway environment,
+/// and a deferred tail that is modelled as a late callback.
+///
+/// The contract under test: the obsolete owed operation is terminated as *failed*,
+/// the accepted prefix is finalized under the exact epoch and stopped generation
+/// the operation recorded and written to History as `incomplete`, the current
+/// Project stays recoverable, and nothing here ever claims the missing tail
+/// arrived.
+@MainActor
+@Suite("Destructive helper reset boundary")
+struct ProjectRecoveryBoundaryTests {
+    // MARK: Internal
+
+    @Test("A pending stop whose helper reply is lost is finalized as an incomplete prefix")
+    func pendingStopIsFinalizedWithoutClaimingTheTail() async throws {
+        let environment = ProjectIsolationEnvironment(name: "recovery-pending-stop")
+        defer { environment.tearDown() }
+        let coordinator = environment.makeCoordinator()
+        await coordinator.hydrateProjectsOnLaunch()
+        let projectA = coordinator.projectStore.activeProjectID
+
+        // A confirmed capture: this Project's own engine epoch and spool hold the
+        // prefix, and one durable History identity was minted at start.
+        let captureToken = coordinator.startGeneration
+        let spool = coordinator.liveCaptureSpool
+        coordinator.resetSessionEngineForSavedCapture(token: captureToken)
+        await coordinator.ingestChain?.value
+        let frames = SampleCapture.frames(now: Self.epoch)
+        coordinator.isCapturing = true
+        coordinator.beginLiveHistoryLifetime(captureGeneration: captureToken)
+        coordinator.ingest(frames, linkType: LinkType.ethernet)
+        await coordinator.ingestChain?.value
+        let expectedSessions = SessionBuilder.build(from: frames, linkType: LinkType.ethernet)
+        #expect(!expectedSessions.isEmpty)
+
+        // Stop reached the backend and minted its boundary; the helper's final reply
+        // is the thing the reset is about to make unreachable.
+        coordinator.startGeneration &+= 1
+        let stoppedToken = coordinator.startGeneration
+        coordinator.freezeLiveHistoryLifetime(captureGeneration: captureToken, stoppedGeneration: stoppedToken)
+        coordinator.isCapturing = false
+        let frozen = try #require(coordinator.frozenHistoryLifetime)
+        coordinator.beginFinalCaptureDrain(stoppedToken: stoppedToken, captureToken: captureToken)
+        #expect(coordinator.isFinalDrainPending)
+        #expect(coordinator.captureStartBlockedMessage != nil)
+
+        coordinator.prepareForDestructiveHelperReset()
+        await coordinator.ingestChain?.value
+        await coordinator.waitForHistory()
+
+        // The obsolete operation is retired, so the app is usable again.
+        #expect(!coordinator.isFinalDrainPending)
+        #expect(coordinator.captureStartBlockedMessage == nil)
+        // Truthfully, not as a success.
+        #expect(coordinator.captureError != nil)
+        #expect(coordinator.historyCaptures.count == 1)
+        #expect(coordinator.historyCaptures.first?.record.completeness == .incomplete)
+        // The recoverable prefix is finalized, never discarded to unblock the app.
+        #expect(coordinator.stoppedCaptureReadyGeneration == coordinator.startGeneration)
+        #expect(coordinator.startGeneration != stoppedToken)
+        #expect(coordinator.sessions.map(\.id) == expectedSessions.map(\.id))
+        #expect(coordinator.historyCaptures.first?.id == frozen.captureID)
+        coordinator.selectHistoryCapture(frozen.captureID)
+        await coordinator.waitForHistory()
+        #expect(coordinator.historySessions.count == expectedSessions.count)
+        #expect(coordinator.liveCaptureSpool === spool)
+        let spooled = try await spool.capture()
+        #expect(spooled.frames.map(\.bytes) == frames.map(\.bytes))
+        // The Project is left exactly where it was, and recoverable.
+        #expect(coordinator.projectStore.activeProjectID == projectA)
+        #expect(coordinator.projectTransitionStatus == .idle)
+    }
+
+    @Test("A stop parked before its stopped token is minted resolves the same operation")
+    func stopWithoutAStoppedTokenIsResolvedOnTheSameOperation() async throws {
+        let environment = ProjectIsolationEnvironment(name: "recovery-unminted-stop")
+        defer { environment.tearDown() }
+        let coordinator = environment.makeCoordinator()
+        await coordinator.hydrateProjectsOnLaunch()
+
+        let captureToken = coordinator.startGeneration
+        coordinator.resetSessionEngineForSavedCapture(token: captureToken)
+        await coordinator.ingestChain?.value
+        coordinator.beginLiveHistoryLifetime(captureGeneration: captureToken)
+        coordinator.isCapturing = true
+
+        // Exactly what `stopCapture()` does when a destructive helper fetch is still
+        // in flight: the drain is owed before a stopped generation exists.
+        coordinator.isStarting = false
+        coordinator.beginFinalCaptureDrain(stoppedToken: nil, captureToken: captureToken)
+        let owedOperation = try #require(coordinator.pendingFinalDrainOperationID)
+
+        coordinator.prepareForDestructiveHelperReset()
+        // The boundary minted here resolves the operation already owed rather than
+        // opening a second one a stale completion could satisfy.
+        #expect(coordinator.pendingFinalDrainOperationID == owedOperation)
+        #expect(!coordinator.isCapturing)
+        await coordinator.ingestChain?.value
+        await coordinator.waitForHistory()
+
+        #expect(!coordinator.isFinalDrainPending)
+        #expect(coordinator.historyCaptures.count == 1)
+        #expect(coordinator.historyCaptures.first?.record.completeness == .incomplete)
+        #expect(coordinator.captureError != nil)
+    }
+
+    @Test("A transition parked on the lost drain fails outgoing and retries after finalization")
+    func failedTransitionStaysOutgoingAndRetriesAfterFinalization() async throws {
+        let environment = ProjectIsolationEnvironment(name: "recovery-retry")
+        defer { environment.tearDown() }
+        let coordinator = environment.makeCoordinator()
+        // Only the reset may release this boundary; no bounded wait can.
+        coordinator.projectTransitionDrainTimeout = .seconds(30)
+        await coordinator.hydrateProjectsOnLaunch()
+
+        let projectA = coordinator.projectStore.activeProjectID
+        let projectB = try #require(await Self.created(coordinator, named: "Bravo"))
+        #expect(await Self.switched(coordinator, to: projectA))
+
+        let captureToken = coordinator.startGeneration
+        coordinator.resetSessionEngineForSavedCapture(token: captureToken)
+        await coordinator.ingestChain?.value
+        coordinator.startGeneration &+= 1
+        let stoppedToken = coordinator.startGeneration
+        coordinator.beginFinalCaptureDrain(stoppedToken: stoppedToken, captureToken: captureToken)
+
+        #expect(coordinator.switchToProject(id: projectB.id))
+        await Task.yield()
+        #expect(coordinator.projectTransitionStatus.isPending)
+
+        coordinator.prepareForDestructiveHelperReset()
+        // The parked transition is failed, never silently switched or completed.
+        #expect(await !coordinator.waitForProjectTransition())
+        #expect(coordinator.projectStore.activeProjectID == projectA)
+        #expect(coordinator.projectTransitionStatus.failureMessage != nil)
+        #expect(coordinator.retryableProjectTransition != nil)
+
+        await coordinator.ingestChain?.value
+        #expect(!coordinator.isFinalDrainPending)
+
+        // An explicit retry may proceed now that the prefix is finalized.
+        coordinator.retryProjectTransition()
+        #expect(await coordinator.waitForProjectTransition())
+        #expect(coordinator.projectStore.activeProjectID == projectB.id)
+    }
+
+    @Test("A late completion from the reset capture cannot release a newer stop")
+    func lateCompletionCannotReleaseANewerStop() async throws {
+        let environment = ProjectIsolationEnvironment(name: "recovery-late-tail")
+        defer { environment.tearDown() }
+        let coordinator = environment.makeCoordinator()
+        await coordinator.hydrateProjectsOnLaunch()
+
+        let captureToken = coordinator.startGeneration
+        coordinator.resetSessionEngineForSavedCapture(token: captureToken)
+        await coordinator.ingestChain?.value
+        coordinator.startGeneration &+= 1
+        let resetStoppedToken = coordinator.startGeneration
+        coordinator.beginFinalCaptureDrain(stoppedToken: resetStoppedToken, captureToken: captureToken)
+        let resetOperation = try #require(coordinator.pendingFinalDrainOperationID)
+
+        coordinator.prepareForDestructiveHelperReset()
+        await coordinator.ingestChain?.value
+        #expect(!coordinator.isFinalDrainPending)
+
+        // A later capture stops and owes its own, different boundary.
+        coordinator.startGeneration &+= 1
+        let newStoppedToken = coordinator.startGeneration
+        coordinator.beginFinalCaptureDrain(stoppedToken: newStoppedToken, captureToken: resetStoppedToken)
+        #expect(coordinator.pendingFinalDrainOperationID != resetOperation)
+
+        // The deferred tail of the reset capture finally arrives. It belongs to a
+        // retired operation, so it releases nothing.
+        coordinator.completeFinalCaptureDrain(stoppedToken: resetStoppedToken)
+        #expect(coordinator.isFinalDrainPending)
+        #expect(coordinator.pendingFinalDrainOperationID != resetOperation)
+
+        coordinator.completeFinalCaptureDrain(stoppedToken: newStoppedToken)
+        #expect(!coordinator.isFinalDrainPending)
+    }
+
+    @Test("Idle helper maintenance stops, republishes and writes nothing")
+    func idleHelperMaintenanceIsInert() async {
+        let environment = ProjectIsolationEnvironment(name: "recovery-idle")
+        defer { environment.tearDown() }
+        let coordinator = environment.makeCoordinator()
+        await coordinator.hydrateProjectsOnLaunch()
+
+        coordinator.sessions = [Self.summary(host: "a.example")]
+        let generation = coordinator.startGeneration
+        #expect(!coordinator.isFinalDrainPending)
+
+        coordinator.prepareForDestructiveHelperReset()
+        await coordinator.ingestChain?.value
+        await coordinator.waitForHistory()
+
+        // No boundary was minted, so no parked engine snapshot was republished and
+        // no terminal History was written for a capture that never stopped.
+        #expect(coordinator.startGeneration == generation)
+        #expect(coordinator.sessions.map(\.host) == ["a.example"])
+        #expect(coordinator.stoppedCaptureReadyGeneration == nil)
+        #expect(!coordinator.isFinalDrainPending)
+        #expect(!coordinator.isCapturing)
+        #expect(coordinator.captureError == nil)
+        #expect(coordinator.historyAvailability == .idle)
+        #expect(coordinator.historyCaptures.isEmpty)
+    }
+
+    // MARK: Private
+
+    private static let epoch = Date(timeIntervalSince1970: 1_700_000_000)
+
+    private static func switched(_ coordinator: MainContentCoordinator, to id: UUID) async -> Bool {
+        guard coordinator.switchToProject(id: id) else {
+            return false
+        }
+        return await coordinator.waitForProjectTransition()
+    }
+
+    private static func created(
+        _ coordinator: MainContentCoordinator,
+        named name: String
+    )
+        async -> Project?
+    {
+        guard let project = coordinator.createProject(named: name),
+              await coordinator.waitForProjectTransition() else
+        {
+            return nil
+        }
+        return project
+    }
+
+    private static func summary(host: String) -> SessionSummary {
+        SessionSummary(
+            id: UUID(),
+            startTime: Date(timeIntervalSince1970: 1_000),
+            duration: 5,
+            processName: "curl",
+            host: host,
+            sourceEndpoint: "10.0.0.1:5000",
+            destinationEndpoint: "93.184.216.34:443",
+            protocolStack: [.tcp, .tls],
+            status: .ok,
+            latencyMilliseconds: 12.5,
+            bytesUp: 100,
+            bytesDown: 200
+        )
+    }
+}

--- a/TracexyTests/ViewModels/ProjectSourceRaceTests.swift
+++ b/TracexyTests/ViewModels/ProjectSourceRaceTests.swift
@@ -1,0 +1,269 @@
+import Foundation
+import Testing
+@testable import Tracexy
+
+// MARK: - SourceRaceGate
+
+private actor SourceRaceGate {
+    // MARK: Internal
+
+    func pause() async {
+        entered = true
+        entry?.resume()
+        entry = nil
+        await withCheckedContinuation { completion = $0 }
+    }
+
+    func waitForEntry() async {
+        if !entered {
+            await withCheckedContinuation { entry = $0 }
+        }
+    }
+
+    func release() {
+        completion?.resume()
+        completion = nil
+    }
+
+    // MARK: Private
+
+    private var entered = false
+    private var entry: CheckedContinuation<Void, Never>?
+    private var completion: CheckedContinuation<Void, Never>?
+}
+
+// MARK: - ProjectSourceRaceTests
+
+@MainActor
+@Suite("Project reverse-order source races")
+struct ProjectSourceRaceTests {
+    // MARK: Internal
+
+    @Test("Save/export outcomes preserve Stop diagnostics and reject foreign Project errors")
+    func captureIOOutcomesRespectSourceOwnership() async {
+        let environment = ProjectIsolationEnvironment(name: "capture-io-outcomes")
+        defer { environment.tearDown() }
+        let coordinator = environment.makeCoordinator()
+        await coordinator.hydrateProjectsOnLaunch()
+        let origin = coordinator.projectStore.activeProjectID
+        let generation = coordinator.startGeneration
+        coordinator.startGeneration &+= 1 // Publication-only Stop boundary.
+        coordinator.captureError = "Stop diagnostic"
+        coordinator.reportCaptureIOOutcome(
+            failure: nil,
+            warning: nil,
+            didWrite: true,
+            originProjectID: origin,
+            originGeneration: generation
+        )
+        #expect(coordinator.captureError == "Stop diagnostic")
+        coordinator.reportCaptureIOOutcome(
+            failure: "Couldn’t export session",
+            warning: nil,
+            didWrite: false,
+            originProjectID: origin,
+            originGeneration: generation
+        )
+        #expect(coordinator.captureError == "Couldn’t export session")
+        coordinator.reportCaptureIOOutcome(
+            failure: nil,
+            warning: "Incomplete exported prefix",
+            didWrite: true,
+            originProjectID: origin,
+            originGeneration: generation
+        )
+        #expect(coordinator.captureError == "Incomplete exported prefix")
+        coordinator.reportCaptureIOOutcome(
+            failure: "Foreign error",
+            warning: nil,
+            didWrite: false,
+            originProjectID: UUID(),
+            originGeneration: coordinator.startGeneration
+        )
+        #expect(coordinator.captureError == "Incomplete exported prefix")
+        coordinator.reportCaptureIOOutcome(
+            failure: nil,
+            warning: nil,
+            didWrite: true,
+            originProjectID: origin,
+            originGeneration: coordinator.startGeneration
+        )
+        #expect(coordinator.captureError == nil)
+    }
+
+    @Test("A Save failure remains visible when Stop advances the same capture's generation")
+    func failedSaveIsReportedAcrossStop() async {
+        let environment = ProjectIsolationEnvironment(name: "save-stop-failure")
+        defer { environment.tearDown() }
+        let coordinator = environment.makeCoordinator()
+        await coordinator.hydrateProjectsOnLaunch()
+        coordinator.resetSessionEngineForSavedCapture(token: coordinator.startGeneration)
+        await coordinator.ingestChain?.value
+        coordinator.isCapturing = true
+        coordinator.ingest(SampleCapture.frames(now: Date()), linkType: LinkType.ethernet)
+        await coordinator.ingestChain?.value
+        let gate = SourceRaceGate()
+        coordinator.captureSaveOperation = CaptureSaveOperation { _, _, _ in
+            await gate.pause()
+            throw CocoaError(.fileWriteUnknown)
+        }
+        coordinator.saveCurrentCapture()
+        await gate.waitForEntry()
+        let save = coordinator.pendingCaptureIOTask
+        let generation = coordinator.startGeneration
+        // This takes the real local Stop boundary without reaching a helper proxy.
+        coordinator.prepareForDestructiveHelperReset()
+        await coordinator.ingestChain?.value
+        #expect(coordinator.startGeneration != generation)
+        await gate.release()
+        await save?.value
+        #expect(!coordinator.isCaptureSourceHeld)
+        #expect(coordinator.captureError?.contains("Couldn’t save") == true)
+    }
+
+    @Test("Stop-and-Switch confirmation rechecks an export started while confirmation was open")
+    func confirmationCannotBypassExportHold() async {
+        let environment = ProjectIsolationEnvironment(name: "confirmation-export-hold")
+        defer { environment.tearDown() }
+        let coordinator = environment.makeCoordinator()
+        await coordinator.hydrateProjectsOnLaunch()
+        let projectA = coordinator.projectStore.activeProjectID
+        coordinator.isCapturing = true // State only; no backend or network is started.
+        _ = coordinator.createProject(named: "Bravo")
+        #expect(coordinator.pendingProjectSwitchConfirmation != nil)
+        // Model Stop having completed while the confirmation remains open, then
+        // an export taking the source before the old confirmation is accepted.
+        coordinator.isCapturing = false
+        coordinator.setSessionExporting(true)
+        defer { coordinator.setSessionExporting(false) }
+        coordinator.confirmPendingProjectSwitch()
+        _ = await coordinator.projectTransitionTask?.value
+        #expect(coordinator.projectStore.activeProjectID == projectA)
+        #expect(coordinator.projectTransitionStatus.failureMessage != nil)
+        #expect(coordinator.retryableProjectTransition != nil)
+        coordinator.setSessionExporting(false)
+        coordinator.retryProjectTransition()
+        #expect(await coordinator.waitForProjectTransition())
+        #expect(coordinator.projectStore.activeProjectID != projectA)
+    }
+
+    @Test("A loader started before Save cannot replace the source at late adoption")
+    func lateOpenCannotReplaceSavingSource() async throws {
+        let environment = ProjectIsolationEnvironment(name: "reverse-open-save")
+        defer { environment.tearDown() }
+        let coordinator = environment.makeCoordinator()
+        await coordinator.hydrateProjectsOnLaunch()
+        let directory = try #require(coordinator.capturesDirectory())
+        let original = try fixture("original", frames: SampleCapture.frames(now: Date()), directory: directory)
+        let replacement = try fixture(
+            "replacement",
+            frames: Array(SampleCapture.frames(now: Date()).prefix(2)),
+            directory: directory
+        )
+        coordinator.openSavedCapture(original)
+        await coordinator.waitForSavedCaptureOpen()
+        await coordinator.waitForHistory()
+        let ids = coordinator.sessions.map(\.id)
+        let result = try SavedCaptureStreamLoader(contentsOf: replacement.url).load()
+        let loaderGate = SourceRaceGate()
+        let saveGate = SourceRaceGate()
+        coordinator.savedCaptureLoadOperation = SavedCaptureLoadOperation { _, _, _ in
+            await loaderGate.pause()
+            return result
+        }
+        coordinator.captureSaveOperation = CaptureSaveOperation { source, spool, destination in
+            await saveGate.pause()
+            try await CaptureSaveOperation.copy.run(source, spool, destination)
+        }
+        coordinator.openSavedCapture(replacement)
+        await loaderGate.waitForEntry()
+        let loader = coordinator.savedCaptureOpenTask
+        coordinator.saveCurrentCapture()
+        await saveGate.waitForEntry()
+        let save = coordinator.pendingCaptureIOTask
+        let generation = coordinator.startGeneration
+        await loaderGate.release()
+        await loader?.value
+        #expect(coordinator.activeSavedCapture == original)
+        #expect(coordinator.sessions.map(\.id) == ids)
+        #expect(coordinator.startGeneration == generation)
+        #expect(!coordinator.isOpeningSavedCapture)
+        #expect(coordinator.isCaptureSourceHeld)
+        await saveGate.release()
+        await save?.value
+        #expect(!coordinator.isCaptureSourceHeld)
+        let saved = try #require(coordinator.savedCaptures.first { $0.name.hasPrefix("Capture ") })
+        #expect(try Data(contentsOf: saved.url) == Data(contentsOf: original.url))
+    }
+
+    @Test("Import cannot replace a Library source while an accepted Save reads it")
+    func importCollisionCannotReplaceSavingSource() async throws {
+        let environment = ProjectIsolationEnvironment(name: "import-save-collision")
+        defer { environment.tearDown() }
+        let coordinator = environment.makeCoordinator()
+        await coordinator.hydrateProjectsOnLaunch()
+        let directory = try #require(coordinator.capturesDirectory())
+        let original = try fixture("collision", frames: SampleCapture.frames(now: Date()), directory: directory)
+        let external = try fixture(
+            "collision",
+            frames: Array(SampleCapture.frames(now: Date()).prefix(2)),
+            directory: environment.root.appendingPathComponent("Import")
+        )
+        let bytes = try Data(contentsOf: original.url)
+        coordinator.openSavedCapture(original)
+        await coordinator.waitForSavedCaptureOpen()
+        await coordinator.waitForHistory()
+        let gate = SourceRaceGate()
+        coordinator.captureSaveOperation = CaptureSaveOperation { source, spool, destination in
+            await gate.pause()
+            try await CaptureSaveOperation.copy.run(source, spool, destination)
+        }
+        coordinator.saveCurrentCapture()
+        await gate.waitForEntry()
+        let save = coordinator.pendingCaptureIOTask
+        coordinator.importCapture(from: external.url)
+        #expect(coordinator.captureError == coordinator.captureSourceHoldMessage)
+        #expect(try Data(contentsOf: original.url) == bytes)
+        #expect(coordinator.activeSavedCapture == original)
+        await gate.release()
+        await save?.value
+        let saved = try #require(coordinator.savedCaptures.first { $0.name.hasPrefix("Capture ") })
+        #expect(try Data(contentsOf: saved.url) == bytes)
+    }
+
+    @Test("A failed Save releases its source hold and permits an explicit retry")
+    func failedSaveReleasesHold() async throws {
+        let environment = ProjectIsolationEnvironment(name: "failed-save-unlock")
+        defer { environment.tearDown() }
+        let coordinator = environment.makeCoordinator()
+        await coordinator.hydrateProjectsOnLaunch()
+        let original = try fixture(
+            "original",
+            frames: SampleCapture.frames(now: Date()),
+            directory: #require(coordinator.capturesDirectory())
+        )
+        coordinator.openSavedCapture(original)
+        await coordinator.waitForSavedCaptureOpen()
+        await coordinator.waitForHistory()
+        coordinator.captureSaveOperation = CaptureSaveOperation { _, _, _ in throw CocoaError(.fileWriteUnknown) }
+        coordinator.saveCurrentCapture()
+        await coordinator.pendingCaptureIOTask?.value
+        #expect(!coordinator.isCaptureSourceHeld)
+        #expect(coordinator.captureStartBlockedMessage == nil)
+        #expect(coordinator.captureError?.contains("Couldn’t save") == true)
+        coordinator.captureSaveOperation = .copy
+        coordinator.saveCurrentCapture()
+        await coordinator.pendingCaptureIOTask?.value
+        #expect(coordinator.captureError == nil)
+        #expect(coordinator.savedCaptures.count == 2)
+    }
+
+    // MARK: Private
+
+    private func fixture(_ name: String, frames: [CapturedFrame], directory: URL) throws -> SavedCapture {
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let url = directory.appendingPathComponent("\(name).pcap")
+        try PcapWriter.write(linkType: LinkType.ethernet, frames: frames, to: url)
+        return try SavedCapture(url: url, name: name, date: Date(), byteCount: Data(contentsOf: url).count)
+    }
+}

--- a/TracexyTests/Views/Main/CaptureInterfaceToolbarTests.swift
+++ b/TracexyTests/Views/Main/CaptureInterfaceToolbarTests.swift
@@ -1,0 +1,106 @@
+import AppKit
+import SwiftUI
+import Testing
+@testable import Tracexy
+
+@MainActor
+struct CaptureInterfaceToolbarTests {
+    @Test("Toolbar source constraints follow a narrow-to-wide resize round trip")
+    func toolbarResizeRoundTrip() async throws {
+        let coordinator = MainContentCoordinator()
+        let split = NativeWorkspaceSplitViewController()
+        let toolbar = NativeWorkspaceToolbar(
+            splitViewController: split,
+            configuration: NativeWorkspaceToolbarConfiguration(coordinator: coordinator)
+        )
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 1_320, height: 700),
+            styleMask: [.titled, .resizable],
+            backing: .buffered,
+            defer: false
+        )
+        window.toolbar = toolbar.managedToolbar
+        let host = try #require(toolbar.managedToolbar.items.first {
+            $0.itemIdentifier == NativeWorkspaceToolbar.interfacePickerIdentifier
+        }?.view as? CaptureInterfaceToolbarHost)
+        #expect(host.sizingOptions.contains(.minSize))
+        #expect(host.sizingOptions.contains(.maxSize))
+        window.orderFront(nil)
+        defer { window.orderOut(nil) }
+        for width: CGFloat in [1_000, 1_320, 1_000, 1_320] {
+            window.setContentSize(NSSize(width: width, height: 700))
+            NotificationCenter.default.post(name: NSWindow.didResizeNotification, object: window)
+            await Task.yield()
+            window.contentView?.superview?.layoutSubtreeIfNeeded()
+            #expect(host.rootView.isCompact == (width < Theme.Metrics.toolbarCompactWindowWidth))
+            #expect(host.frame.width >= host.fittingSize.width - 1)
+        }
+    }
+
+    @Test("Source control remains measurable in light, dark, and high-contrast appearances")
+    func nativeAppearances() {
+        let host = CaptureInterfaceToolbarHost(coordinator: MainContentCoordinator())
+        for name in [
+            NSAppearance.Name.aqua,
+            .darkAqua,
+            .accessibilityHighContrastAqua,
+            .accessibilityHighContrastDarkAqua
+        ] {
+            host.appearance = NSAppearance(named: name)
+            for compact in [false, true] {
+                host.rootView.isCompact = compact
+                host.layoutSubtreeIfNeeded()
+                let size = host.fittingSize
+                #expect(size.width.isFinite && size.width > 0)
+                #expect(size.height.isFinite && size.height > 0)
+            }
+        }
+    }
+
+    @Test("Source label collapses at narrow widths without changing capture selection")
+    func responsiveDensity() {
+        let coordinator = MainContentCoordinator()
+        let selectedInterface = NetworkInterfaces.available().first?.id ?? coordinator.captureInterface
+        coordinator.captureInterface = selectedInterface
+        let host = CaptureInterfaceToolbarHost(coordinator: coordinator)
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 1_320, height: 700),
+            styleMask: [.titled, .resizable], backing: .buffered, defer: false
+        )
+        window.contentView = host
+        #expect(!host.rootView.isCompact)
+
+        window.setContentSize(NSSize(width: 1_000, height: 700))
+        NotificationCenter.default.post(name: NSWindow.didResizeNotification, object: window)
+        #expect(host.rootView.isCompact)
+
+        window.setContentSize(NSSize(width: Theme.Metrics.toolbarCompactWindowWidth, height: 700))
+        NotificationCenter.default.post(name: NSWindow.didResizeNotification, object: window)
+        #expect(!host.rootView.isCompact)
+        #expect(coordinator.captureInterface == selectedInterface)
+    }
+
+    @Test("Rehosting observes only the current window")
+    func windowObservationOwnership() {
+        let host = CaptureInterfaceToolbarHost(coordinator: MainContentCoordinator())
+        let narrow = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 1_000, height: 700),
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false
+        )
+        let wide = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 1_320, height: 700),
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false
+        )
+        narrow.contentView = host
+        #expect(host.rootView.isCompact)
+        narrow.contentView = nil
+        wide.contentView = host
+        #expect(!host.rootView.isCompact)
+        NotificationCenter.default.post(name: NSWindow.didResizeNotification, object: narrow)
+        #expect(!host.rootView.isCompact)
+    }
+}

--- a/TracexyTests/Views/Main/LiveSessionFollowingTests.swift
+++ b/TracexyTests/Views/Main/LiveSessionFollowingTests.swift
@@ -134,11 +134,9 @@ struct LiveSessionFollowingTests {
     }
 
     private func makeLoadedCoordinator(function: String = #function) async throws -> Environment {
-        let suiteName = "com.amunx.tracexy.tests.\(function).\(UUID().uuidString)"
-        let defaults = try #require(UserDefaults(suiteName: suiteName))
-        let coordinator = MainContentCoordinator(
-            layoutPreferences: WorkspaceLayoutPreferences(defaults: defaults)
-        )
+        let isolation = ProjectIsolationEnvironment(name: function)
+        let coordinator = isolation.makeCoordinator()
+        await coordinator.hydrateProjectsOnLaunch()
         let directory = URL(fileURLWithPath: NSTemporaryDirectory())
             .appendingPathComponent("tracexy-follow-tests-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
@@ -153,7 +151,7 @@ struct LiveSessionFollowingTests {
         try #require(!coordinator.sessions.isEmpty)
 
         return Environment(coordinator: coordinator) {
-            defaults.removePersistentDomain(forName: suiteName)
+            isolation.tearDown()
             try? FileManager.default.removeItem(at: directory)
         }
     }

--- a/TracexyTests/Views/Main/NativeSplitLayoutTests.swift
+++ b/TracexyTests/Views/Main/NativeSplitLayoutTests.swift
@@ -139,6 +139,21 @@ struct NativeSplitLayoutTests {
         #expect(workspace != bottom)
     }
 
+    @MainActor
+    @Test("Each Project owns separate root and evidence divider positions")
+    func projectAutosaveNamesAreDistinct() {
+        let first = UUID()
+        let second = UUID()
+        let names = [
+            RootView.workspaceSplitAutosaveName(projectID: first),
+            RootView.workspaceSplitAutosaveName(projectID: second),
+            RootView.bottomInspectorSplitAutosaveName(projectID: first),
+            RootView.bottomInspectorSplitAutosaveName(projectID: second),
+        ]
+        #expect(Set(names).count == 4)
+        #expect(names[0] == RootView.workspaceSplitAutosaveName(projectID: first))
+    }
+
     // MARK: Native window toolbar chrome
 
     @MainActor
@@ -204,7 +219,9 @@ struct NativeSplitLayoutTests {
         let statusIndex = identifiers.firstIndex(of: NativeWorkspaceToolbar.captureStatusIdentifier)
         #expect(projectSelectorIndex.map { identifiers[$0 + 1] } == .flexibleSpace)
         #expect(interfacePickerIndex == statusIndex.map { $0 + 2 })
-        #expect(captureIndex == interfacePickerIndex.map { $0 + 1 })
+        #expect(interfacePickerIndex.map { identifiers[$0 + 1] }
+            == NativeWorkspaceToolbar.captureSeparatorIdentifier)
+        #expect(captureIndex == interfacePickerIndex.map { $0 + 2 })
         #expect(captureIndex.map { identifiers[$0 + 1] } == .space)
 
         let selectorItem = toolbar.managedToolbar.items.first(where: {
@@ -278,13 +295,81 @@ struct NativeSplitLayoutTests {
             $0.itemIdentifier == NativeWorkspaceToolbar.sessionExportIdentifier
         }) as? NSMenuToolbarItem
         #expect(exportItem != nil)
-        #expect(exportItem?.isBordered == false)
+        #expect(exportItem?.isBordered == true)
         #expect(exportItem?.showsIndicator == true)
         #expect(exportItem?.menu.items.map(\.title) == [
             "Export Session",
             "Export as pcap",
             "Export as pcapng",
         ])
+    }
+
+    @MainActor
+    @Test("Capture separator is a noninteractive native hairline")
+    func nativeCaptureSeparator() throws {
+        let controller = makeToolbarController()
+        let toolbar = NativeWorkspaceToolbar(
+            splitViewController: controller,
+            configuration: NativeWorkspaceToolbarConfiguration(coordinator: MainContentCoordinator())
+        )
+        let window = NSWindow(contentViewController: controller)
+        window.toolbar = toolbar.managedToolbar
+        let item = try #require(toolbar.managedToolbar.items.first {
+            $0.itemIdentifier == NativeWorkspaceToolbar.captureSeparatorIdentifier
+        })
+        let separator = try #require(item.view as? NSBox)
+        #expect(separator.boxType == .separator)
+        #expect(!separator.isAccessibilityElement())
+        #expect(!separator.acceptsFirstResponder)
+        #expect(!item.isBordered)
+        #expect(item.action == nil)
+        // NSBox includes native padding in fittingSize; pin the requested
+        // hairline constraint and its vertical orientation, not that padding.
+        #expect(separator.constraints.contains {
+            $0.isActive && $0.firstAttribute == .width
+                && $0.constant == Theme.Metrics.toolbarSeparatorWidth
+        })
+        #expect(separator.fittingSize.width < separator.fittingSize.height)
+        #expect(separator.fittingSize.height == Theme.Metrics.toolbarSeparatorHeight)
+    }
+
+    @MainActor
+    @Test("Export retains its native border across selection and busy states")
+    func nativeExportAvailability() async throws {
+        let controller = makeToolbarController()
+        let coordinator = MainContentCoordinator()
+        let toolbar = NativeWorkspaceToolbar(
+            splitViewController: controller,
+            configuration: NativeWorkspaceToolbarConfiguration(coordinator: coordinator)
+        )
+        let window = NSWindow(contentViewController: controller)
+        window.toolbar = toolbar.managedToolbar
+        let item = try #require(toolbar.managedToolbar.items.first {
+            $0.itemIdentifier == NativeWorkspaceToolbar.sessionExportIdentifier
+        } as? NSMenuToolbarItem)
+        toolbar.startObservingState()
+        #expect(!item.isEnabled)
+        #expect(item.isBordered)
+
+        let frames = ReplayCorpus.tcpConnectionCapturedFrames()
+        coordinator.retainedFrames.append(contentsOf: frames)
+        coordinator.sessions = SessionBuilder.build(from: frames, linkType: LinkType.ethernet)
+        try coordinator.select(#require(coordinator.sessions.first))
+        await Task.yield()
+        #expect(item.isEnabled)
+        #expect(item.isBordered)
+
+        coordinator.setSessionExporting(true)
+        await Task.yield()
+        #expect(!item.isEnabled)
+        #expect(item.isBordered)
+        coordinator.setSessionExporting(false)
+        await Task.yield()
+        #expect(item.isEnabled)
+        coordinator.workspaces.activeWorkspace.selectedSessionID = nil
+        await Task.yield()
+        #expect(!item.isEnabled)
+        #expect(item.isBordered)
     }
 
     @MainActor

--- a/TracexyTests/Views/Main/NativeSplitLayoutTests.swift
+++ b/TracexyTests/Views/Main/NativeSplitLayoutTests.swift
@@ -178,6 +178,55 @@ struct NativeSplitLayoutTests {
     }
 
     @MainActor
+    @Test("Project stands alone after the sidebar; capture source stays beside Start/Stop")
+    func nativeProjectSelectorPlacement() {
+        let controller = makeToolbarController()
+        let toolbar = NativeWorkspaceToolbar(
+            splitViewController: controller,
+            configuration: NativeWorkspaceToolbarConfiguration(coordinator: MainContentCoordinator())
+        )
+        let window = NSWindow(contentViewController: controller)
+        window.toolbar = toolbar.managedToolbar
+
+        let identifiers = toolbar.managedToolbar.items.map(\.itemIdentifier)
+        let trackingSeparatorIndex = identifiers.firstIndex(
+            of: NativeWorkspaceToolbar.sidebarTrackingSeparatorIdentifier
+        )
+        let projectSelectorIndex = identifiers.firstIndex(
+            of: NativeWorkspaceToolbar.projectSelectorIdentifier
+        )
+        let interfacePickerIndex = identifiers.firstIndex(
+            of: NativeWorkspaceToolbar.interfacePickerIdentifier
+        )
+
+        #expect(projectSelectorIndex == trackingSeparatorIndex.map { $0 + 1 })
+        let captureIndex = identifiers.firstIndex(of: NativeWorkspaceToolbar.captureActionIdentifier)
+        let statusIndex = identifiers.firstIndex(of: NativeWorkspaceToolbar.captureStatusIdentifier)
+        #expect(projectSelectorIndex.map { identifiers[$0 + 1] } == .flexibleSpace)
+        #expect(interfacePickerIndex == statusIndex.map { $0 + 2 })
+        #expect(captureIndex == interfacePickerIndex.map { $0 + 1 })
+        #expect(captureIndex.map { identifiers[$0 + 1] } == .space)
+
+        let selectorItem = toolbar.managedToolbar.items.first(where: {
+            $0.itemIdentifier == NativeWorkspaceToolbar.projectSelectorIdentifier
+        })
+        #expect(selectorItem?.view != nil)
+        #expect(selectorItem?.visibilityPriority == .high)
+    }
+
+    @MainActor
+    @Test("Project selector width stays bounded for short and long names")
+    func projectSelectorWidthIsBounded() {
+        let shortWidth = ProjectToolbarSelectorMetrics.preferredWidth(for: "A")
+        let longWidth = ProjectToolbarSelectorMetrics.preferredWidth(
+            for: String(repeating: "Very Long Project Name ", count: 20)
+        )
+
+        #expect(shortWidth == ProjectToolbarSelectorMetrics.minimumWidth)
+        #expect(longWidth == ProjectToolbarSelectorMetrics.maximumWidth)
+    }
+
+    @MainActor
     @Test("Centered capture status leaves its single border to the native toolbar item")
     func nativeCaptureStatusSurfaceOwnership() {
         let controller = makeToolbarController()
@@ -200,7 +249,7 @@ struct NativeSplitLayoutTests {
     }
 
     @MainActor
-    @Test("Trailing export menu stays visible beside the grouped capture and inspector actions")
+    @Test("Export and inspectors stay separate from the source and capture action")
     func nativeActionGroupStructure() {
         let controller = makeToolbarController()
         let toolbar = NativeWorkspaceToolbar(
@@ -219,8 +268,11 @@ struct NativeSplitLayoutTests {
 
         let group = actionsItem as? NSToolbarItemGroup
         #expect(group != nil)
-        #expect(group?.subitems.count == 3)
-        #expect(group?.subitems.map(\.label) == ["Start", "Bottom Inspector", "Inspector"])
+        #expect(group?.subitems.count == 2)
+        #expect(group?.subitems.map(\.label) == ["Bottom Inspector", "Inspector"])
+        #expect(toolbar.managedToolbar.items.contains {
+            $0.itemIdentifier == NativeWorkspaceToolbar.captureActionIdentifier
+        })
 
         let exportItem = toolbar.managedToolbar.items.first(where: {
             $0.itemIdentifier == NativeWorkspaceToolbar.sessionExportIdentifier
@@ -247,13 +299,9 @@ struct NativeSplitLayoutTests {
         let window = NSWindow(contentViewController: controller)
         window.toolbar = toolbar.managedToolbar
 
-        guard let group = toolbar.managedToolbar.items.first(where: {
-            $0.itemIdentifier == NativeWorkspaceToolbar.actionsIdentifier
-        }) as? NSToolbarItemGroup,
-            let captureItem = group.subitems.first(where: {
-                $0.itemIdentifier == NativeWorkspaceToolbar.captureActionIdentifier
-            }) else
-        {
+        guard let captureItem = toolbar.managedToolbar.items.first(where: {
+            $0.itemIdentifier == NativeWorkspaceToolbar.captureActionIdentifier
+        }) else {
             Issue.record("Capture toolbar item was not installed")
             return
         }

--- a/TracexyTests/Views/Main/SavedCaptureOpeningTests.swift
+++ b/TracexyTests/Views/Main/SavedCaptureOpeningTests.swift
@@ -9,7 +9,7 @@ struct SavedCaptureOpeningTests {
 
     @Test("Open publishes only one final bounded result and lazy-loads selected evidence")
     func finalOnlyOpenAndLazyEvidence() async throws {
-        let environment = try makeEnvironment()
+        let environment = try await makeEnvironment()
         defer { environment.teardown() }
         let frames = SampleCapture.frames(now: Date())
         let capture = try writeCapture(named: "bounded", frames: frames, in: environment.directory)
@@ -41,7 +41,7 @@ struct SavedCaptureOpeningTests {
 
     @Test("A malformed newer open preserves the previously published capture")
     func malformedOpenPreservesPublishedState() async throws {
-        let environment = try makeEnvironment()
+        let environment = try await makeEnvironment()
         defer { environment.teardown() }
         let valid = try writeCapture(
             named: "valid",
@@ -65,7 +65,7 @@ struct SavedCaptureOpeningTests {
 
     @Test("A newer open retires every result and progress callback from the older request")
     func newerOpenWins() async throws {
-        let environment = try makeEnvironment()
+        let environment = try await makeEnvironment()
         defer { environment.teardown() }
         let first = try writeCapture(
             named: "first",
@@ -86,7 +86,7 @@ struct SavedCaptureOpeningTests {
 
     @Test("Clear retires a pending saved open without publishing partial state")
     func clearRetiresPendingOpen() async throws {
-        let environment = try makeEnvironment()
+        let environment = try await makeEnvironment()
         defer { environment.teardown() }
         let capture = try writeCapture(
             named: "cancelled",
@@ -107,7 +107,7 @@ struct SavedCaptureOpeningTests {
 
     @Test("A multi-gigabyte sparse open cancels without publishing or traversing the sparse tail")
     func sparseOpenCancelsIncrementally() async throws {
-        let environment = try makeEnvironment()
+        let environment = try await makeEnvironment()
         defer { environment.teardown() }
         let firstFrame = try #require(SampleCapture.frames(now: Date()).first)
         let base = try writeCapture(named: "sparse", frames: [firstFrame], in: environment.directory)
@@ -137,7 +137,7 @@ struct SavedCaptureOpeningTests {
 
     @Test("A truncated tail publishes prior sessions with an explicit warning")
     func truncatedTailIsExplicit() async throws {
-        let environment = try makeEnvironment()
+        let environment = try await makeEnvironment()
         defer { environment.teardown() }
         let frames = SampleCapture.frames(now: Date())
         let capture = try writeCapture(named: "truncated", frames: frames, in: environment.directory)
@@ -165,7 +165,7 @@ struct SavedCaptureOpeningTests {
 
     @Test("Opening a saved capture adopts the loader's connection snapshot")
     func openAdoptsConnectionSnapshot() async throws {
-        let environment = try makeEnvironment()
+        let environment = try await makeEnvironment()
         defer { environment.teardown() }
         let frames = ReplayCorpus.tcpConnectionCapturedFrames()
         let capture = try writeCapture(named: "connections", frames: frames, in: environment.directory)
@@ -195,7 +195,7 @@ struct SavedCaptureOpeningTests {
 
     @Test("Clear removes both the sessions and the connection snapshot")
     func clearRemovesSessionsAndConnections() async throws {
-        let environment = try makeEnvironment()
+        let environment = try await makeEnvironment()
         defer { environment.teardown() }
         let frames = ReplayCorpus.tcpConnectionCapturedFrames()
         let capture = try writeCapture(named: "clearable", frames: frames, in: environment.directory)
@@ -215,7 +215,7 @@ struct SavedCaptureOpeningTests {
 
     @Test("A malformed newer open preserves the previously published session/connection pair")
     func malformedOpenPreservesConnectionPair() async throws {
-        let environment = try makeEnvironment()
+        let environment = try await makeEnvironment()
         defer { environment.teardown() }
         let valid = try writeCapture(
             named: "valid-connections",
@@ -247,7 +247,7 @@ struct SavedCaptureOpeningTests {
 
     @Test("A live investigation publication adopts the exact pair only for the current generation and state")
     func liveInvestigationPublicationHonorsGenerationAndState() async throws {
-        let environment = try makeEnvironment()
+        let environment = try await makeEnvironment()
         defer { environment.teardown() }
         let coordinator = environment.coordinator
 
@@ -303,7 +303,7 @@ struct SavedCaptureOpeningTests {
 
     @Test("Opening a saved capture adopts a non-vacuous datagram analysis and clear resets it")
     func openAdoptsNonVacuousDatagramAnalysisAndClearResetsIt() async throws {
-        let environment = try makeEnvironment()
+        let environment = try await makeEnvironment()
         defer { environment.teardown() }
         // A capture whose IPv4 UDP-DNS response has the TC bit set, so the datagram
         // analysis is a non-vacuous single note rather than empty.
@@ -327,7 +327,7 @@ struct SavedCaptureOpeningTests {
 
     @Test("A malformed newer open preserves a non-vacuous datagram analysis")
     func malformedOpenPreservesNonVacuousDatagramAnalysis() async throws {
-        let environment = try makeEnvironment()
+        let environment = try await makeEnvironment()
         defer { environment.teardown() }
         let valid = try writeCapture(
             named: "valid-datagram",
@@ -351,7 +351,7 @@ struct SavedCaptureOpeningTests {
 
     @Test("A live datagram publication adopts the exact non-vacuous value only for the current generation/state")
     func liveDatagramPublicationHonorsGenerationAndState() async throws {
-        let environment = try makeEnvironment()
+        let environment = try await makeEnvironment()
         defer { environment.teardown() }
         let coordinator = environment.coordinator
 
@@ -448,18 +448,14 @@ struct SavedCaptureOpeningTests {
         }
     }
 
-    private func makeEnvironment(function: String = #function) throws -> Environment {
-        let suiteName = "com.amunx.tracexy.saved-open.\(function).\(UUID().uuidString)"
-        let defaults = try #require(UserDefaults(suiteName: suiteName))
-        let directory = URL(fileURLWithPath: NSTemporaryDirectory())
-            .appendingPathComponent("tracexy-saved-open-\(UUID().uuidString)", isDirectory: true)
+    private func makeEnvironment(function: String = #function) async throws -> Environment {
+        let isolation = ProjectIsolationEnvironment(name: function)
+        let coordinator = isolation.makeCoordinator()
+        await coordinator.hydrateProjectsOnLaunch()
+        let directory = isolation.root.appendingPathComponent("Fixtures", isDirectory: true)
         try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
-        let coordinator = MainContentCoordinator(
-            layoutPreferences: WorkspaceLayoutPreferences(defaults: defaults)
-        )
         return Environment(coordinator: coordinator, directory: directory) {
-            defaults.removePersistentDomain(forName: suiteName)
-            try? FileManager.default.removeItem(at: directory)
+            isolation.tearDown()
         }
     }
 

--- a/TracexyTests/Views/Main/WorkspacePresentationContractTests.swift
+++ b/TracexyTests/Views/Main/WorkspacePresentationContractTests.swift
@@ -208,7 +208,7 @@ struct WorkspacePresentationContractTests {
         #expect(!settings.contains("TabView(selection:"))
     }
 
-    @Test("Main toolbar keeps workspace titles out and the capture picker in its native slot")
+    @Test("Main toolbar separates Project context from capture controls")
     func mainToolbarOwnsWorkspaceContext() throws {
         let root = try readProjectFile("Tracexy/Views/Main/RootView.swift")
         let chrome = try readProjectFile("Tracexy/Views/Common/NativeWorkspaceWindowChrome.swift")
@@ -217,7 +217,12 @@ struct WorkspacePresentationContractTests {
         #expect(!root.contains(".navigationSubtitle("))
         #expect(chrome.contains("window.title = TracexyIdentity.current.displayName"))
         #expect(chrome.contains("window.titleVisibility = .hidden"))
-        #expect(chrome.contains("Self.sidebarTrackingSeparatorIdentifier,\n            Self.interfacePickerIdentifier"))
+        #expect(chrome.contains(
+            "Self.sidebarTrackingSeparatorIdentifier,\n            Self.projectSelectorIdentifier,\n            .flexibleSpace"
+        ))
+        #expect(chrome.contains(
+            "Self.interfacePickerIdentifier,\n            Self.captureActionIdentifier,\n            .space"
+        ))
     }
 
     @Test("Capture status uses the native toolbar as its only visible surface")

--- a/TracexyTests/Views/Main/WorkspacePresentationContractTests.swift
+++ b/TracexyTests/Views/Main/WorkspacePresentationContractTests.swift
@@ -6,6 +6,33 @@ import Testing
 struct WorkspacePresentationContractTests {
     // MARK: Internal
 
+    @Test("Project changes remount native layout and scoped editors without remounting launch setup")
+    func projectPresentationIdentity() throws {
+        let root = try readProjectFile("Tracexy/Views/Main/RootView.swift")
+        let app = try readProjectFile("Tracexy/TracexyApp.swift")
+        let manager = try readProjectFile("Tracexy/Views/Projects/ProjectPresentation.swift")
+        #expect(root.contains("return ZStack {"))
+        #expect(root.contains(".id(activeProjectID)"))
+        #expect(root.contains("isSidebarPresented: sidebarVisibility"))
+        #expect(root.contains("coordinator.startGeneration == launchGeneration"))
+        #expect(app.contains(".defaultAppStorage(coordinator.activeProjectDefaults)"))
+        #expect(app.components(separatedBy: ".id(coordinator.projectStore.activeProjectID)").count == 5)
+        #expect(root.contains("ProjectTransitionPresentation("))
+        #expect(manager.contains("ProjectTransitionPresentation("))
+        #expect(manager.contains("unsaved in-memory sessions and evidence"))
+    }
+
+    @Test("Synthetic Project composition isolates storage roots and application settings")
+    func demoProjectCompositionIsIsolated() throws {
+        let app = try readProjectFile("Tracexy/TracexyApp.swift")
+        let settings = try readProjectFile("Tracexy/Views/Settings/SettingsView.swift")
+        #expect(app.contains("applicationSupportRoot: demoRoot.appendingPathComponent"))
+        #expect(app.contains("cacheRoot: demoRoot.appendingPathComponent"))
+        #expect(app.contains("applicationDefaults: Self.applicationDefaults"))
+        #expect(settings.contains("GeneralSettingsView(applicationDefaults: applicationDefaults)"))
+        #expect(settings.contains("applicationDefaults: applicationDefaults,"))
+    }
+
     @Test("Monitor navigation is exactly Overview, Sessions, Flow Map, History, in that order")
     func monitorOrder() {
         #expect(SidebarSection.monitor.items == [.overview, .sessions, .flow, .history])
@@ -221,7 +248,7 @@ struct WorkspacePresentationContractTests {
             "Self.sidebarTrackingSeparatorIdentifier,\n            Self.projectSelectorIdentifier,\n            .flexibleSpace"
         ))
         #expect(chrome.contains(
-            "Self.interfacePickerIdentifier,\n            Self.captureActionIdentifier,\n            .space"
+            "Self.interfacePickerIdentifier,\n            Self.captureSeparatorIdentifier,\n            Self.captureActionIdentifier,\n            .space"
         ))
     }
 
@@ -381,9 +408,10 @@ struct WorkspacePresentationContractTests {
         #expect(sidebar.contains("restoreLabel: \"Restore Hidden Domains\""))
         #expect(sidebar.contains("restoreLabel: \"Restore Hidden IP Addresses\""))
         #expect(sidebar.contains(".frame(maxWidth: .infinity, alignment: .leading)"))
-        #expect(visibility.contains("sources.hiddenApps"))
-        #expect(visibility.contains("sources.hiddenDomains"))
-        #expect(visibility.contains("sources.hiddenIPs"))
+        #expect(visibility.contains("ProjectScopedSettingsKeys.hiddenSourceApps"))
+        #expect(visibility.contains("ProjectScopedSettingsKeys.hiddenSourceDomains"))
+        #expect(visibility.contains("ProjectScopedSettingsKeys.hiddenSourceIPs"))
+        #expect(visibility.contains("defaults: activeProjectDefaults"))
         #expect(visibility.contains("persistHiddenSources()"))
         #expect(!visibility.contains("sessions.removeAll"))
     }

--- a/TracexyTests/Views/Overview/OverviewScopeTests.swift
+++ b/TracexyTests/Views/Overview/OverviewScopeTests.swift
@@ -211,11 +211,9 @@ struct OverviewScopeTests {
     /// Writes the sample frames to a real `.pcap` and opens it through
     /// `openSavedCapture`, the same path the sidebar uses.
     private func makeLoadedCoordinator(function: String = #function) async throws -> Environment {
-        let suiteName = "com.amunx.tracexy.tests.\(function).\(UUID().uuidString)"
-        let defaults = try #require(UserDefaults(suiteName: suiteName))
-        let coordinator = MainContentCoordinator(
-            layoutPreferences: WorkspaceLayoutPreferences(defaults: defaults)
-        )
+        let isolation = ProjectIsolationEnvironment(name: function)
+        let coordinator = isolation.makeCoordinator()
+        await coordinator.hydrateProjectsOnLaunch()
 
         let directory = URL(fileURLWithPath: NSTemporaryDirectory())
             .appendingPathComponent("tracexy-tests-\(UUID().uuidString)", isDirectory: true)
@@ -231,7 +229,7 @@ struct OverviewScopeTests {
         try #require(!coordinator.sessions.isEmpty, "opening the sample capture must produce sessions")
 
         return Environment(coordinator: coordinator) {
-            defaults.removePersistentDomain(forName: suiteName)
+            isolation.tearDown()
             try? FileManager.default.removeItem(at: directory)
         }
     }

--- a/TracexyTests/Views/Sessions/SessionRowGroupingTests.swift
+++ b/TracexyTests/Views/Sessions/SessionRowGroupingTests.swift
@@ -161,11 +161,9 @@ struct SessionRowGroupingTests {
     }
 
     private func makeLoadedCoordinator(function: String = #function) async throws -> Environment {
-        let suiteName = "com.amunx.tracexy.tests.\(function).\(UUID().uuidString)"
-        let defaults = try #require(UserDefaults(suiteName: suiteName))
-        let coordinator = MainContentCoordinator(
-            layoutPreferences: WorkspaceLayoutPreferences(defaults: defaults)
-        )
+        let isolation = ProjectIsolationEnvironment(name: function)
+        let coordinator = isolation.makeCoordinator()
+        await coordinator.hydrateProjectsOnLaunch()
 
         let directory = URL(fileURLWithPath: NSTemporaryDirectory())
             .appendingPathComponent("tracexy-tests-\(UUID().uuidString)", isDirectory: true)
@@ -180,7 +178,7 @@ struct SessionRowGroupingTests {
         try #require(!coordinator.sessions.isEmpty)
 
         return Environment(coordinator: coordinator) {
-            defaults.removePersistentDomain(forName: suiteName)
+            isolation.tearDown()
             try? FileManager.default.removeItem(at: directory)
         }
     }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -35,6 +35,32 @@ evidence and an explicit confidence tier (weak / strong / causal).
 saved focus sets) are resolved once from an `AppPolicy` at the composition root and injected downward,
 keeping the limits in one place rather than scattered as constants.
 
+**Projects** are the isolation boundary above all of it. One coordinator serves every Project and holds
+one `ProjectRuntimeState` bucket per Project, bounded by `AppPolicy.maxProjects`. A parked Project keeps
+its *actual* `WorkspaceStore`, `SessionStore`, `LiveCaptureSpool` actor, capture Library folder and
+`UserDefaults` suite — nothing is evicted and nothing is rebuilt from portable configuration, so
+switching back restores its retained investigation; derived queries/evidence are refreshed and raw
+Follow Stream is requested on demand. `ProjectDataProviding` resolves those per-Project
+locations; `ProjectCatalog.legacyDataOwnerProjectID` names the one Project that owns the pre-Projects
+History database and Captures folder, assigned once and never reassigned.
+
+There is a single capture engine and helper backend, so a Project change that involves a running
+capture is a lifecycle transition, not a swap: stop → helper's final drain → final fold → terminal
+History write → *then* the store/spool/preferences references move. Switch, create, import,
+delete-active and recovery all run that one path. Generation and request tokens are globally monotonic
+and are never restored to an older counter; a restored Project's stopped-spool readiness marker is
+rebased onto a fresh token while the spool's own opaque evidence locators are left untouched.
+
+Final-drain waiters are tied to one owed operation, not elapsed time. An explicit destructive helper
+reset finalizes that operation's accepted prefix as incomplete under its recorded engine epoch. A
+fresh publication token retires old replies while preserving the frozen History identity and
+timestamps. The outgoing Project remains active until a later explicit retry succeeds.
+
+Accepted saves and session exports hold their source against Clear, Start, saved-file adoption,
+import replacement and trash. A Project transition drains queued saves and rejects active exports,
+including revalidation after a delayed Stop-and-Switch confirmation. Restoring a runtime restarts
+interrupted initial History reads, but preserves loaded pages/cursors and does not trigger retention.
+
 ## Repository map
 
 ```text

--- a/docs/design/liquid-glass-view-audit.md
+++ b/docs/design/liquid-glass-view-audit.md
@@ -2,7 +2,7 @@
 
 Audited 2026-08-24 against the production `Tracexy/Views` tree and every app scene in `TracexyApp.swift`. This inventory is exhaustive for current source. It distinguishes functional chrome from data content so “more glass” never becomes glass behind packet text, tables or evidence.
 
-Toolbar entries reconciled 2026-09-04: Project context and capture-source controls now have separate native toolbar ownership and responsive interface labeling.
+Toolbar entries reconciled 2026-09-04: Project context and capture-source controls now have separate native toolbar ownership and responsive interface labeling. A noninteractive native vertical separator distinguishes the source menu from Start/Stop; Export retains its native bordered surface even when disabled.
 
 ## Window and split hierarchy
 

--- a/docs/design/liquid-glass-view-audit.md
+++ b/docs/design/liquid-glass-view-audit.md
@@ -2,12 +2,16 @@
 
 Audited 2026-08-24 against the production `Tracexy/Views` tree and every app scene in `TracexyApp.swift`. This inventory is exhaustive for current source. It distinguishes functional chrome from data content so “more glass” never becomes glass behind packet text, tables or evidence.
 
+Toolbar entries reconciled 2026-09-04: Project context and capture-source controls now have separate native toolbar ownership and responsive interface labeling.
+
 ## Window and split hierarchy
 
 | Source | Disposition |
 | --- | --- |
-| `TracexyApp.swift` | The main workspace keeps a hidden semantic title with a unified native toolbar, so no view title or tagline displaces the capture picker. Settings, Focus Set and Noise Control remain titled Mac windows. |
-| `Common/NativeWorkspaceWindowChrome.swift` | Hidden semantic title, unified toolbar, leading interface picker, centered status, visible native export menu and one grouped capture/inspector action family. |
+| `TracexyApp.swift` | The main workspace keeps a hidden semantic title with a unified native toolbar, so no view title or tagline displaces the Project selector. Settings, Focus Set and Noise Control remain titled Mac windows. |
+| `Common/NativeWorkspaceWindowChrome.swift` | Hidden semantic title, unified toolbar, standalone leading Project selector, centered status, trailing interface picker beside Start/Stop, then a native gap before Export and grouped inspector controls. |
+| `Common/CaptureInterfaceToolbarPicker.swift` | Native menu with a bounded friendly interface label, icon-only at compact widths, and full interface identity retained in the menu, tooltip and accessibility value. Hosting constraints preserve spacing across resize round trips. |
+| `Projects/ProjectPresentation.swift` | Standalone native Project menu and management sheets; bounded configuration-only content stays separate from capture-source controls. |
 | `Main/NativeWorkspaceSplitView.swift` | Native sidebar, workspace and trailing inspector split items; owns resizing and collapse semantics. |
 | `Main/NativeBottomInspectorSplitView.swift` | Native resizable evidence inspector below the session workspace. |
 | `Main/RootView.swift` | Owns toolbar controls, top session command safe-area bar and bottom status safe-area bar. |

--- a/docs/design/ui-implementation-contract.md
+++ b/docs/design/ui-implementation-contract.md
@@ -8,7 +8,7 @@ This contract describes the current native macOS presentation boundary. Product 
 - Keep navigation in `List(.sidebar)` and session data in the existing native `Table` path. Do not replace selection, resizing, focus, menus or keyboard behavior with painted lookalikes.
 - Keep the right Details inspector and bottom evidence inspector as independently resizable native split regions.
 - Seat functional top and bottom chrome with `safeAreaBar`; allow scrollable content to continue underneath it and choose one deliberate scroll-edge style per pane. Do not add another rounded glass background merely because content sits in a safe-area bar.
-- Keep the main window title semantic but hidden. Surface titles and the product tagline must never enter the toolbar or displace the leading capture-interface picker.
+- Keep the main window title semantic but hidden. Surface titles and the product tagline must never enter the toolbar or displace the leading Project selector. Keep capture status centered, the capture-interface picker beside Start/Stop on the trailing side, and a native gap before Export and inspector controls.
 - Preserve semantic SF Symbols, system type styles and system colors across Light, Dark and accessibility appearances.
 
 ## Liquid Glass policy

--- a/docs/design/ui-implementation-contract.md
+++ b/docs/design/ui-implementation-contract.md
@@ -10,6 +10,7 @@ This contract describes the current native macOS presentation boundary. Product 
 - Seat functional top and bottom chrome with `safeAreaBar`; allow scrollable content to continue underneath it and choose one deliberate scroll-edge style per pane. Do not add another rounded glass background merely because content sits in a safe-area bar.
 - Keep the main window title semantic but hidden. Surface titles and the product tagline must never enter the toolbar or displace the leading Project selector. Keep capture status centered, the capture-interface picker beside Start/Stop on the trailing side, and a native gap before Export and inspector controls.
 - Preserve semantic SF Symbols, system type styles and system colors across Light, Dark and accessibility appearances.
+- Separate capture-source configuration from Start/Stop with a noninteractive native vertical separator. Export keeps its native bordered menu surface in both enabled and disabled states; do not replace it with a floating borderless glyph or add a custom glass background.
 
 ## Liquid Glass policy
 

--- a/docs/privacy-and-security.md
+++ b/docs/privacy-and-security.md
@@ -17,6 +17,29 @@ page states plainly what the app does and does not do today.
   evidence-preserving formats. When a Privacy protection is enabled, every raw export requires explicit
   acknowledgement before the save panel opens.
 
+### Project isolation
+
+Each Project keeps its capture sessions, saved-capture Library folder, local History database, and
+capture/privacy preferences separate from every other Project. Privacy protections and History
+Auto-clear are therefore *per Project*: enabling IP masking or a short retention window in one
+investigation does not silently change what another exports or retains. A new Project starts from the
+shipped protective defaults and never inherits another Project's values.
+
+Isolation is arranged by scoping storage, never by copying or deleting user data. Data written before
+Project isolation existed keeps its original location and is attached to exactly one Project the first
+time the catalog is loaded; that ownership is persisted before any capture, History write, or Library
+scan is allowed and is never reassigned — not when the owning Project is deleted, and not when the
+catalog is repaired. Repair deliberately leaves that data unattached rather than handing one person's
+capture history to a freshly created Project.
+
+Deleting a Project removes it from the catalog and discards its unsaved in-memory sessions and
+evidence. Its saved captures and History remain on disk and are not deleted; they simply stop being
+reachable from the app. Configuration-only `.tracexyproject`
+exports are unchanged: they never carry packets, payloads, paths, selection, findings, or History.
+
+Sessions held only in memory are not checkpointed. They survive Project switches for the life of the
+app session and are lost on quit unless saved — Tracexy does not claim otherwise.
+
 ### Protected session export
 
 Settings → Privacy controls the native `.tracexysession` export path. Redacting payloads, stripping

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -9,7 +9,9 @@ Choose the capture interface from the toolbar menu beside **Start/Stop**, on the
 The compact label shows the interface's friendly name (for example, **Wi-Fi**); the menu,
 tooltip, and accessibility value retain its BSD identifier (for example, **Wi-Fi (en0)**).
 At narrow window widths the same menu becomes icon-only. Project selection remains separate
-on the left; a native gap separates capture controls from Export and the inspectors.
+on the left. A vertical divider distinguishes interface selection from Start/Stop; a native gap
+separates capture controls from Export and the inspectors. Export retains its button background
+when disabled and becomes available when a session with retained capture frames is selected.
 
 Live capture reads from a network interface through the signed privileged helper. By default, it
 begins when you press **Start**. If you explicitly enable **Settings → Capture → Auto-start capture
@@ -66,15 +68,63 @@ results, and selected-evidence reads.
 
 ## Projects
 
-Projects keep investigation workspaces organized without moving or rewriting capture data. Use the
-Project selector in the main toolbar, immediately beside the sidebar controls, or the **Project** menu
-to switch, create, rename, and manage Projects. Each Project remembers its workspace names, filters,
-grouping, navigation, and inspector layout. Switching Projects restores that view configuration.
+A Project is a complete, isolated investigation. Use the Project selector in the main toolbar,
+immediately beside the sidebar controls, or the **Project** menu to switch, create, rename, and manage
+Projects.
+
+Each Project owns, separately from every other Project:
+
+- its captured sessions, investigation snapshot, findings, evidence, retained frames, capture
+  statistics, errors, warnings, and throughput chart;
+- its workspace tabs — names, filters, grouping, navigation, inspector layout, selected session, and
+  structured query drafts and results;
+- its saved-capture Library folder and its local History database, including History selection,
+  paging, Clear, and retention;
+- its capture settings (interface, filter mode and BPF, snap length, promiscuous mode, retention
+  size, auto-start), its privacy settings (payload redaction, credential stripping, IP masking,
+  History Auto-clear), and its pins, Focus Sets, muted noise, hidden sources, and default view.
+
+Appearance, byte units, quit confirmation, workspace restoration, the selected Settings tab, the
+"Local only" posture, analytics, updates, and the privileged helper stay application-wide. The
+Settings window shows the Project name beside the panes it edits, and it reopens against the new
+Project when you switch, so an editor left open cannot apply one Project's draft to another.
+
+Switching Projects preserves the investigation within an app session. Going A → B → A restores A's
+sessions, snapshot, findings, evidence, retained frames, selected session, query drafts and results,
+saved source references, capture statistics and chart, removed-session state, and History selection
+exactly as they were. Starting, clearing, filtering, or changing settings in B never affects A.
+In-flight derived work is cancelled at the boundary; evidence projections and accepted queries are
+rebuilt from the restored snapshot. Interrupted initial History reads restart in the restored
+Project; already-loaded pages and their paging position are preserved. An on-demand Follow Stream
+request can be run again.
+
+If a capture is running when you change Projects, Tracexy asks first. **Cancel** leaves the running
+capture and its Project completely untouched. **Stop and Switch** stops the capture and waits for the
+helper's final packets, the final session fold, and the terminal History entry *before* the Project
+changes. If the helper does not confirm that final drain, Tracexy stays where it is, says so, and
+offers a retry — a timeout never counts as a confirmed drain. Capture cannot be started while a
+Project change or a final drain is in progress, and auto-start applies only at launch, never on a
+switch. If you explicitly reset the helper while its final reply is unavailable, Tracexy preserves
+the accepted packet prefix, marks its terminal History entry **incomplete**, and stays in the
+outgoing Project. Retry the Project change after recovery has settled; the missing tail is not
+reported as recovered.
+
+An accepted **Save Capture** or session export holds its capture source until it finishes or fails.
+During that time Start, Clear, opening another capture, import replacement, and Library trash are
+refused so they cannot change the bytes being saved or exported. Stop remains available. Project
+changes wait for accepted saves; finish or cancel an export before changing Projects.
+Import and Trash explain when the capture source is busy rather than reporting a filesystem
+permission problem. Save/export failures remain visible even if you stopped the capture while
+the operation was running. If a resumed History read fails, it offers retry instead of leaving
+the selected-session pane loading indefinitely.
+The destination is prepared and the catalog saved before activation. A failed save keeps the old
+Project and investigation active. Deleting an inactive Project does not stop the active capture.
 
 **Project → Manage Projects…** opens the same management sheet used by the toolbar control. Its sidebar
 lists local Projects and their workspace counts; the detail area can open, rename, import, export, or
-delete the selected Project. Deleting a Project removes only its saved workspace configuration. It does
-not delete the current capture, saved `.pcap`/`.pcapng` files, or History.
+delete the selected Project. Deleting a Project removes it from the catalog and releases it from the
+app, discarding its unsaved in-memory sessions and evidence. Its saved captures and local History are
+**not** deleted — they remain on disk — but they are no longer reachable from Tracexy.
 
 **Export Project Configuration…** writes a configuration-only `.tracexyproject` file. It can include
 user-authored filter text, so review it before sharing, but it never includes packets, payloads, capture
@@ -82,8 +132,21 @@ paths, session selection, findings, or History. Import always creates a new loca
 identities and never replaces an existing Project. Project files and the local catalog are size-bounded
 and validated before adoption.
 
-Capture, decoded sessions, saved captures, and History currently remain app-wide. Changing the active
-Project therefore does not stop a live capture, change evidence ownership, or hide terminal History.
+### What survives quitting
+
+Durable configuration, per-Project History, and managed saved captures survive relaunch. **Sessions
+held only in memory do not**: Tracexy does not checkpoint an unsaved live capture, so a Project's
+current sessions and retained frames exist for the life of the app session only. Use **Save Capture**
+before quitting if you need them later.
+
+Data written before Project isolation existed — the original History database and Captures folder —
+is attached to exactly one Project the first time the catalog is loaded, and that ownership is
+recorded and never reassigned. Nothing is copied, moved, or deleted. If the catalog has to be
+repaired, that data stays on disk and is deliberately left unattached rather than handed to a newly
+created Project.
+Catalog reload is a startup-recovery action. If an investigation is already open, save unsaved captures
+and relaunch before reloading. Explicit catalog reset warns about discarding in-memory investigations;
+it prepares the replacement before changing the catalog, and preserves saved files and History on disk.
 
 ## Local History
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -5,6 +5,12 @@ hex are demoted to an inspector tab, one click away when the bytes are the answe
 
 ## Live capture
 
+Choose the capture interface from the toolbar menu beside **Start/Stop**, on the right.
+The compact label shows the interface's friendly name (for example, **Wi-Fi**); the menu,
+tooltip, and accessibility value retain its BSD identifier (for example, **Wi-Fi (en0)**).
+At narrow window widths the same menu becomes icon-only. Project selection remains separate
+on the left; a native gap separates capture controls from Export and the inspectors.
+
 Live capture reads from a network interface through the signed privileged helper. By default, it
 begins when you press **Start**. If you explicitly enable **Settings → Capture → Auto-start capture
 on launch**, Tracexy starts capture after launch setup completes. Starting a capture clears the
@@ -57,6 +63,27 @@ Only the recent raw-frame inspection window stays in memory. Session summaries c
 file, and the Inspector reopens exactly one representative frame by validated file offset when a saved
 session is selected. Opening another file, clearing, or starting live capture retires stale progress,
 results, and selected-evidence reads.
+
+## Projects
+
+Projects keep investigation workspaces organized without moving or rewriting capture data. Use the
+Project selector in the main toolbar, immediately beside the sidebar controls, or the **Project** menu
+to switch, create, rename, and manage Projects. Each Project remembers its workspace names, filters,
+grouping, navigation, and inspector layout. Switching Projects restores that view configuration.
+
+**Project → Manage Projects…** opens the same management sheet used by the toolbar control. Its sidebar
+lists local Projects and their workspace counts; the detail area can open, rename, import, export, or
+delete the selected Project. Deleting a Project removes only its saved workspace configuration. It does
+not delete the current capture, saved `.pcap`/`.pcapng` files, or History.
+
+**Export Project Configuration…** writes a configuration-only `.tracexyproject` file. It can include
+user-authored filter text, so review it before sharing, but it never includes packets, payloads, capture
+paths, session selection, findings, or History. Import always creates a new local Project with fresh
+identities and never replaces an existing Project. Project files and the local catalog are size-bounded
+and validated before adoption.
+
+Capture, decoded sessions, saved captures, and History currently remain app-wide. Changing the active
+Project therefore does not stop a live capture, change evidence ownership, or hide terminal History.
 
 ## Local History
 


### PR DESCRIPTION
## Summary

Make Projects independent investigations, with native management controls and safe transitions between capture sessions.

- Add a Project selector, application menu, management sheets, and configuration-only import/export. Separate Project context from capture controls, add a divider between interface selection and Start/Stop, and retain the Export button background when disabled.
- Isolate sessions, evidence, workspace state, capture/privacy settings, saved-capture libraries, and SQLite History per Project. Restore the retained investigation when switching back without inheriting another Project's settings or data.
- Route Project changes through a durable transition: confirm an active capture, stop and drain its final packets, complete the final fold and History write, prepare destination resources, then persist and activate the destination. Failed transitions preserve the outgoing investigation; switching never automatically starts capture.
- Protect Save and Export source ownership against concurrent Start, Clear, Open, import replacement, and Trash. Guard stale asynchronous results, recover interrupted History reads without losing loaded pages, and preserve incomplete evidence during explicit helper-reset recovery.
- Preserve existing capture files and History in place with stable legacy ownership. Update usage, architecture, privacy, and UI documentation.

## Validation

- [x] `swiftformat --lint .` — no files require formatting.
- [x] `swiftlint lint --strict --quiet` — passed.
- [x] `git diff --check` — passed.
- [x] App/helper test build and the complete `TracexyTests` suite — **1,123 tests passed, 0 failed, 0 skipped** on macOS arm64.
- [x] Regression coverage includes per-Project persistence, durable transition failures, stale callbacks, capture-source races, History resume/retry, recovery boundaries, and 12 complete A → B → A round trips using synthetic capture data and real SQLite storage.

The full unit suite ran on a byte-identical temporary source snapshot because macOS denied the test host access to source files under Documents. Source and test directories were compared again before committing; no assertions were skipped and privacy permissions were not changed.

The public-safety scan reports **four inherited commit-metadata email findings**, all already reachable from both `origin/develop` and `origin/main`. It found no new working-tree issues. Existing published history is unchanged; the full-history gate is not claimed as passing.

## Safety Checklist

- [x] Targets `develop`.
- [x] Includes regression tests and updated documentation for user-facing changes.
- [x] Preserves capture/helper/XPC trust boundaries and local-by-default data handling.
- [x] Adds no credentials, signing files, machine-specific paths, raw capture files, or private configuration.
- [x] Keeps public metadata product-focused and both commits authored by Stephen.
- [ ] I have read and agree to the Tracexy ICLA v1.0.

## Notes

- Unsaved in-memory sessions survive Project switches only for the current app session; save captures before quitting. Project configuration exports do not include packet data, findings, paths, selection, or History.
- Installed-helper/live-XPC end-to-end testing and native modal UI automation were not rerun in this validation pass. Existing Swift 6 migration warnings remain outside this change.
- The current Build & Validate workflow does not trigger for pull requests targeting `develop`; local validation is reported above, not a CI pass.
- The ICLA acknowledgement is left unchecked for the repository owner to attest personally.
